### PR TITLE
Hotkey TDP + fix for #373

### DIFF
--- a/HandheldCompanion/Views/QuickPages/QuickPerformancePage.xaml.cs
+++ b/HandheldCompanion/Views/QuickPages/QuickPerformancePage.xaml.cs
@@ -63,8 +63,8 @@ namespace HandheldCompanion.Views.QuickPages
                             if (!SettingsManager.GetBoolean("QuickToolsPerformanceTDPEnabled") || currentProfile.TDP_override)
                                 return;
 
-                            TDPSustainedSlider.Value++;
                             TDPBoostSlider.Value++;
+                            TDPSustainedSlider.Value++;
                         }
                         break;
                     case "decreaseTDP":

--- a/HandheldCompanion/Views/QuickPages/QuickProfilesPage.xaml.cs
+++ b/HandheldCompanion/Views/QuickPages/QuickProfilesPage.xaml.cs
@@ -130,8 +130,8 @@ namespace HandheldCompanion.Views.QuickPages
                             if (currentProfile is null || currentProfile.isDefault || !currentProfile.TDP_override)
                                 return;
 
-                            TDPSustainedSlider.Value++;
                             TDPBoostSlider.Value++;
+                            TDPSustainedSlider.Value++;
                         }
                         break;
                     case "decreaseTDP":


### PR DESCRIPTION
Call Boost before Sustained, prevents boost first being set the same as sustained and then again being +1d.