### PR TITLE
(PoC) Prevent full screen games from minimizing when using QuickTools…

### DIFF
--- a/HandheldCompanion/Views/Windows/OverlayQuickTools.xaml
+++ b/HandheldCompanion/Views/Windows/OverlayQuickTools.xaml
@@ -25,9 +25,8 @@
     ResizeMode="NoResize"
     ShowInTaskbar="False"
     SourceInitialized="Window_SourceInitialized"
-    Topmost="True"
     WindowStyle="SingleBorderWindow"
-    mc:Ignorable="d">
+    mc:Ignorable="d" ShowActivated="False">
 
     <Grid>
         <ui:NavigationView

--- a/HandheldCompanion/Views/Windows/OverlayQuickTools.xaml.cs
+++ b/HandheldCompanion/Views/Windows/OverlayQuickTools.xaml.cs
@@ -25,7 +25,6 @@ using PowerManager = ControllerCommon.Managers.PowerManager;
 using Screen = WpfScreenHelper.Screen;
 using SystemInformation = System.Windows.Forms.SystemInformation;
 using SystemPowerManager = Windows.System.Power.PowerManager;
-using Control = System.Windows.Controls.Control;
 using HandheldCompanion.Views.Classes;
 
 namespace HandheldCompanion.Views.Windows;
@@ -56,6 +55,9 @@ public partial class OverlayQuickTools : GamepadWindow
 
     public OverlayQuickTools()
     {
+        WindowSinker overlayquickToolsSinker = new WindowSinker(this);
+        overlayquickToolsSinker.Sink();
+
         InitializeComponent();
 
         // used by gamepad navigation
@@ -265,9 +267,6 @@ public partial class OverlayQuickTools : GamepadWindow
                 case Visibility.Collapsed:
                 case Visibility.Hidden:
                     Show();
-                    Activate();
-                    Focus();
-                    Topmost = true;
                     break;
                 case Visibility.Visible:
                     Hide();
@@ -275,7 +274,6 @@ public partial class OverlayQuickTools : GamepadWindow
             }
         });
     }
-
     private void Window_Closing(object sender, CancelEventArgs e)
     {
         // position and size settings

--- a/HandheldCompanion/WindowSinker.cs
+++ b/HandheldCompanion/WindowSinker.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Windows.Interop;
+using System.Windows;
+
+namespace HandheldCompanion
+{
+    public class WindowSinker
+    {
+        #region Properties
+
+        const UInt32 SWP_NOSIZE = 0x0001;
+        const UInt32 SWP_NOMOVE = 0x0002;
+        const UInt32 SWP_NOACTIVATE = 0x0010;
+        const UInt32 SWP_NOZORDER = 0x0004;
+        const int WM_ACTIVATEAPP = 0x001C;
+        const int WM_ACTIVATE = 0x0006;
+        const int WM_SETFOCUS = 0x0007;
+        const int WM_WINDOWPOSCHANGING = 0x0046;
+
+        static readonly IntPtr HWND_BOTTOM = new IntPtr(1);
+
+        static readonly int HWND_TOPMOST = -1;
+
+        Window Window;
+
+        #endregion
+
+        #region WindowSinker
+
+        public WindowSinker(Window Window)
+        {
+            this.Window = Window;
+        }
+
+        #endregion
+
+        #region Methods
+
+        [DllImport("user32.dll")]
+        static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
+
+        [DllImport("user32.dll")]
+        static extern IntPtr DeferWindowPos(IntPtr hWinPosInfo, IntPtr hWnd, IntPtr hWndInsertAfter, int x, int y, int cx, int cy, uint uFlags);
+
+        [DllImport("user32.dll")]
+        static extern IntPtr BeginDeferWindowPos(int nNumWindows);
+
+        [DllImport("user32.dll")]
+        static extern bool EndDeferWindowPos(IntPtr hWinPosInfo);
+
+        void OnClosing(object sender, System.ComponentModel.CancelEventArgs e)
+        {
+            var Handle = (new WindowInteropHelper(Window)).Handle;
+
+            var Source = HwndSource.FromHwnd(Handle);
+            Source.RemoveHook(new HwndSourceHook(WndProc));
+        }
+
+        void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            var Hwnd = new WindowInteropHelper(Window).Handle;
+            SetWindowPos(Hwnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE | SWP_NOACTIVATE);
+
+            var Handle = (new WindowInteropHelper(Window)).Handle;
+
+            var Source = HwndSource.FromHwnd(Handle);
+            Source.AddHook(new HwndSourceHook(WndProc));
+        }
+
+        IntPtr WndProc(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+        {
+            if (msg == WM_SETFOCUS)
+            {
+                hWnd = new WindowInteropHelper(Window).Handle;
+                SetWindowPos(hWnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE | SWP_NOACTIVATE);
+                handled = true;
+            }
+            return IntPtr.Zero;
+        }
+
+        public void Sink()
+        {
+            Window.Loaded += OnLoaded;
+            Window.Closing += OnClosing;
+        }
+
+        public void Unsink()
+        {
+            Window.Loaded -= OnLoaded;
+            Window.Closing -= OnClosing;
+        }
+
+        #endregion
+    }
+
+    public static class WindowExtensions
+    {
+        #region Always On Bottom
+
+        public static readonly DependencyProperty SinkerProperty = DependencyProperty.RegisterAttached("Sinker", typeof(WindowSinker), typeof(WindowExtensions), new UIPropertyMetadata(null));
+        public static WindowSinker GetSinker(DependencyObject obj)
+        {
+            return (WindowSinker)obj.GetValue(SinkerProperty);
+        }
+        public static void SetSinker(DependencyObject obj, WindowSinker value)
+        {
+            obj.SetValue(SinkerProperty, value);
+        }
+
+        public static readonly DependencyProperty AlwaysOnBottomProperty = DependencyProperty.RegisterAttached("AlwaysOnBottom", typeof(bool), typeof(WindowExtensions), new UIPropertyMetadata(false, OnAlwaysOnBottomChanged));
+        public static bool GetAlwaysOnBottom(DependencyObject obj)
+        {
+            return (bool)obj.GetValue(AlwaysOnBottomProperty);
+        }
+        public static void SetAlwaysOnBottom(DependencyObject obj, bool value)
+        {
+            obj.SetValue(AlwaysOnBottomProperty, value);
+        }
+        static void OnAlwaysOnBottomChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            var Window = sender as Window;
+            if (Window != null)
+            {
+                if ((bool)e.NewValue)
+                {
+                    var Sinker = new WindowSinker(Window);
+                    Sinker.Sink();
+                    SetSinker(Window, Sinker);
+                }
+                else
+                {
+                    var Sinker = GetSinker(Window);
+                    Sinker.Unsink();
+                    SetSinker(Window, null);
+                }
+            }
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
… menu.

Reference: https://stackoverflow.com/questions/66512492/c-sharp-wpf-overlay-for-fullscreen-applications

Implementation of WindowSinker using HWND_TOPMOST flag instead of HWND_BOTTOM for QuickTools menu. Testing indicates that most games are no longer minimizing when bringing the QuickTools menu up. However, because there is no focus on the QuickTools menu, you can't change options. Interacting with the QuickTools menu will minimize the game. Possible solution is to capture controller actions independently and send them to the QuickTools window ?

Note: some games like Elden Ring will continue to minimize even when using this solution. I believe it's because the game is using exclusive fullscreen. My research leads me to think we won't be able to fix this with this approach. We will possibly need a different technology such as Metro apps or a driver-level overlay.

This is a proof-of-concept for research and testing purposes, therefore it should not be considered as a working solution.