### PR TITLE
Add an option to enable desktop profile on application start

### DIFF
--- a/HandheldCompanion/App.config
+++ b/HandheldCompanion/App.config
@@ -202,6 +202,9 @@
             <setting name="MainWindowIsPaneOpen" serializeAs="String">
                 <value>True</value>
             </setting>
+            <setting name="DesktopProfileOnStart" serializeAs="String">
+                <value>True</value>
+            </setting>
         </HandheldCompanion.Properties.Settings>
     </userSettings>
 </configuration>

--- a/HandheldCompanion/Managers/Hotkeys/Hotkey.cs
+++ b/HandheldCompanion/Managers/Hotkeys/Hotkey.cs
@@ -143,7 +143,7 @@ namespace HandheldCompanion.Managers
             }
         }
 
-        public void Refresh()
+        public void Draw()
         {
             // update name
             if (string.IsNullOrEmpty(Name) || inputsHotkey.hotkeyType != InputsHotkeyType.Custom)

--- a/HandheldCompanion/Managers/Hotkeys/InputsHotkey.cs
+++ b/HandheldCompanion/Managers/Hotkeys/InputsHotkey.cs
@@ -22,50 +22,50 @@ namespace HandheldCompanion.Managers
         public static SortedDictionary<ushort, InputsHotkey> InputsHotkeys = new()
         {
             // Overlay hotkeys
-            { 01, new InputsHotkey(InputsHotkeyType.Overlay,    "\uEDE3",   "overlayGamepad",                   "Segoe Fluent Icons",   20, false,  true) },
-            { 02, new InputsHotkey(InputsHotkeyType.Overlay,    "\uEDA4",   "overlayTrackpads",                 "Segoe Fluent Icons",   20, false,  true) },
+            { 01, new InputsHotkey(InputsHotkeyType.Overlay,    "\uEDE3",   "overlayGamepad",                   "Segoe Fluent Icons",   20, false,  true,   null,                   string.Empty,           false) },
+            { 02, new InputsHotkey(InputsHotkeyType.Overlay,    "\uEDA4",   "overlayTrackpads",                 "Segoe Fluent Icons",   20, false,  true,   null,                   string.Empty,           false) },
 
             // Quicktools hotkeys
-            { 10, new InputsHotkey(InputsHotkeyType.Quicktools, "\uEC7A",   "quickTools",                       "Segoe Fluent Icons",   20, false,  true) },
-            { 11, new InputsHotkey(InputsHotkeyType.Quicktools, "\u2795",   "increaseTDP",                      "Segoe UI Symbol",      20, false,  true) },
-            { 12, new InputsHotkey(InputsHotkeyType.Quicktools, "\u2796",   "decreaseTDP",                      "Segoe UI Symbol",      20, false,  true) },
-            { 13, new InputsHotkey(InputsHotkeyType.Quicktools, "\uE769",   "suspendResumeTask",                "Segoe Fluent Icons",   20, false,  true) },
+            { 10, new InputsHotkey(InputsHotkeyType.Quicktools, "\uEC7A",   "quickTools",                       "Segoe Fluent Icons",   20, false,  true,   null,                   string.Empty,           false) },
+            { 11, new InputsHotkey(InputsHotkeyType.Quicktools, "\u2795",   "increaseTDP",                      "Segoe UI Symbol",      20, false,  true,   null,                   string.Empty,           false) },
+            { 12, new InputsHotkey(InputsHotkeyType.Quicktools, "\u2796",   "decreaseTDP",                      "Segoe UI Symbol",      20, false,  true,   null,                   string.Empty,           false) },
+            { 13, new InputsHotkey(InputsHotkeyType.Quicktools, "\uE769",   "suspendResumeTask",                "Segoe Fluent Icons",   20, false,  true,   null,                   string.Empty,           false) },
 
             // Microsoft Windows hotkeys
-            { 20, new InputsHotkey(InputsHotkeyType.Windows,    "\uE765",   "shortcutKeyboard",                 "Segoe Fluent Icons",   20, false,  true) },
-            { 21, new InputsHotkey(InputsHotkeyType.Windows,    "\uE138",   "shortcutDesktop",                  "Segoe UI Symbol",      20, false,  true) },
-            { 22, new InputsHotkey(InputsHotkeyType.Windows,    "ESC",      "shortcutESC",                      "Segoe UI",             12, false,  true) },
-            { 23, new InputsHotkey(InputsHotkeyType.Windows,    "\uEE49",   "shortcutExpand",                   "Segoe Fluent Icons",   20, false,  true) },
-            { 24, new InputsHotkey(InputsHotkeyType.Windows,    "\uE7C4",   "shortcutTaskview",                 "Segoe MDL2 Assets",    20, false,  true) },
-            { 25, new InputsHotkey(InputsHotkeyType.Windows,    "\uE71D",   "shortcutTaskManager",              "Segoe Fluent Icons",   20, false,  true) },
-            { 26, new InputsHotkey(InputsHotkeyType.Windows,    "\uE8BB",   "shortcutKillApp",                  "Segoe Fluent Icons",   20, false,  true) },
-            { 27, new InputsHotkey(InputsHotkeyType.Windows,    "\uE7E7",   "shortcutControlCenter",            "Segoe Fluent Icons",   20, false,  true) },
+            { 20, new InputsHotkey(InputsHotkeyType.Windows,    "\uE765",   "shortcutKeyboard",                 "Segoe Fluent Icons",   20, false,  true,   null,                   string.Empty,           true) },
+            { 21, new InputsHotkey(InputsHotkeyType.Windows,    "\uE138",   "shortcutDesktop",                  "Segoe UI Symbol",      20, false,  true,   null,                   string.Empty,           true) },
+            { 22, new InputsHotkey(InputsHotkeyType.Windows,    "ESC",      "shortcutESC",                      "Segoe UI",             12, false,  true,   null,                   string.Empty,           false) },
+            { 23, new InputsHotkey(InputsHotkeyType.Windows,    "\uEE49",   "shortcutExpand",                   "Segoe Fluent Icons",   20, false,  true,   null,                   string.Empty,           false) },
+            { 24, new InputsHotkey(InputsHotkeyType.Windows,    "\uE7C4",   "shortcutTaskview",                 "Segoe MDL2 Assets",    20, false,  true,   null,                   string.Empty,           false) },
+            { 25, new InputsHotkey(InputsHotkeyType.Windows,    "\uE71D",   "shortcutTaskManager",              "Segoe Fluent Icons",   20, false,  true,   null,                   string.Empty,           false) },
+            { 26, new InputsHotkey(InputsHotkeyType.Windows,    "\uE8BB",   "shortcutKillApp",                  "Segoe Fluent Icons",   20, false,  true,   null,                   string.Empty,           false) },
+            { 27, new InputsHotkey(InputsHotkeyType.Windows,    "\uE7E7",   "shortcutControlCenter",            "Segoe Fluent Icons",   20, false,  true,   null,                   string.Empty,           true) },
 
             // Handheld Companion hotkeys
-            { 30, new InputsHotkey(InputsHotkeyType.HC,         "\uE7C4",   "shortcutMainwindow",               "Segoe Fluent Icons",   20, false,  true) },
-            { 31, new InputsHotkey(InputsHotkeyType.HC,         "\uE961",   "shortcutDesktopLayout",            "Segoe Fluent Icons",   20, false,  true) },
+            { 30, new InputsHotkey(InputsHotkeyType.HC,         "\uE7C4",   "shortcutMainwindow",               "Segoe Fluent Icons",   20, false,  true,   null,                   string.Empty,           true) },
+            { 31, new InputsHotkey(InputsHotkeyType.HC,         "\uE961",   "shortcutDesktopLayout",            "Segoe Fluent Icons",   20, false,  true,   null,                   string.Empty,           true) },
 
             // Device specific hotkeys
-            { 40, new InputsHotkey(InputsHotkeyType.Device,     "\uE708",   "QuietModeToggled",                 "Segoe Fluent Icons",   20, false,  true,   null,               "QuietModeEnabled") },
-            { 41, new InputsHotkey(InputsHotkeyType.Device,     "\uEFA5",   "SteamDeckLizardMouse",             "Segoe MDL2 Assets",    20, false,  true,   typeof(SteamDeck)) },
-            { 42, new InputsHotkey(InputsHotkeyType.Device,     "\uF093",   "SteamDeckLizardButtons",           "Segoe MDL2 Assets",    20, false,  true,   typeof(SteamDeck)) },
+            { 40, new InputsHotkey(InputsHotkeyType.Device,     "\uE708",   "QuietModeToggled",                 "Segoe Fluent Icons",   20, false,  true,   null,                   "QuietModeEnabled",     false) },
+            { 41, new InputsHotkey(InputsHotkeyType.Device,     "\uEFA5",   "SteamDeckLizardMouse",             "Segoe MDL2 Assets",    20, false,  true,   typeof(SteamDeck),      string.Empty,           false) },
+            { 42, new InputsHotkey(InputsHotkeyType.Device,     "\uF093",   "SteamDeckLizardButtons",           "Segoe MDL2 Assets",    20, false,  true,   typeof(SteamDeck),      string.Empty,           false) },
 
             // User customizable hotkeys
-            { 50, new InputsHotkey(InputsHotkeyType.Custom,     "\u2780",   "shortcutCustom0",                  "Segoe UI Symbol",      20, false,  true) },
-            { 51, new InputsHotkey(InputsHotkeyType.Custom,     "\u2781",   "shortcutCustom1",                  "Segoe UI Symbol",      20, false,  true) },
-            { 52, new InputsHotkey(InputsHotkeyType.Custom,     "\u2782",   "shortcutCustom2",                  "Segoe UI Symbol",      20, false,  true) },
-            { 53, new InputsHotkey(InputsHotkeyType.Custom,     "\u2783",   "shortcutCustom3",                  "Segoe UI Symbol",      20, false,  true) },
-            { 54, new InputsHotkey(InputsHotkeyType.Custom,     "\u2784",   "shortcutCustom4",                  "Segoe UI Symbol",      20, false,  true) },
-            { 55, new InputsHotkey(InputsHotkeyType.Custom,     "\u2785",   "shortcutCustom5",                  "Segoe UI Symbol",      20, false,  true) },
-            { 56, new InputsHotkey(InputsHotkeyType.Custom,     "\u2786",   "shortcutCustom6",                  "Segoe UI Symbol",      20, false,  true) },
-            { 57, new InputsHotkey(InputsHotkeyType.Custom,     "\u2787",   "shortcutCustom7",                  "Segoe UI Symbol",      20, false,  true) },
-            { 58, new InputsHotkey(InputsHotkeyType.Custom,     "\u2788",   "shortcutCustom8",                  "Segoe UI Symbol",      20, false,  true) },
-            { 59, new InputsHotkey(InputsHotkeyType.Custom,     "\u2789",   "shortcutCustom9",                  "Segoe UI Symbol",      20, false,  true) },
+            { 50, new InputsHotkey(InputsHotkeyType.Custom,     "\u2780",   "shortcutCustom0",                  "Segoe UI Symbol",      20, false,  true,   null,                   string.Empty,           false) },
+            { 51, new InputsHotkey(InputsHotkeyType.Custom,     "\u2781",   "shortcutCustom1",                  "Segoe UI Symbol",      20, false,  true,   null,                   string.Empty,           false) },
+            { 52, new InputsHotkey(InputsHotkeyType.Custom,     "\u2782",   "shortcutCustom2",                  "Segoe UI Symbol",      20, false,  true,   null,                   string.Empty,           false) },
+            { 53, new InputsHotkey(InputsHotkeyType.Custom,     "\u2783",   "shortcutCustom3",                  "Segoe UI Symbol",      20, false,  true,   null,                   string.Empty,           false) },
+            { 54, new InputsHotkey(InputsHotkeyType.Custom,     "\u2784",   "shortcutCustom4",                  "Segoe UI Symbol",      20, false,  true,   null,                   string.Empty,           false) },
+            { 55, new InputsHotkey(InputsHotkeyType.Custom,     "\u2785",   "shortcutCustom5",                  "Segoe UI Symbol",      20, false,  true,   null,                   string.Empty,           false) },
+            { 56, new InputsHotkey(InputsHotkeyType.Custom,     "\u2786",   "shortcutCustom6",                  "Segoe UI Symbol",      20, false,  true,   null,                   string.Empty,           false) },
+            { 57, new InputsHotkey(InputsHotkeyType.Custom,     "\u2787",   "shortcutCustom7",                  "Segoe UI Symbol",      20, false,  true,   null,                   string.Empty,           false) },
+            { 58, new InputsHotkey(InputsHotkeyType.Custom,     "\u2788",   "shortcutCustom8",                  "Segoe UI Symbol",      20, false,  true,   null,                   string.Empty,           false) },
+            { 59, new InputsHotkey(InputsHotkeyType.Custom,     "\u2789",   "shortcutCustom9",                  "Segoe UI Symbol",      20, false,  true,   null,                   string.Empty,           false) },
 
             // Special, UI hotkeys
-            { 60, new InputsHotkey(InputsHotkeyType.Embedded,   "\uEDE3",   "shortcutProfilesPage@",            "Segoe Fluent Icons",   20, true,   true) },
-            { 61, new InputsHotkey(InputsHotkeyType.Embedded,   "\uEDE3",   "shortcutProfilesPage@@",           "Segoe Fluent Icons",   20, true,   true) },
-            { 62, new InputsHotkey(InputsHotkeyType.Embedded,   "\uEDE3",   "shortcutProfilesSettingsMode0",    "Segoe Fluent Icons",   20, true,   true) },
+            { 60, new InputsHotkey(InputsHotkeyType.Embedded,   "\uEDE3",   "shortcutProfilesPage@",            "Segoe Fluent Icons",   20, true,   true,   null,                   string.Empty,           false) },
+            { 61, new InputsHotkey(InputsHotkeyType.Embedded,   "\uEDE3",   "shortcutProfilesPage@@",           "Segoe Fluent Icons",   20, true,   true,   null,                   string.Empty,           false) },
+            { 62, new InputsHotkey(InputsHotkeyType.Embedded,   "\uEDE3",   "shortcutProfilesSettingsMode0",    "Segoe Fluent Icons",   20, true,   true,   null,                   string.Empty,           false) },
         };
 
         public string Glyph { get; set; }
@@ -78,8 +78,9 @@ namespace HandheldCompanion.Managers
         public bool OnKeyUp { get; set; }
         public Type DeviceType { get; set; }
         public string Settings { get; set; }
+        public bool DefaultPinned { get; set; }
 
-        public InputsHotkey(InputsHotkeyType hotkeyType, string glyph, string listener, string fontFamily, double fontSize, bool onKeyDown, bool onKeyUp, Type deviceType = null, string settings = "")
+        public InputsHotkey(InputsHotkeyType hotkeyType, string glyph, string listener, string fontFamily, double fontSize, bool onKeyDown, bool onKeyUp, Type deviceType = null, string settings = "", bool defaultPinned = false)
         {
             this.hotkeyType = hotkeyType;
             this.Glyph = glyph;
@@ -91,6 +92,7 @@ namespace HandheldCompanion.Managers
 
             this.DeviceType = deviceType;
             this.Settings = settings;
+            this.DefaultPinned = defaultPinned;
         }
 
         public InputsHotkey()

--- a/HandheldCompanion/Managers/HotkeysManager.cs
+++ b/HandheldCompanion/Managers/HotkeysManager.cs
@@ -83,7 +83,10 @@ namespace HandheldCompanion.Managers
 
                 // no hotkey found or failed parsing
                 if (hotkey is null)
+                {
                     hotkey = new Hotkey(Id);
+                    hotkey.IsPinned = inputsHotkey.DefaultPinned;
+                }
 
                 // hotkey is outdated and using an unknown inputs hotkey
                 if (!InputsHotkeys.ContainsKey(hotkey.hotkeyId))
@@ -91,7 +94,7 @@ namespace HandheldCompanion.Managers
 
                 // pull inputs hotkey
                 hotkey.SetInputsHotkey(InputsHotkeys[hotkey.hotkeyId]);
-                hotkey.Refresh();
+                hotkey.Draw();
 
                 if (!Hotkeys.ContainsKey(hotkey.hotkeyId))
                     Hotkeys.Add(hotkey.hotkeyId, hotkey);

--- a/HandheldCompanion/Properties/Resources.Designer.cs
+++ b/HandheldCompanion/Properties/Resources.Designer.cs
@@ -2763,7 +2763,25 @@ namespace HandheldCompanion.Properties {
                 return ResourceManager.GetString("SettingsPage_CloseMinimizesDesc", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Enable desktop profile on start.
+        /// </summary>
+        public static string SettingsPage_DesktopProfileOnStart {
+            get {
+                return ResourceManager.GetString("SettingsPage_DesktopProfileOnStart", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The desktop profile will be automatically enabled on application start.
+        /// </summary>
+        public static string SettingsPage_DesktopProfileOnStartDesc {
+            get {
+                return ResourceManager.GetString("SettingsPage_DesktopProfileOnStartDesc", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Download.
         /// </summary>

--- a/HandheldCompanion/Properties/Settings.Designer.cs
+++ b/HandheldCompanion/Properties/Settings.Designer.cs
@@ -802,5 +802,17 @@ namespace HandheldCompanion.Properties {
                 this["MainWindowIsPaneOpen"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool DesktopProfileOnStart {
+            get {
+                return ((bool)(this["DesktopProfileOnStart"]));
+            }
+            set {
+                this["DesktopProfileOnStart"] = value;
+            }
+        }
     }
 }

--- a/HandheldCompanion/Properties/Settings.settings
+++ b/HandheldCompanion/Properties/Settings.settings
@@ -197,5 +197,8 @@
     <Setting Name="MainWindowIsPaneOpen" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="DesktopProfileOnStart" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/HandheldCompanion/Views/Pages/SettingsPage.xaml
+++ b/HandheldCompanion/Views/Pages/SettingsPage.xaml
@@ -212,6 +212,44 @@
                     </Grid>
                 </Border>
 
+                <!--  Enable desktop profile on start  -->
+                <Border
+                    Padding="15,12,12,12"
+                    Background="{DynamicResource ExpanderHeaderBackground}"
+                    CornerRadius="{DynamicResource ControlCornerRadius}">
+
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="5*" MinWidth="200" />
+                            <ColumnDefinition Width="5*" MinWidth="200" />
+                        </Grid.ColumnDefinitions>
+
+                        <DockPanel>
+                            <ui:FontIcon
+                                Height="40"
+                                HorizontalAlignment="Center"
+                                FontFamily="{DynamicResource SymbolThemeFontFamily}"
+                                Glyph="&#xEA6C;" />
+
+                            <ui:SimpleStackPanel Margin="12,0,0,0" VerticalAlignment="Center">
+                                <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="Enable desktop profile on start" />
+                                <TextBlock
+                                    Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                                    Style="{StaticResource CaptionTextBlockStyle}"
+                                    Text="The desktop profile will be automatically enabled on application start"
+                                    TextWrapping="Wrap" />
+                            </ui:SimpleStackPanel>
+                        </DockPanel>
+
+                        <ui:ToggleSwitch
+                            Name="Toggle_DesktopProfileOnStart"
+                            Grid.Column="1"
+                            HorizontalAlignment="Right"
+                            Style="{DynamicResource InvertedToggleSwitchStyle}"
+                            Toggled="Toggle_DesktopProfileOnStart_Toggled" />
+                    </Grid>
+                </Border>
+
                 <!--  Application theme  -->
                 <Border
                     Padding="15,12,12,12"

--- a/HandheldCompanion/Views/Pages/SettingsPage.xaml.cs
+++ b/HandheldCompanion/Views/Pages/SettingsPage.xaml.cs
@@ -118,6 +118,9 @@ namespace HandheldCompanion.Views.Pages
                     case "CloseMinimises":
                         Toggle_CloseMinimizes.IsOn = Convert.ToBoolean(value);
                         break;
+                    case "DesktopProfileOnStart":
+                        Toggle_DesktopProfileOnStart.IsOn = Convert.ToBoolean(value);
+                        break;
                     case "ToastEnable":
                         Toggle_Notification.IsOn = Convert.ToBoolean(value);
                         break;
@@ -236,6 +239,14 @@ namespace HandheldCompanion.Views.Pages
                 return;
 
             SettingsManager.SetProperty("CloseMinimises", Toggle_CloseMinimizes.IsOn);
+        }
+
+        private void Toggle_DesktopProfileOnStart_Toggled(object? sender, System.Windows.RoutedEventArgs? e)
+        {
+            if (!IsLoaded)
+                return;
+
+            SettingsManager.SetProperty("DesktopProfileOnStart", Toggle_DesktopProfileOnStart.IsOn);
         }
 
         private void UpdateManager_Updated(UpdateStatus status, UpdateFile updateFile, object value)

--- a/HandheldCompanion/Views/Windows/MainWindow.xaml.cs
+++ b/HandheldCompanion/Views/Windows/MainWindow.xaml.cs
@@ -185,6 +185,10 @@ namespace HandheldCompanion.Views
             foreach (Manager manager in _managers)
                 new Thread(manager.Start).Start();
 
+            // do this before SettingsManager.Start() so we have the correct profile on startup
+            if (SettingsManager.GetBoolean("DesktopProfileOnStart"))
+                SettingsManager.SetProperty("shortcutDesktopLayout", true, false, true);
+
             // start setting last
             SettingsManager.SettingValueChanged += SettingsManager_SettingValueChanged;
             SettingsManager.Start();

--- a/HandheldCompanion/Views/Windows/MainWindow.xaml.cs
+++ b/HandheldCompanion/Views/Windows/MainWindow.xaml.cs
@@ -185,10 +185,6 @@ namespace HandheldCompanion.Views
             foreach (Manager manager in _managers)
                 new Thread(manager.Start).Start();
 
-            // do this before SettingsManager.Start() so we have the correct profile on startup
-            if (SettingsManager.GetBoolean("DesktopProfileOnStart"))
-                SettingsManager.SetProperty("shortcutDesktopLayout", true, false, true);
-
             // start setting last
             SettingsManager.SettingValueChanged += SettingsManager_SettingValueChanged;
             SettingsManager.Start();
@@ -216,6 +212,10 @@ namespace HandheldCompanion.Views
             {
                 case "ToastEnable":
                     ToastManager.IsEnabled = Convert.ToBoolean(value);
+                    break;
+                case "DesktopProfileOnStart":
+                    bool DesktopLayout = Convert.ToBoolean(value);
+                    SettingsManager.SetProperty("shortcutDesktopLayout", DesktopLayout, false, true);
                     break;
             }
 


### PR DESCRIPTION
By default it's true and has a nice side effect of making the mouse/keyboard work automatically on first HC start after it's installed.