### PR TITLE
Vibration feedback when device max steer angles are reached

### DIFF
--- a/ControllerCommon/Utils/InputUtils.cs
+++ b/ControllerCommon/Utils/InputUtils.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using SharpDX.XInput;
 
 namespace ControllerCommon.Utils
 {
@@ -174,6 +175,43 @@ namespace ControllerCommon.Utils
             // Apply direction again
             return (JoystickPos < 0.0) ? -Result : Result;
         }
+
+        // Provide direction depended vibration feedback to player when physical 
+        // device reaches configured max angle to be used for joystick input
+        public static Vibration MaxSteerAngleReachedVibration(float Angle, float DeviceAngleMax, double VibrationStrength)
+        {
+            // Default 0
+            Vibration maxSteerAngleReachedVibration = new() { LeftMotorSpeed = 0, RightMotorSpeed = 0 };
+
+            // Turn right is negative angle, turn left is postive angle
+            // Within normal range, no vibration, default scenario
+            if (Math.Abs(Angle) < DeviceAngleMax)
+            {
+                maxSteerAngleReachedVibration = new() { LeftMotorSpeed = 0, RightMotorSpeed = 0 };
+            }
+            // Vibrate motor left
+            else if (Angle > DeviceAngleMax)
+            {
+                maxSteerAngleReachedVibration = new()
+                {
+                    LeftMotorSpeed = (ushort)(ushort.MaxValue * VibrationStrength),
+                    RightMotorSpeed = 0,
+                };
+            }
+            // Vibrate motor right
+            else if (Angle < DeviceAngleMax)
+            {
+                maxSteerAngleReachedVibration = new()
+                {
+                    LeftMotorSpeed = 0,
+                    RightMotorSpeed = (ushort)(ushort.MaxValue * VibrationStrength),
+                };
+            }
+
+            return maxSteerAngleReachedVibration;
+        }
+
+
 
         // Compensation for in game deadzone
         // Inputs: raw ThumbValue and deadzone 0-100%

--- a/ControllerService/Targets/ViGEmTarget.cs
+++ b/ControllerService/Targets/ViGEmTarget.cs
@@ -203,6 +203,17 @@ namespace ControllerService.Targets
                                     ControllerService.profile.steering_power,
                                     ControllerService.profile.steering_deadzone);
 
+                                Vibration maxSteerAngleReachedVibration = InputUtils.MaxSteerAngleReachedVibration(
+                                    xinputController.sensorFusion.DeviceAngle.Y,
+                                    ControllerService.profile.steering_max_angle,
+                                    vibrationStrength);
+
+                                // Only apply if max angle is reached, as set vibration overrules in game vibrations, no mixing (yet?)
+                                if (maxSteerAngleReachedVibration.LeftMotorSpeed > 0 
+                                    || maxSteerAngleReachedVibration.RightMotorSpeed > 0) {
+                                    physicalController.SetVibration(maxSteerAngleReachedVibration);
+                                }
+
                                 switch (ControllerService.profile.umc_output)
                                 {
                                     default:


### PR DESCRIPTION
Tested, unfortunately gets stuck and overwrites game vibrations all the time.

Vibration strength is used, but might not be in the right place (combined with game feedback?).

Help needed.
