### PR TITLE
oem1 and oem2 key not registering when using emulated ds4 controller

### DIFF
--- a/ControllerCommon/Devices/ASUS/ROGAlly.cs
+++ b/ControllerCommon/Devices/ASUS/ROGAlly.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using ControllerCommon.Inputs;
 using ControllerCommon.Managers;
+using ControllerCommon.Utils;
 using HandheldCompanion;
 using HidSharp;
 using HidSharp.Reports.Input;
@@ -160,6 +161,19 @@ public class ROGAlly : IDevice
         return DeviceHelper.IsDeviceAvailable(parent_guid, parent_instanceId);
     }
 
+    public override void SetKeyPressDelay(HIDmode controllerMode)
+    {
+        switch(controllerMode)
+        {
+            case HIDmode.DualShock4Controller:
+                KeyPressDelay = 180; 
+                break;
+            default:
+                KeyPressDelay = 20;
+                break;
+        }
+    }
+
     private void InputReportReceiver_Received(HidDevice hidDevice, DeviceItemInputParser hiddeviceInputParser,
         HidDeviceInputReceiver hidDeviceInputReceiver)
     {
@@ -198,6 +212,19 @@ public class ROGAlly : IDevice
                     previousWasEmpty = true;
                 }
                     return;
+
+                case 56:
+                case 166:
+                {
+                    // OEM1 and OEM2 key needs a key press delay based on emulated controller
+                    Task.Factory.StartNew(async () =>
+                    {
+                        KeyPress(button);
+                        await Task.Delay(KeyPressDelay);
+                        KeyRelease(button);
+                    });
+                }
+                break;
 
                 case 165:
                 case 167:

--- a/ControllerCommon/Devices/IDevice.cs
+++ b/ControllerCommon/Devices/IDevice.cs
@@ -98,6 +98,9 @@ public abstract class IDevice
     // mininum delay before trying to emulate a virtual controller on system resume (milliseconds)
     public short ResumeDelay = 10000;
 
+    // key press delay to use for certain scenarios
+    public short KeyPressDelay = 20;
+
     protected USBDeviceInfo sensor = new();
 
     public IDevice()
@@ -322,6 +325,16 @@ public abstract class IDevice
     public virtual bool IsReady()
     {
         return true;
+    }
+
+    public virtual void SetKeyPressDelay(HIDmode controllerMode)
+    {
+        switch (controllerMode)
+        {
+            default:
+                KeyPressDelay = 20;
+                break;
+        }
     }
 
     public void PullSensors()

--- a/HandheldCompanion/Views/Windows/MainWindow.xaml.cs
+++ b/HandheldCompanion/Views/Windows/MainWindow.xaml.cs
@@ -20,6 +20,7 @@ using ControllerCommon.Devices;
 using ControllerCommon.Inputs;
 using ControllerCommon.Managers;
 using ControllerCommon.Pipes;
+using ControllerCommon.Utils;
 using HandheldCompanion.Managers;
 using HandheldCompanion.Views.Classes;
 using HandheldCompanion.Views.Pages;
@@ -380,6 +381,7 @@ public partial class MainWindow : GamepadWindow
 
         // handle controllerPage events
         controllerPage.HIDchanged += HID => { overlayModel.UpdateHIDMode(HID); };
+        controllerPage.HIDchanged += ControllerPage_HIDchanged;
     }
 
     private void loadWindows()
@@ -523,6 +525,11 @@ public partial class MainWindow : GamepadWindow
         prevWindowState = (WindowState)SettingsManager.GetInt("MainWindowPrevState");
 
         IsReady = true;
+    }
+
+    private void ControllerPage_HIDchanged(HIDmode controllerMode)
+    {
+        CurrentDevice.SetKeyPressDelay(controllerMode);
     }
 
     public void UpdateSettings(Dictionary<string, string> args)


### PR DESCRIPTION
rog ally's oem1 and oem2 key not registering when using emulated ds4 controller in certain apps such as Steam Big Picture.

added a conditional delay based on emulated controller specifically for rog ally's oem1 and oem2 keys. other oem keys don't seem to have the issue.