### PR TITLE
Prevent minimizing when using Quick Tools

### DIFF
--- a/ControllerCommon/ControllerCommon.csproj
+++ b/ControllerCommon/ControllerCommon.csproj
@@ -8,6 +8,7 @@
 		<Version>0.9.3.0</Version>
 		<OutputPath>$(SolutionDir)bin\$(Configuration)</OutputPath>
 		<Platforms>AnyCPU;x64</Platforms>
+		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/HandheldCompanion/Views/Windows/OverlayQuickTools.xaml
+++ b/HandheldCompanion/Views/Windows/OverlayQuickTools.xaml
@@ -25,14 +25,19 @@
     ResizeMode="NoResize"
     ShowInTaskbar="False"
     SourceInitialized="Window_SourceInitialized"
-    Topmost="True"
     WindowStyle="SingleBorderWindow"
-    mc:Ignorable="d">
+    mc:Ignorable="d" ShowActivated="False">
 
     <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="40*"/>
+            <ColumnDefinition Width="63*"/>
+            <ColumnDefinition Width="52*"/>
+            <ColumnDefinition Width="285*"/>
+        </Grid.ColumnDefinitions>
         <ui:NavigationView
             Name="navView"
-            Grid.ColumnSpan="2"
+            Grid.ColumnSpan="4"
             BackRequested="navView_BackRequested"
             IsBackButtonVisible="Collapsed"
             IsBackEnabled="False"

--- a/HandheldCompanion/Views/Windows/OverlayQuickTools.xaml.cs
+++ b/HandheldCompanion/Views/Windows/OverlayQuickTools.xaml.cs
@@ -27,6 +27,11 @@ using SystemInformation = System.Windows.Forms.SystemInformation;
 using SystemPowerManager = Windows.System.Power.PowerManager;
 using Control = System.Windows.Controls.Control;
 using HandheldCompanion.Views.Classes;
+using System.Runtime.InteropServices;
+using static System.Windows.Forms.VisualStyles.VisualStyleElement;
+using System.Runtime.CompilerServices;
+using static WindowsInput.Native.SystemMetrics;
+using ControllerCommon;
 
 namespace HandheldCompanion.Views.Windows;
 
@@ -264,9 +269,7 @@ public partial class OverlayQuickTools : GamepadWindow
                 case Visibility.Collapsed:
                 case Visibility.Hidden:
                     Show();
-                    Activate();
-                    Focus();
-                    Topmost = true;
+                    WinAPI.ShowInactiveTopmost(this);
                     break;
                 case Visibility.Visible:
                     Hide();
@@ -274,7 +277,6 @@ public partial class OverlayQuickTools : GamepadWindow
             }
         });
     }
-
     private void Window_Closing(object sender, CancelEventArgs e)
     {
         // position and size settings


### PR DESCRIPTION
This is an attempt to prevent minimizing when using Quick Tools menu on Fullscreen games. Most of this is a proof of concept.