### PR TITLE
Fan control fixes, fixes #461

### DIFF
--- a/HandheldCompanion/Managers/SystemManager.cs
+++ b/HandheldCompanion/Managers/SystemManager.cs
@@ -206,12 +206,27 @@ namespace HandheldCompanion.Managers
         {
             switch (name)
             {
+                case "QuietModeEnabled":
+                    {
+                        bool enabled = Convert.ToBoolean(value);
+                        bool toggled = SettingsManager.GetBoolean("QuietModeToggled");
+
+                        if (!enabled && toggled)
+                            SettingsManager.SetProperty("QuietModeToggled", false);
+                    }
+                    break;
                 case "QuietModeToggled":
                     {
-                        bool status = Convert.ToBoolean(value);
-                        MainWindow.CurrentDevice.SetFanControl(status);
+                        bool toggled = Convert.ToBoolean(value);
+                        bool startup = SettingsManager.GetBoolean("DuringStartup", true);
 
-                        if (!status)
+                        // if it's off avoid sending any control commands to the hardware on startup
+                        if (startup && !toggled)
+                            return;
+
+                        MainWindow.CurrentDevice.SetFanControl(toggled);
+
+                        if (!toggled)
                             return;
 
                         double duty = SettingsManager.GetDouble("QuietModeDuty");
@@ -220,11 +235,13 @@ namespace HandheldCompanion.Managers
                     break;
                 case "QuietModeDuty":
                     {
-                        bool status = SettingsManager.GetBoolean("QuietModeEnabled");
-                        if (!status)
+                        bool enabled = SettingsManager.GetBoolean("QuietModeEnabled");
+                        bool toggled = SettingsManager.GetBoolean("QuietModeToggled");
+
+                        if (!enabled || !toggled)
                             return;
 
-                        double duty = SettingsManager.GetDouble("QuietModeDuty");
+                        double duty = Convert.ToDouble(value);
                         MainWindow.CurrentDevice.SetFanDuty(duty);
                     }
                     break;

--- a/HandheldCompanion/Views/QuickPages/QuickPerformancePage.xaml
+++ b/HandheldCompanion/Views/QuickPages/QuickPerformancePage.xaml
@@ -417,40 +417,5 @@
             BorderThickness="0,1,0,0"
             Opacity="0.25" />
 
-        <!--  Fan mode  -->
-        <Border Padding="15,6,15,6" CornerRadius="{DynamicResource ControlCornerRadius}">
-
-            <Grid>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition />
-                    <ColumnDefinition Width="0.2*" MinWidth="80" />
-                </Grid.ColumnDefinitions>
-
-                <DockPanel>
-                    <ui:FontIcon
-                        Height="40"
-                        HorizontalAlignment="Center"
-                        FontFamily="{DynamicResource SymbolThemeFontFamily}"
-                        Glyph="&#xE708;" />
-
-                    <ui:SimpleStackPanel Margin="12,0,0,0" VerticalAlignment="Center">
-                        <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{x:Static resx:Resources.InputsHotkey_QuietModeToggled}" />
-                        <TextBlock
-                            Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
-                            Style="{StaticResource CaptionTextBlockStyle}"
-                            Text="{x:Static resx:Resources.InputsHotkey_QuietModeToggledDesc}"
-                            TextWrapping="Wrap" />
-                    </ui:SimpleStackPanel>
-                </DockPanel>
-
-                <ui:ToggleSwitch
-                    Name="QuietModeToggle"
-                    Grid.Column="1"
-                    HorizontalAlignment="Right"
-                    IsEnabled="False"
-                    Style="{DynamicResource InvertedToggleSwitchStyle}" />
-            </Grid>
-        </Border>
-
     </ui:SimpleStackPanel>
 </Page>

--- a/HandheldCompanion/Views/QuickPages/QuickPerformancePage.xaml.cs
+++ b/HandheldCompanion/Views/QuickPages/QuickPerformancePage.xaml.cs
@@ -97,12 +97,6 @@ namespace HandheldCompanion.Views.QuickPages
                     case "QuickToolsPerformanceGPUEnabled":
                         GPUToggle.IsOn = Convert.ToBoolean(value);
                         break;
-                    case "QuietModeEnabled":
-                        QuietModeToggle.IsEnabled = Convert.ToBoolean(value);
-                        break;
-                    case "QuietModeToggled":
-                        QuietModeToggle.IsOn = Convert.ToBoolean(value);
-                        break;
                     case "QuickToolsPerformanceTDPSustainedValue":
                         {
                             double TDP = Convert.ToDouble(value);

--- a/HandheldCompanion/Views/Windows/MainWindow.xaml.cs
+++ b/HandheldCompanion/Views/Windows/MainWindow.xaml.cs
@@ -74,6 +74,8 @@ namespace HandheldCompanion.Views
         {
             InitializeComponent();
 
+            SettingsManager.SetProperty("DuringStartup", true, false, true);
+
             fileVersionInfo = _fileVersionInfo;
             CurrentWindow = this;
 
@@ -204,6 +206,8 @@ namespace HandheldCompanion.Views
             // update FirstStart
             if (IsFirstStart)
                 SettingsManager.SetProperty("FirstStart", false);
+
+            SettingsManager.SetProperty("DuringStartup", false, false, true);
         }
 
         private void SettingsManager_SettingValueChanged(string name, object value)


### PR DESCRIPTION
1. Don't send any commands to fan control when it's disabled on start. It's safer that way.
2. Rework conditions in SettingsManager_SettingValueChanged() to only send what's required. Nothing more.
3. Disable Toggle (if enabled) when disabling Override. This way the fan will return to normal when disabling the override during quiet mode work.
4. Remove the Fan Control toggle from the Performance page. It wasn't fully implemented and we have pinnable Quiet Mode in hotkeys.