### PR TITLE
Some minor cleanups for the layout exporter functionality

### DIFF
--- a/HandheldCompanion/Managers/LayoutManager.cs
+++ b/HandheldCompanion/Managers/LayoutManager.cs
@@ -120,14 +120,12 @@ namespace HandheldCompanion.Managers
 
         private static bool LayoutTemplateExist(LayoutTemplate layoutTemplate)
         {
-            string fileName = Path.Combine(LayoutsPath, $"{layoutTemplate.Name}.json");
+            string fileName = Path.Combine(TemplatesPath, $"{layoutTemplate.Name}.json");
             return File.Exists(fileName);
         }
 
         private static void ProcessLayoutTemplate(string fileName)
         {
-            string layoutName = Path.GetFileNameWithoutExtension(fileName);
-
             // UI thread (synchronous)
             // We need to wait for each controller to initialize and take (or not) its slot in the array
             Application.Current.Dispatcher.BeginInvoke(() =>
@@ -230,7 +228,7 @@ namespace HandheldCompanion.Managers
             if (layoutTemplate.IsTemplate)
                 fileName = Path.Combine(TemplatesPath, $"{layoutTemplate.Name}.json");
             else
-                fileName = Path.Combine(LayoutsPath, $"{layoutTemplate.Name}_{layoutTemplate.Product}_{layoutTemplate.Author}.json");
+                fileName = Path.Combine(LayoutsPath, $"{layoutTemplate.Name}_{layoutTemplate.Author}.json");
 
             File.WriteAllText(fileName, jsonString);
         }

--- a/HandheldCompanion/Views/Pages/LayoutPage.xaml
+++ b/HandheldCompanion/Views/Pages/LayoutPage.xaml
@@ -125,6 +125,8 @@
                             HorizontalAlignment="Right"
                             Orientation="Horizontal"
                             Spacing="6">
+
+                            <!-- Apply layout -->
                             <Button
                                 Name="ButtonApplyLayout"
                                 Click="ButtonApplyLayout_Click"
@@ -133,7 +135,7 @@
                                 Apply layout
                             </Button>
 
-                            <!--  Implement me  -->
+                            <!--  Export layout  -->
                             <Button Name="ButtonLayoutSettings" Content="Export layout">
                                 <ui:FlyoutService.Flyout>
                                     <ui:Flyout
@@ -157,7 +159,8 @@
                                                     Name="LayoutAuthor"
                                                     HorizontalAlignment="Stretch"
                                                     ui:ControlHelper.Header="Layout author" />
-                                                <CheckBox Content="Export for current controller" />
+                                                <CheckBox x:Name="ExportForCurrent" Content="Export for current controller" />
+                                                <CheckBox x:Name="SaveGameInfo" Content="Save game information with the layout" IsChecked="True" />
 
                                                 <!--  Separator  -->
                                                 <Separator

--- a/HandheldCompanion/Views/Pages/LayoutPage.xaml.cs
+++ b/HandheldCompanion/Views/Pages/LayoutPage.xaml.cs
@@ -433,25 +433,15 @@ namespace HandheldCompanion.Views.Pages
                 Name = LayoutTitle.Text,
                 Description = LayoutDescription.Text,
                 Author = LayoutAuthor.Text,
-                Executable = currentTemplate.Executable,
-                Product = ProfilesPage.currentProfile.Name,
+                Executable = SaveGameInfo.IsChecked == true ? currentTemplate.Executable : "",
+                Product = SaveGameInfo.IsChecked == true ? ProfilesPage.currentProfile.Name : "",
                 IsCommunity = true,
                 IsTemplate = false
             };
 
-            if ((bool)CheckBoxDeviceLayouts.IsChecked)
+            if (ExportForCurrent.IsChecked == true)
                 newLayout.ControllerType = ControllerManager.GetTargetController().GetType();
             
-            /* System.Windows.Forms.SaveFileDialog saveFileDialog = new()
-            {
-                FileName = $"{newLayout.Name}_{newLayout.Product}_{newLayout.Author}",
-                AddExtension = true,
-                DefaultExt = "json",
-                Filter = "Layout Files (*.json)|*.json",
-                InitialDirectory = LayoutManager.InstallPath,
-            };
-
-            if (saveFileDialog.ShowDialog() == System.Windows.Forms.DialogResult.OK) */
             LayoutManager.SerializeLayoutTemplate(newLayout);
 
             // close flyout
@@ -460,14 +450,14 @@ namespace HandheldCompanion.Views.Pages
             // display message
             // todo: localize me
             _ = Dialog.ShowAsync("Layout template exported",
-                             $"{currentTemplate.Name} was exported.",
+                             $"{newLayout.Name} was exported.",
                              ContentDialogButton.Primary, null, $"{Properties.Resources.ProfilesPage_OK}");
         }
 
         private void Flyout_Opening(object sender, object e)
         {
-            // manage visibility
-            LayoutTitle.Text = $"{currentTemplate.Name} - {currentTemplate.Product}";
+            string separator = (currentTemplate.Name.Length > 0 && currentTemplate.Product.Length > 0) ? " - " : "";
+            LayoutTitle.Text = $"{currentTemplate.Name}{separator}{currentTemplate.Product}";
             LayoutDescription.Text = currentTemplate.Description;
             LayoutAuthor.Text = currentTemplate.Author;
         }

--- a/HandheldCompanion/Views/Pages/ProfilesPage.xaml.cs
+++ b/HandheldCompanion/Views/Pages/ProfilesPage.xaml.cs
@@ -269,7 +269,7 @@ namespace HandheldCompanion.Views.Pages
 
                     Profile profile = new Profile(path);
                     profile.Layout = LayoutTemplate.DefaultLayout.Layout.Clone() as Layout;
-                    profile.LayoutTitle = LayoutTemplate.DesktopLayout.Name;
+                    profile.LayoutTitle = LayoutTemplate.DefaultLayout.Name;
                     profile.TDPOverrideValues = MainWindow.CurrentDevice.nTDP;
 
                     bool exists = false;


### PR DESCRIPTION
- minor cleanups
- remove dead code
- fix for naming the new profile for a game
- fix for overwriting the Desktop profile on HC start
- fix for the "current controller" checkbox
- added a checkbox to export game info with the layout
- finetune the exported profile naming