### PR TITLE
Reworked Mouse TouchPad implementation

### DIFF
--- a/ControllerCommon/Controllers/ControllerState.cs
+++ b/ControllerCommon/Controllers/ControllerState.cs
@@ -14,14 +14,21 @@ namespace ControllerCommon.Controllers
 
         // todo: move me and make me configurable !
         [JsonIgnore]
-        public static Dictionary<AxisLayoutFlags, short> AxisDeadzones = new()
+        public static readonly Dictionary<AxisLayoutFlags, short> AxisDeadzones = new()
         {
             { AxisLayoutFlags.RightThumb, Gamepad.RightThumbDeadZone },
             { AxisLayoutFlags.LeftThumb, Gamepad.LeftThumbDeadZone },
             { AxisLayoutFlags.L2, Gamepad.TriggerThreshold },
             { AxisLayoutFlags.R2, Gamepad.TriggerThreshold },
-            { AxisLayoutFlags.RightPad, Gamepad.TriggerThreshold },
-            { AxisLayoutFlags.LeftPad, Gamepad.TriggerThreshold },
+        };
+
+        [JsonIgnore]
+        public static readonly Dictionary<AxisLayoutFlags, ButtonFlags> AxisTouchButtons = new()
+        {
+            { AxisLayoutFlags.RightThumb, ButtonFlags.RightThumbTouch },
+            { AxisLayoutFlags.LeftThumb, ButtonFlags.LeftThumbTouch },
+            { AxisLayoutFlags.RightPad, ButtonFlags.RightPadTouch },
+            { AxisLayoutFlags.LeftPad, ButtonFlags.LeftPadTouch },
         };
 
         public int Timestamp;

--- a/HandheldCompanion/Controls/Layout/LayoutTemplate.xaml.cs
+++ b/HandheldCompanion/Controls/Layout/LayoutTemplate.xaml.cs
@@ -107,7 +107,7 @@ namespace HandheldCompanion.Controls
                             { AxisLayoutFlags.LeftThumb, new MouseActions() { MouseType = MouseActionsType.Scroll, Sensivity = 25.0f } },
                             { AxisLayoutFlags.RightThumb, new MouseActions() { MouseType = MouseActionsType.Move, Sensivity = 25.0f } },
                             { AxisLayoutFlags.LeftPad, new MouseActions() { MouseType = MouseActionsType.Scroll, Sensivity = 25.0f } },
-                            { AxisLayoutFlags.RightPad, new MouseActions() { MouseType = MouseActionsType.Move, Sensivity = 10.0f } },
+                            { AxisLayoutFlags.RightPad, new MouseActions() { MouseType = MouseActionsType.Move, Sensivity = 25.0f } },
                         };
 
                         this.Layout.ButtonLayout = new()
@@ -156,7 +156,7 @@ namespace HandheldCompanion.Controls
                             { AxisLayoutFlags.LeftThumb, new EmptyActions() },
                             { AxisLayoutFlags.RightThumb, new MouseActions() { MouseType = MouseActionsType.Move, Sensivity = 25.0f } },
                             { AxisLayoutFlags.LeftPad, new EmptyActions() },
-                            { AxisLayoutFlags.RightPad, new MouseActions() { MouseType = MouseActionsType.Move, Sensivity = 10.0f } },
+                            { AxisLayoutFlags.RightPad, new MouseActions() { MouseType = MouseActionsType.Move, Sensivity = 25.0f } },
                         };
 
                         this.Layout.ButtonLayout = new()

--- a/HandheldCompanion/Managers/LayoutManager.cs
+++ b/HandheldCompanion/Managers/LayoutManager.cs
@@ -317,7 +317,13 @@ namespace HandheldCompanion.Managers
                     case ActionType.Mouse:
                         {
                             MouseActions mAction = action as MouseActions;
-                            mAction.Execute(InLayout);
+
+                            // This buttonState check won't work here if UpdateInputs is event based, might need a rework in the future
+                            bool touched = false;
+                            if (ControllerState.AxisTouchButtons.TryGetValue(InLayout.flags, out ButtonFlags touchButton))
+                                touched = controllerState.ButtonState[touchButton];
+
+                            mAction.Execute(InLayout, touched);
                         }
                         break;
 

--- a/HandheldCompanion/Simulators/MouseSimulator.cs
+++ b/HandheldCompanion/Simulators/MouseSimulator.cs
@@ -79,7 +79,8 @@ namespace HandheldCompanion.Simulators
             }
         }
 
-        public static void MoveTo(int x, int y)
+        // TODO: unused, remove?
+        public static void MoveTo(double x, double y)
         {
             try
             {


### PR DESCRIPTION
Reworked Mouse TouchPad implementation

And analogous improvements to Mouse Joystick implementation.

This fixes https://github.com/Valkirie/HandheldCompanion/issues/417 and https://github.com/Valkirie/HandheldCompanion/issues/420

Two biggest changes:
- Moved from MoveTo() to MoveBy() implementation. Not because I prefer one or
  another but MoveTo() doesn't work with FPP games that center the cursor. Not
  sure why and did not manage to make it work despite several tries. The
  drawback of MoveBy() is that it's int only and small touchpad movements can be
  subpixel, so I've added a code that mitigates that and caches the float
  movement that has been left unused after a move cycle. This way very slow
  touchpad movement still progresses properly.
  Applied this to Joystick as well which visibly improves it even more.
- I've moved away from the hack to detect the touchpad touch to properly
  detecting the touch using device's sensors. Unfortunately the implementation
  is another hack that works only because the whole system is not event
  based. It might need a rework in the future.

Smaller changes:
- fixed deadzone application for joystick (cast to float before dividing)
- less vectors
- cleaner and more readable code (akin to joystick)
- some consistency changes to joystick as well
- common code for joystick/touchpad
- invert axis is applied for touchpad now
- removed deadzone definitions for touchpads as they make no sense
- changed MouseSimulator.MoveTo() to double as the underlying
  InputSimulator.Mouse.MoveMouseTo() is double but this function is unused now
  so can probably be removed altogether
- sensitivity changed to a safe (somewhat slow) value of 25 akin to joystick
  (both in the templates and in the MouseActions)