### PR TITLE
Improve device and controller behavior on system resume

### DIFF
--- a/ControllerCommon/Controllers/IController.cs
+++ b/ControllerCommon/Controllers/IController.cs
@@ -226,8 +226,8 @@ public abstract class IController
 
     protected void RefreshControls()
     {
-        // UI thread (async)
-        Application.Current.Dispatcher.BeginInvoke(() =>
+        // UI thread
+        Application.Current.Dispatcher.Invoke(() =>
         {
             ui_button_hook.IsEnabled = !IsPlugged();
             ui_button_hook.Content = IsPlugged() ? "Connected" : "Connect";

--- a/ControllerCommon/Controllers/IController.cs
+++ b/ControllerCommon/Controllers/IController.cs
@@ -226,8 +226,8 @@ public abstract class IController
 
     protected void RefreshControls()
     {
-        // UI thread
-        Application.Current.Dispatcher.Invoke(() =>
+        // UI thread (async)
+        Application.Current.Dispatcher.BeginInvoke(() =>
         {
             ui_button_hook.IsEnabled = !IsPlugged();
             ui_button_hook.Content = IsPlugged() ? "Connected" : "Connect";

--- a/ControllerCommon/Controllers/IController.cs
+++ b/ControllerCommon/Controllers/IController.cs
@@ -226,9 +226,13 @@ public abstract class IController
 
     protected void RefreshControls()
     {
-        ui_button_hook.IsEnabled = !IsPlugged();
-        ui_button_hook.Content = IsPlugged() ? "Connected" : "Connect";
-        ui_button_hide.Content = IsHidden() ? "Unhide" : "Hide";
+        // UI thread (async)
+        Application.Current.Dispatcher.BeginInvoke(() =>
+        {
+            ui_button_hook.IsEnabled = !IsPlugged();
+            ui_button_hook.Content = IsPlugged() ? "Connected" : "Connect";
+            ui_button_hide.Content = IsHidden() ? "Unhide" : "Hide";
+        });
     }
 
     public Border GetControl()

--- a/ControllerCommon/Devices/ASUS/ROGAlly.cs
+++ b/ControllerCommon/Devices/ASUS/ROGAlly.cs
@@ -75,6 +75,10 @@ public class ROGAlly : IDevice
 
     public override bool Open()
     {
+        var success = base.Open();
+        if (!success)
+            return false;
+
         // prepare configuration
         var deviceConfiguration = new OpenConfiguration();
         deviceConfiguration.SetOption(OpenOption.Exclusive, true);
@@ -98,7 +102,7 @@ public class ROGAlly : IDevice
             }
         }
 
-        return base.Open();
+        return true;
     }
 
     public override void Close()

--- a/ControllerCommon/Devices/IDevice.cs
+++ b/ControllerCommon/Devices/IDevice.cs
@@ -310,6 +310,9 @@ public abstract class IDevice
 
     public virtual void Close()
     {
+        if (openLibSys is null)
+            return;
+
         SetFanControl(false);
 
         openLibSys.Dispose();

--- a/ControllerCommon/Managers/DeviceManager.cs
+++ b/ControllerCommon/Managers/DeviceManager.cs
@@ -44,9 +44,7 @@ public static class DeviceManager
         HidDeviceListener.DeviceArrived += HidDevice_DeviceArrived;
         HidDeviceListener.DeviceRemoved += HidDevice_DeviceRemoved;
 
-        RefreshHID();
-        RefreshXInput();
-        RefreshDInput();
+        Refresh();
 
         IsInitialized = true;
         Initialized?.Invoke();
@@ -74,6 +72,13 @@ public static class DeviceManager
         HidDeviceListener.DeviceRemoved -= HidDevice_DeviceRemoved;
 
         LogManager.LogInformation("{0} has stopped", "DeviceManager");
+    }
+
+    public static void Refresh()
+    {
+        RefreshHID();
+        RefreshXInput();
+        RefreshDInput();
     }
 
     private static void RefreshXInput()

--- a/ControllerService/ControllerService.cs
+++ b/ControllerService/ControllerService.cs
@@ -576,10 +576,6 @@ public class ControllerService : IHostedService
                     case SystemStatus.SystemPending:
                         // resume from sleep
                         Thread.Sleep(CurrentDevice.ResumeDelay);
-
-                        // refresh device list
-                        DeviceManager.Refresh();
-
                         // restart IMU
                         IMU.Restart(true);
                         break;

--- a/ControllerService/ControllerService.cs
+++ b/ControllerService/ControllerService.cs
@@ -576,6 +576,11 @@ public class ControllerService : IHostedService
                     case SystemStatus.SystemPending:
                         // resume from sleep
                         Thread.Sleep(CurrentDevice.ResumeDelay);
+
+                        // refresh device list
+                        DeviceManager.Refresh();
+
+                        // restart IMU
                         IMU.Restart(true);
                         break;
                 }

--- a/HandheldCompanion/Managers/ControllerManager.cs
+++ b/HandheldCompanion/Managers/ControllerManager.cs
@@ -348,11 +348,6 @@ public static class ControllerManager
             if (!controller.IsConnected())
                 return;
 
-            /*
-            if (controller.IsVirtual())
-                return;
-            */
-
             // update or create controller
             var path = controller.GetInstancePath();
             Controllers[path] = controller;
@@ -363,6 +358,8 @@ public static class ControllerManager
 
             // raise event
             ControllerPlugged?.Invoke(controller);
+            LogManager.LogDebug("DInput controller plugged: {0}", controller.ToString());
+
             ToastManager.SendToast(controller.ToString(), "detected");
         });
     }
@@ -371,14 +368,6 @@ public static class ControllerManager
     {
         if (!Controllers.TryGetValue(details.deviceInstanceId, out var controller))
             return;
-
-        if (!controller.IsConnected())
-            return;
-
-        /*
-        if (controller.IsVirtual())
-            return;
-        */
 
         // XInput controller are handled elsewhere
         if (controller.GetType() == typeof(XInputController))
@@ -411,6 +400,8 @@ public static class ControllerManager
                 break;
         }
 
+        LogManager.LogDebug("XInput slot available: {0}", slot);
+
         // UI thread (synchronous)
         // We need to wait for each controller to initialize and take (or not) its slot in the array
         Application.Current.Dispatcher.Invoke(() =>
@@ -419,18 +410,19 @@ public static class ControllerManager
 
             // failed to initialize
             if (controller.Details is null)
+            {
+                LogManager.LogError("XInput details is empty");
                 return;
+            }
 
             if (!controller.IsConnected())
+            {
+                LogManager.LogError("XInput controller is not connected");
                 return;
+            }
 
             // slot is now busy
             XUsbControllers[slot] = false;
-
-            /*
-            if (controller.IsVirtual())
-                return;
-            */
 
             // update or create controller
             var path = controller.GetInstancePath();
@@ -442,6 +434,8 @@ public static class ControllerManager
 
             // raise event
             ControllerPlugged?.Invoke(controller);
+            LogManager.LogDebug("XInput controller plugged: {0}", controller.ToString());
+
             ToastManager.SendToast(controller.ToString(), "detected");
         });
     }
@@ -451,17 +445,9 @@ public static class ControllerManager
         if (!Controllers.TryGetValue(details.deviceInstanceId, out var controller))
             return;
 
-        if (controller.IsConnected())
-            return;
-
         // slot is now free
         var slot = (UserIndex)controller.GetUserIndex();
         XUsbControllers[slot] = true;
-
-        /*
-        if (controller.IsVirtual())
-            return;
-        */
 
         // controller was unplugged
         Controllers.Remove(details.deviceInstanceId);

--- a/HandheldCompanion/Views/Pages/ControllerPage.xaml.cs
+++ b/HandheldCompanion/Views/Pages/ControllerPage.xaml.cs
@@ -182,8 +182,6 @@ public partial class ControllerPage : Page
 
     private void ControllerPlugged(IController Controller)
     {
-        LogManager.LogDebug("Controller plugged: {0}", Controller.ToString());
-
         // UI thread (async)
         Application.Current.Dispatcher.BeginInvoke(() =>
         {

--- a/HandheldCompanion/Views/Windows/MainWindow.xaml.cs
+++ b/HandheldCompanion/Views/Windows/MainWindow.xaml.cs
@@ -680,9 +680,6 @@ public partial class MainWindow : GamepadWindow
                         case PowerManager.SystemStatus.SystemPending:
                             // resume from sleep
                             Thread.Sleep(2000);
-
-                            // refresh device list
-                            DeviceManager.Refresh();
                             break;
                     }
 

--- a/HandheldCompanion/Views/Windows/MainWindow.xaml.cs
+++ b/HandheldCompanion/Views/Windows/MainWindow.xaml.cs
@@ -683,12 +683,14 @@ public partial class MainWindow : GamepadWindow
                             break;
                     }
 
-                    // open current device (threaded to avoid device to hang)
-                    new Thread(() => { CurrentDevice.Open(); }).Start();
-
-                    // restore device settings
-                    CurrentDevice.SetFanControl(SettingsManager.GetBoolean("QuietModeToggled"));
-                    CurrentDevice.SetFanDuty(SettingsManager.GetDouble("QuietModeDuty"));
+                    new Thread(() => {
+                        // open current device (threaded to avoid device to hang)
+                        CurrentDevice.Open();
+                        
+                        // restore device settings
+                        CurrentDevice.SetFanControl(SettingsManager.GetBoolean("QuietModeToggled"));
+                        CurrentDevice.SetFanDuty(SettingsManager.GetDouble("QuietModeDuty"));
+                    }).Start();
 
                     // restore inputs manager
                     InputsManager.TriggerRaised += InputsManager_TriggerRaised;

--- a/HandheldCompanion/Views/Windows/MainWindow.xaml.cs
+++ b/HandheldCompanion/Views/Windows/MainWindow.xaml.cs
@@ -680,6 +680,9 @@ public partial class MainWindow : GamepadWindow
                         case PowerManager.SystemStatus.SystemPending:
                             // resume from sleep
                             Thread.Sleep(2000);
+
+                            // refresh device list
+                            DeviceManager.Refresh();
                             break;
                     }
 

--- a/HandheldCompanion/Views/Windows/MainWindow.xaml.cs
+++ b/HandheldCompanion/Views/Windows/MainWindow.xaml.cs
@@ -683,8 +683,8 @@ public partial class MainWindow : GamepadWindow
                             break;
                     }
 
-                    // open current device
-                    CurrentDevice.Open();
+                    // open current device (threaded to avoid device to hang)
+                    new Thread(() => { CurrentDevice.Open(); }).Start();
 
                     // restore device settings
                     CurrentDevice.SetFanControl(SettingsManager.GetBoolean("QuietModeToggled"));


### PR DESCRIPTION
- Open and Close device on system suspend, resume.
- Use a separated thread on Device.Open() to avoid UI to hang in case we can't pull data out of HidDevice(s).
- Simplify Controller manager XInput slot check logic.
- Prevent crash when calling Device.Close() and device has not yet been opened.
- Allow Controller manager to automatically connect and disconnect controllers when removed or added (if alone).