### PR TITLE
Fix adding a profile for game that already exists

### DIFF
--- a/HandheldCompanion/Managers/ProfileManager.cs
+++ b/HandheldCompanion/Managers/ProfileManager.cs
@@ -113,7 +113,7 @@ namespace HandheldCompanion.Managers
         public static bool Contains(Profile profile)
         {
             foreach (Profile pr in profiles.Values)
-                if (pr.Guid.Equals(profile.Guid))
+                if (pr.Executable.Equals(profile.Executable))
                     return true;
 
             return false;

--- a/HandheldCompanion/Views/Pages/ProfilesPage.xaml.cs
+++ b/HandheldCompanion/Views/Pages/ProfilesPage.xaml.cs
@@ -155,7 +155,7 @@ namespace HandheldCompanion.Views.Pages
                 int idx = -1;
                 foreach (Profile pr in cB_Profiles.Items)
                 {
-                    if (pr.Guid == profile.Guid)
+                    if (pr.Executable == profile.Executable)
                     {
                         idx = cB_Profiles.Items.IndexOf(pr);
                         break;


### PR DESCRIPTION
Fixes #477

Not sure this fix is correct. This probably needs some review for GUID vs Executable usage.