### PR TITLE
Display ticks for axis rotation sliders

### DIFF
--- a/HandheldCompanion/Controls/Mapping/AxisMapping.xaml
+++ b/HandheldCompanion/Controls/Mapping/AxisMapping.xaml
@@ -127,6 +127,7 @@
                                         ScrollViewer.PanningMode="HorizontalOnly"
                                         Style="{DynamicResource SliderStyle1}"
                                         TickFrequency="90"
+                                        TickPlacement="BottomRight"
                                         ValueChanged="Axis_Rotation_Slider_ValueChanged" />
                                 </ui:SimpleStackPanel>
                             </Grid>
@@ -283,6 +284,7 @@
                                         ScrollViewer.PanningMode="HorizontalOnly"
                                         Style="{DynamicResource SliderStyle1}"
                                         TickFrequency="90"
+                                        TickPlacement="BottomRight"
                                         ValueChanged="Axis2MouseRotation_ValueChanged" />
                                 </ui:SimpleStackPanel>
                             </Grid>


### PR DESCRIPTION
I had this as part of the other pull request, but it was unrelated, so I decided to split it off into its own. Just enables the visibility of the ticks for the axis rotation sliders.