### PR TITLE
Steam deck to Dualshock4 fix

### DIFF
--- a/ControllerService/Targets/DualShock4Target.cs
+++ b/ControllerService/Targets/DualShock4Target.cs
@@ -41,7 +41,7 @@ internal class DualShock4Target : ViGEmTarget
         // initialize controller
         HID = HIDmode.DualShock4Controller;
 
-        virtualController = ControllerService.vClient.CreateDualShock4Controller();
+        virtualController = ControllerService.vClient.CreateDualShock4Controller(0x054C, 0x09CC);
         virtualController.AutoSubmitReport = false;
         virtualController.FeedbackReceived += FeedbackReceived;
 

--- a/ControllerService/Targets/DualShock4Target.cs
+++ b/ControllerService/Targets/DualShock4Target.cs
@@ -26,8 +26,8 @@ internal class DualShock4Target : ViGEmTarget
     // Note, at +/- 2000 the value is still off by a factor 5
     private static readonly SensorSpec DS4GyroscopeSensorSpec = new()
     {
-        minIn = -10000.0f,
-        maxIn = 10000.0f,
+        minIn = -2000.0f,
+        maxIn = 2000.0f,
         minOut = short.MinValue,
         maxOut = short.MaxValue
     };

--- a/HandheldCompanion/Managers/LayoutManager.cs
+++ b/HandheldCompanion/Managers/LayoutManager.cs
@@ -312,10 +312,16 @@ internal static class LayoutManager
 
             // skip, if not mapped
             if (!currentLayout.ButtonLayout.TryGetValue(button, out var action))
+            {
+                outputState.ButtonState[button] = value;
                 continue;
+            }
 
             if (action is null)
+            {
+                outputState.ButtonState[button] = value;
                 continue;
+            }
 
             switch (action.ActionType)
             {
@@ -348,10 +354,8 @@ internal static class LayoutManager
             }
         }
 
-        foreach (var axisLayout in currentLayout.AxisLayout)
+        foreach (AxisLayoutFlags flags in Enum.GetValues(typeof(AxisLayoutFlags)))
         {
-            var flags = axisLayout.Key;
-
             // read origin values
             var InLayout = AxisLayout.Layouts[flags];
             var InAxisX = InLayout.GetAxisFlags('X');
@@ -361,10 +365,20 @@ internal static class LayoutManager
             InLayout.vector.Y = controllerState.AxisState[InAxisY];
 
             // pull action
-            var action = axisLayout.Value;
+            // skip, if not mapped
+            if (!currentLayout.AxisLayout.TryGetValue(flags, out var action))
+            {
+                outputState.AxisState[InAxisX] = controllerState.AxisState[InAxisX];
+                outputState.AxisState[InAxisY] = controllerState.AxisState[InAxisY];
+                continue;
+            }
 
             if (action is null)
+            {
+                outputState.AxisState[InAxisX] = controllerState.AxisState[InAxisX];
+                outputState.AxisState[InAxisY] = controllerState.AxisState[InAxisY];
                 continue;
+            }
 
             switch (action.ActionType)
             {
@@ -379,9 +393,9 @@ internal static class LayoutManager
                     var OutAxisY = OutLayout.GetAxisFlags('Y');
 
                     outputState.AxisState[OutAxisX] =
-                        (short)Math.Clamp(aAction.GetValue().X, short.MinValue, short.MaxValue);
+                        (short)Math.Clamp(outputState.AxisState[OutAxisX] + aAction.GetValue().X, short.MinValue, short.MaxValue);
                     outputState.AxisState[OutAxisY] =
-                        (short)Math.Clamp(aAction.GetValue().Y, short.MinValue, short.MaxValue);
+                        (short)Math.Clamp(outputState.AxisState[OutAxisY] + aAction.GetValue().Y, short.MinValue, short.MaxValue);
                 }
                     break;
 


### PR DESCRIPTION
Fix known issues with Dualshock 4 emulation on Steam Deck.
- Gyrometer is now snappy.
- Emulating a 2nd generation DualShock 4 to improve compatibility.
- Properly pass pads clicks and movements to virtual DS4 touch panel.