### PR TITLE
Implement options for setting rotation on joysticks

### DIFF
--- a/ControllerCommon/Actions/AxisActions.cs
+++ b/ControllerCommon/Actions/AxisActions.cs
@@ -14,6 +14,7 @@ namespace ControllerCommon.Actions
 
         // Axis to axis
         public bool AxisInverted { get; set; } = false;
+        public bool AxisRotated { get; set; } = false;
         public int AxisDeadZoneInner { get; set; } = 0;
         public int AxisDeadZoneOuter { get; set; } = 0;
         public float AxisAntiDeadZone { get; set; } = 0.0f;
@@ -55,7 +56,7 @@ namespace ControllerCommon.Actions
             if (ImproveCircularity)
                 layout.vector = InputUtils.ImproveCircularity(layout.vector);
 
-            this.Vector = layout.vector * (AxisInverted ? -1.0f : 1.0f);
+            this.Vector = (AxisRotated ? new(layout.vector.Y, -layout.vector.X) : layout.vector) * (AxisInverted ? -1.0f : 1.0f);
         }
 
         public Vector2 GetValue()

--- a/HandheldCompanion/Actions/MouseActions.cs
+++ b/HandheldCompanion/Actions/MouseActions.cs
@@ -42,6 +42,7 @@ namespace HandheldCompanion.Actions
         public float Sensivity { get; set; } = 25.0f;
         public float Deadzone { get; set; } = 25.0f;
         public bool AxisInverted { get; set; } = false;
+        public bool AxisRotated { get; set; } = false;
 
         public MouseActions()
         {
@@ -195,8 +196,10 @@ namespace HandheldCompanion.Actions
                     break;
             }
 
-            // apply sensitivity, invert and slider finetune
+            // apply sensitivity, rotation and slider finetune
             deltaVector *= Sensivity * sensitivityFinetune;
+            if (AxisRotated)
+                deltaVector = new(-deltaVector.Y, deltaVector.X);
             deltaVector *= (AxisInverted ? -1.0f : 1.0f);
 
             // handle the fact that MoveBy()/*Scroll() are int only and we can have movement (0 < abs(delta) < 1)

--- a/HandheldCompanion/Controls/Mapping/AxisMapping.xaml
+++ b/HandheldCompanion/Controls/Mapping/AxisMapping.xaml
@@ -127,6 +127,32 @@
                                 BorderThickness="0,1,0,0"
                                 Opacity="0.25" />
 
+                            <!--  Rotate Axis  -->
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="9*" MinWidth="200" />
+                                    <ColumnDefinition MinWidth="80" />
+                                </Grid.ColumnDefinitions>
+
+                                <TextBlock
+                                    VerticalAlignment="Center"
+                                    Style="{StaticResource BodyTextBlockStyle}"
+                                    Text="Rotate axis 90 degrees" />
+
+                                <ui:ToggleSwitch
+                                    Name="Axis2AxisRotateAxis"
+                                    Grid.Column="1"
+                                    HorizontalAlignment="Right"
+                                    Style="{DynamicResource InvertedToggleSwitchStyle}"
+                                    Toggled="Axis2AxisRotateAxis_Toggled" />
+                            </Grid>
+
+                            <!--  Separator  -->
+                            <Separator
+                                BorderBrush="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
+                                BorderThickness="0,1,0,0"
+                                Opacity="0.25" />
+
                             <!--  Inner deadzone  -->
                             <Grid>
                                 <ui:SimpleStackPanel Spacing="6">

--- a/HandheldCompanion/Controls/Mapping/AxisMapping.xaml
+++ b/HandheldCompanion/Controls/Mapping/AxisMapping.xaml
@@ -257,24 +257,34 @@
                     <ui:SimpleStackPanel Spacing="12">
                         <ui:SimpleStackPanel Spacing="6">
 
-                            <!--  Invert Axis  -->
+                            <!--  Axis rotation  -->
                             <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="9*" MinWidth="200" />
-                                    <ColumnDefinition MinWidth="80" />
-                                </Grid.ColumnDefinitions>
+                                <ui:SimpleStackPanel Spacing="6">
+                                    <Grid>
+                                        <TextBlock
+                                            HorizontalAlignment="Left"
+                                            VerticalAlignment="Center"
+                                            Style="{StaticResource BodyTextBlockStyle}"
+                                            Text="Rotate axis (degrees)" />
+                                        <TextBox
+                                            HorizontalAlignment="Right"
+                                            HorizontalContentAlignment="Center"
+                                            IsReadOnly="True"
+                                            Text="{Binding Value, ElementName=Axis2MouseRotation, Mode=OneWay}" />
+                                    </Grid>
 
-                                <TextBlock
-                                    VerticalAlignment="Center"
-                                    Style="{StaticResource BodyTextBlockStyle}"
-                                    Text="Invert axis" />
-
-                                <ui:ToggleSwitch
-                                    Name="Axis2MouseInvertAxis"
-                                    Grid.Column="1"
-                                    HorizontalAlignment="Right"
-                                    Style="{DynamicResource InvertedToggleSwitchStyle}"
-                                    Toggled="Axis2MouseInvertAxis_Toggled" />
+                                    <Slider
+                                        x:Name="Axis2MouseRotation"
+                                        FlowDirection="LeftToRight"
+                                        IsMoveToPointEnabled="True"
+                                        IsSnapToTickEnabled="True"
+                                        Maximum="270"
+                                        Minimum="0"
+                                        ScrollViewer.PanningMode="HorizontalOnly"
+                                        Style="{DynamicResource SliderStyle1}"
+                                        TickFrequency="90"
+                                        ValueChanged="Axis2MouseRotation_ValueChanged" />
+                                </ui:SimpleStackPanel>
                             </Grid>
 
                             <!--  Separator  -->

--- a/HandheldCompanion/Controls/Mapping/AxisMapping.xaml
+++ b/HandheldCompanion/Controls/Mapping/AxisMapping.xaml
@@ -101,50 +101,34 @@
                                 BorderThickness="0,1,0,0"
                                 Opacity="0.25" />
 
-                            <!--  Invert Axis  -->
+                            <!--  Axis rotation  -->
                             <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="9*" MinWidth="200" />
-                                    <ColumnDefinition MinWidth="80" />
-                                </Grid.ColumnDefinitions>
+                                <ui:SimpleStackPanel Spacing="6">
+                                    <Grid>
+                                        <TextBlock
+                                            HorizontalAlignment="Left"
+                                            VerticalAlignment="Center"
+                                            Style="{StaticResource BodyTextBlockStyle}"
+                                            Text="Rotate axis (degrees)" />
+                                        <TextBox
+                                            HorizontalAlignment="Right"
+                                            HorizontalContentAlignment="Center"
+                                            IsReadOnly="True"
+                                            Text="{Binding Value, ElementName=Axis2AxisRotation, Mode=OneWay}" />
+                                    </Grid>
 
-                                <TextBlock
-                                    VerticalAlignment="Center"
-                                    Style="{StaticResource BodyTextBlockStyle}"
-                                    Text="Invert axis" />
-
-                                <ui:ToggleSwitch
-                                    Name="Axis2AxisInvertAxis"
-                                    Grid.Column="1"
-                                    HorizontalAlignment="Right"
-                                    Style="{DynamicResource InvertedToggleSwitchStyle}"
-                                    Toggled="Axis2AxisInvertAxis_Toggled" />
-                            </Grid>
-
-                            <!--  Separator  -->
-                            <Separator
-                                BorderBrush="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
-                                BorderThickness="0,1,0,0"
-                                Opacity="0.25" />
-
-                            <!--  Rotate Axis  -->
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="9*" MinWidth="200" />
-                                    <ColumnDefinition MinWidth="80" />
-                                </Grid.ColumnDefinitions>
-
-                                <TextBlock
-                                    VerticalAlignment="Center"
-                                    Style="{StaticResource BodyTextBlockStyle}"
-                                    Text="Rotate axis 90 degrees" />
-
-                                <ui:ToggleSwitch
-                                    Name="Axis2AxisRotateAxis"
-                                    Grid.Column="1"
-                                    HorizontalAlignment="Right"
-                                    Style="{DynamicResource InvertedToggleSwitchStyle}"
-                                    Toggled="Axis2AxisRotateAxis_Toggled" />
+                                    <Slider
+                                        x:Name="Axis2AxisRotation"
+                                        FlowDirection="LeftToRight"
+                                        IsMoveToPointEnabled="True"
+                                        IsSnapToTickEnabled="True"
+                                        Maximum="270"
+                                        Minimum="0"
+                                        ScrollViewer.PanningMode="HorizontalOnly"
+                                        Style="{DynamicResource SliderStyle1}"
+                                        TickFrequency="90"
+                                        ValueChanged="Axis_Rotation_Slider_ValueChanged" />
+                                </ui:SimpleStackPanel>
                             </Grid>
 
                             <!--  Separator  -->

--- a/HandheldCompanion/Controls/Mapping/AxisMapping.xaml.cs
+++ b/HandheldCompanion/Controls/Mapping/AxisMapping.xaml.cs
@@ -108,6 +108,7 @@ namespace HandheldCompanion.Controls
                 // settings
                 Axis2AxisImproveCircularity.IsOn = ((AxisActions)this.Actions).ImproveCircularity;
                 Axis2AxisInvertAxis.IsOn = ((AxisActions)this.Actions).AxisInverted;
+                Axis2AxisRotateAxis.IsOn = ((AxisActions)this.Actions).AxisRotated;
                 Axis2AxisInnerDeadzone.Value = ((AxisActions)this.Actions).AxisDeadZoneInner;
                 Axis2AxisOuterDeadzone.Value = ((AxisActions)this.Actions).AxisDeadZoneOuter;
                 Axis2AxisAntiDeadzone.Value = ((AxisActions)this.Actions).AxisAntiDeadZone;
@@ -206,6 +207,21 @@ namespace HandheldCompanion.Controls
             {
                 case ActionType.Joystick:
                     ((AxisActions)this.Actions).AxisInverted = Axis2AxisInvertAxis.IsOn;
+                    break;
+            }
+
+            base.Update();
+        }
+
+        private void Axis2AxisRotateAxis_Toggled(object sender, RoutedEventArgs e)
+        {
+            if (this.Actions is null)
+                return;
+
+            switch (this.Actions.ActionType)
+            {
+                case ActionType.Joystick:
+                    ((AxisActions)this.Actions).AxisRotated = Axis2AxisRotateAxis.IsOn;
                     break;
             }
 

--- a/HandheldCompanion/Controls/Mapping/AxisMapping.xaml.cs
+++ b/HandheldCompanion/Controls/Mapping/AxisMapping.xaml.cs
@@ -107,8 +107,7 @@ namespace HandheldCompanion.Controls
 
                 // settings
                 Axis2AxisImproveCircularity.IsOn = ((AxisActions)this.Actions).ImproveCircularity;
-                Axis2AxisInvertAxis.IsOn = ((AxisActions)this.Actions).AxisInverted;
-                Axis2AxisRotateAxis.IsOn = ((AxisActions)this.Actions).AxisRotated;
+                Axis2AxisRotation.Value = (((AxisActions)this.Actions).AxisInverted ? 180 : 0) + (((AxisActions)this.Actions).AxisRotated ? 90 : 0);
                 Axis2AxisInnerDeadzone.Value = ((AxisActions)this.Actions).AxisDeadZoneInner;
                 Axis2AxisOuterDeadzone.Value = ((AxisActions)this.Actions).AxisDeadZoneOuter;
                 Axis2AxisAntiDeadzone.Value = ((AxisActions)this.Actions).AxisAntiDeadZone;
@@ -198,7 +197,7 @@ namespace HandheldCompanion.Controls
             }
         }
 
-        private void Axis2AxisInvertAxis_Toggled(object sender, RoutedEventArgs e)
+        private void Axis_Rotation_Slider_ValueChanged(object sender, RoutedEventArgs e)
         {
             if (this.Actions is null)
                 return;
@@ -206,22 +205,8 @@ namespace HandheldCompanion.Controls
             switch (this.Actions.ActionType)
             {
                 case ActionType.Joystick:
-                    ((AxisActions)this.Actions).AxisInverted = Axis2AxisInvertAxis.IsOn;
-                    break;
-            }
-
-            base.Update();
-        }
-
-        private void Axis2AxisRotateAxis_Toggled(object sender, RoutedEventArgs e)
-        {
-            if (this.Actions is null)
-                return;
-
-            switch (this.Actions.ActionType)
-            {
-                case ActionType.Joystick:
-                    ((AxisActions)this.Actions).AxisRotated = Axis2AxisRotateAxis.IsOn;
+                    ((AxisActions)this.Actions).AxisInverted = (((int)Axis2AxisRotation.Value / 90) & 2) == 2;
+                    ((AxisActions)this.Actions).AxisRotated = (((int)Axis2AxisRotation.Value / 90) & 1) == 1;
                     break;
             }
 

--- a/HandheldCompanion/Controls/Mapping/AxisMapping.xaml.cs
+++ b/HandheldCompanion/Controls/Mapping/AxisMapping.xaml.cs
@@ -140,7 +140,7 @@ namespace HandheldCompanion.Controls
 
                 // settings
                 Axis2MousePointerSpeed.Value = ((MouseActions)this.Actions).Sensivity;
-                Axis2MouseInvertAxis.IsOn = ((MouseActions)this.Actions).AxisInverted;
+                Axis2MouseRotation.Value = (((MouseActions)this.Actions).AxisInverted ? 180 : 0) + (((MouseActions)this.Actions).AxisRotated ? 90 : 0);
                 Axis2MouseDeadzone.Value = ((MouseActions)this.Actions).Deadzone;
             }
 
@@ -197,7 +197,7 @@ namespace HandheldCompanion.Controls
             }
         }
 
-        private void Axis_Rotation_Slider_ValueChanged(object sender, RoutedEventArgs e)
+        private void Axis_Rotation_Slider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
             if (this.Actions is null)
                 return;
@@ -288,7 +288,7 @@ namespace HandheldCompanion.Controls
             base.Update();
         }
 
-        private void Axis2MouseInvertAxis_Toggled(object sender, RoutedEventArgs e)
+        private void Axis2MouseRotation_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
             if (this.Actions is null)
                 return;
@@ -296,7 +296,8 @@ namespace HandheldCompanion.Controls
             switch (this.Actions.ActionType)
             {
                 case ActionType.Mouse:
-                    ((MouseActions)this.Actions).AxisInverted = Axis2MouseInvertAxis.IsOn;
+                    ((MouseActions)this.Actions).AxisInverted = (((int)Axis2MouseRotation.Value / 90) & 2) == 2;
+                    ((MouseActions)this.Actions).AxisRotated = (((int)Axis2MouseRotation.Value / 90) & 1) == 1;
                     break;
             }
 

--- a/HandheldCompanion/Managers/LayoutManager.cs
+++ b/HandheldCompanion/Managers/LayoutManager.cs
@@ -309,8 +309,8 @@ namespace HandheldCompanion.Managers
                             AxisFlags OutAxisX = OutLayout.GetAxisFlags('X');
                             AxisFlags OutAxisY = OutLayout.GetAxisFlags('Y');
 
-                            outputState.AxisState[OutAxisX] = (short)aAction.GetValue().X;
-                            outputState.AxisState[OutAxisY] = (short)aAction.GetValue().Y;
+                            outputState.AxisState[OutAxisX] = (short)(Math.Clamp(aAction.GetValue().X, short.MinValue, short.MaxValue));
+                            outputState.AxisState[OutAxisY] = (short)(Math.Clamp(aAction.GetValue().Y, short.MinValue, short.MaxValue));
                         }
                         break;
 


### PR DESCRIPTION
This is an implementation of what I mentioned in #456. Implements rotation options for the joysticks, which are useful for the built-in joysticks on handhelds when using the device in different screen orientations (for example, portrait-mode games).

Internally, this implementation makes use of the existing invert axis option and leaves alone the internals of that one, and just adds an additional 90 degree rotation, along with changing the visible option to a slider instead of just toggles. The slider allows selection of 0 (default, no rotation), 90, 180, or 270 degree rotation.

I've also applied a couple Math.Clamp calls in one particular place, which seems to have fixed the issue I reported on #454.