### PR TITLE
Reworked the deadzone and sensitivity of joysticks

### DIFF
--- a/HandheldCompanion/Controls/Layout/LayoutTemplate.xaml.cs
+++ b/HandheldCompanion/Controls/Layout/LayoutTemplate.xaml.cs
@@ -105,7 +105,7 @@ namespace HandheldCompanion.Controls
                         this.Layout.AxisLayout = new()
                         {
                             { AxisLayoutFlags.LeftThumb, new MouseActions() { MouseType = MouseActionsType.Scroll, Sensivity = 25.0f } },
-                            { AxisLayoutFlags.RightThumb, new MouseActions() { MouseType = MouseActionsType.Move, Sensivity = 20.0f } },
+                            { AxisLayoutFlags.RightThumb, new MouseActions() { MouseType = MouseActionsType.Move, Sensivity = 25.0f } },
                             { AxisLayoutFlags.LeftPad, new MouseActions() { MouseType = MouseActionsType.Scroll, Sensivity = 25.0f } },
                             { AxisLayoutFlags.RightPad, new MouseActions() { MouseType = MouseActionsType.Move, Sensivity = 10.0f } },
                         };
@@ -154,7 +154,7 @@ namespace HandheldCompanion.Controls
                         this.Layout.AxisLayout = new()
                         {
                             { AxisLayoutFlags.LeftThumb, new EmptyActions() },
-                            { AxisLayoutFlags.RightThumb, new MouseActions() { MouseType = MouseActionsType.Move, Sensivity = 20.0f } },
+                            { AxisLayoutFlags.RightThumb, new MouseActions() { MouseType = MouseActionsType.Move, Sensivity = 25.0f } },
                             { AxisLayoutFlags.LeftPad, new EmptyActions() },
                             { AxisLayoutFlags.RightPad, new MouseActions() { MouseType = MouseActionsType.Move, Sensivity = 10.0f } },
                         };

--- a/HandheldCompanion/Views/Pages/LayoutPage.xaml
+++ b/HandheldCompanion/Views/Pages/LayoutPage.xaml
@@ -24,7 +24,7 @@
         ItemInvoked="navView_ItemInvoked"
         Loaded="navView_Loaded"
         OpenPaneLength="150"
-        PaneDisplayMode="Left"
+        PaneDisplayMode="Top"
         SelectionFollowsFocus="Enabled"
         ShoulderNavigationEnabled="WhenSelectionFollowsFocus">
 


### PR DESCRIPTION
Proper deadzone application. Minimal deflection over the deadzone results in minimal movement. This way even on highest sensitivity small movement is possible. Sensitivity 100 results in VERY fast movement, but still you can do precise ones.

Don't apply sensitivity twice, use rescale consts to fine tune sensitivity slider. Finetuned for the safe default values of 25.

This greatly improves #420