### PR TITLE
Update workflow to use pwsh instead of action for version replace

### DIFF
--- a/.github/workflows/publish-hc.yml
+++ b/.github/workflows/publish-hc.yml
@@ -53,10 +53,10 @@ jobs:
             Exit 1
           }
 
-          if ('${{ github.ref }}' -ne 'refs/heads/main') {
-            Write-Error "Release may only be created from main"
-            Exit 1
-          }
+          #if ('${{ github.ref }}' -ne 'refs/heads/main') {
+          #  Write-Error "Release may only be created from main"
+          #  Exit 1
+          #}
 
       # This step sets release version in source control. Uses pwsh for lack of an available github action.
       - name: Set Release Version in Repo

--- a/.github/workflows/publish-hc.yml
+++ b/.github/workflows/publish-hc.yml
@@ -58,31 +58,14 @@ jobs:
             Exit 1
           }
 
-      - name: Set HandheldCompanion Release Version
+      # This step sets release version in source control. Uses pwsh for lack of an available github action.
+      - name: Set Release Version in Repo
         if: inputs.releaseVersion != ''
-        uses: mingjun97/file-regex-replace@v1
-        with:
-          regex: "<Version>\\d+(?:\\.\\d+){3}<\\/Version>"
-          replacement: "<Version>${{ inputs.releaseVersion }}</Version>"
-          include: 'HandheldCompanion.csproj'
-          path: ./HandheldCompanion
-
-      - name: Set ControllerService Release Version
-        if: inputs.releaseVersion != ''
-        uses: mingjun97/file-regex-replace@v1
-        with:
-          regex: "\\d+(?:\\.\\d+){3}"
-          replacement: "${{ inputs.releaseVersion }}"
-          include: 'AssemblyInfo1.cs'
-          path: ./ControllerService
-
-      - name: Set Installer Release Version
-        if: inputs.releaseVersion != ''
-        uses: mingjun97/file-regex-replace@v1
-        with:
-          regex: "#define MyAppVersion '\\d+(?:\\.\\d+){3}'"
-          replacement: "#define MyAppVersion '${{ inputs.releaseVersion }}'"
-          include: 'HandheldCompanion-Offline.iss|HandheldCompanion.iss'
+        run: |
+          (Get-Content -Path ./HandheldCompanion.iss) -replace "#define MyAppVersion `'\d+(?:\.\d+){3}`'", "#define MyAppVersion '0.0.0.0'" | Out-File ./HandheldCompanion.iss
+          (Get-Content -Path ./HandheldCompanion-Offline.iss) -replace "#define MyAppVersion `'\d+(?:\.\d+){3}`'", "#define MyAppVersion '0.0.0.0'" | Out-File ./HandheldCompanion-Offline.iss
+          (Get-Content -Path ./ControllerService/AssemblyInfo1.cs) -replace '\d+(?:\.\d+){3}', "0.0.0.0" | Out-File ./ControllerService/AssemblyInfo1.cs
+          (Get-Content -Path ./HandheldCompanion/HandheldCompanion.csproj) -replace "<Version>\d+(?:\.\d+){3}</Version>", "<Version>0.0.0.0</Version>" | Out-File ./HandheldCompanion/HandheldCompanion.csproj
 
       - name: Install Innosetup
         run: |

--- a/.github/workflows/publish-hc.yml
+++ b/.github/workflows/publish-hc.yml
@@ -62,10 +62,10 @@ jobs:
       - name: Set Release Version in Repo
         if: inputs.releaseVersion != ''
         run: |
-          (Get-Content -Path ./HandheldCompanion.iss) -replace "#define MyAppVersion `'\d+(?:\.\d+){3}`'", "#define MyAppVersion '0.0.0.0'" | Out-File ./HandheldCompanion.iss
-          (Get-Content -Path ./HandheldCompanion-Offline.iss) -replace "#define MyAppVersion `'\d+(?:\.\d+){3}`'", "#define MyAppVersion '0.0.0.0'" | Out-File ./HandheldCompanion-Offline.iss
-          (Get-Content -Path ./ControllerService/AssemblyInfo1.cs) -replace '\d+(?:\.\d+){3}', "0.0.0.0" | Out-File ./ControllerService/AssemblyInfo1.cs
-          (Get-Content -Path ./HandheldCompanion/HandheldCompanion.csproj) -replace "<Version>\d+(?:\.\d+){3}</Version>", "<Version>0.0.0.0</Version>" | Out-File ./HandheldCompanion/HandheldCompanion.csproj
+          (Get-Content -Path ./HandheldCompanion.iss) -replace "#define MyAppVersion `'\d+(?:\.\d+){3}`'", "#define MyAppVersion '${{ inputs.releaseVersion }}'" | Out-File ./HandheldCompanion.iss
+          (Get-Content -Path ./HandheldCompanion-Offline.iss) -replace "#define MyAppVersion `'\d+(?:\.\d+){3}`'", "#define MyAppVersion '${{ inputs.releaseVersion }}'" | Out-File ./HandheldCompanion-Offline.iss
+          (Get-Content -Path ./ControllerService/AssemblyInfo1.cs) -replace '\d+(?:\.\d+){3}', '${{ inputs.releaseVersion }}' | Out-File ./ControllerService/AssemblyInfo1.cs
+          (Get-Content -Path ./HandheldCompanion/HandheldCompanion.csproj) -replace "<Version>\d+(?:\.\d+){3}</Version>", "<Version>${{ inputs.releaseVersion }}</Version>" | Out-File ./HandheldCompanion/HandheldCompanion.csproj
 
       - name: Install Innosetup
         run: |

--- a/.github/workflows/publish-hc.yml
+++ b/.github/workflows/publish-hc.yml
@@ -53,10 +53,10 @@ jobs:
             Exit 1
           }
 
-          #if ('${{ github.ref }}' -ne 'refs/heads/main') {
-          #  Write-Error "Release may only be created from main"
-          #  Exit 1
-          #}
+          if ('${{ github.ref }}' -ne 'refs/heads/main') {
+            Write-Error "Release may only be created from main"
+            Exit 1
+          }
 
       # This step sets release version in source control. Uses pwsh for lack of an available github action.
       - name: Set Release Version in Repo


### PR DESCRIPTION
Replaces action `mingjun97/file-regex-replace@v1` with a pwsh step.

Github is deprecating the use of Node12 towards the end of summer which this task uses. See: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

Unfortunately the only other available task that I'm aware of is `jacobtomlinson/gha-find-replace` which only works on linux (we're required to use a windows worker due to iscc)

https://github.com/jacobtomlinson/gha-find-replace/issues/33 

![image](https://github.com/Valkirie/HandheldCompanion/assets/5052021/b4cadb1f-bd30-43b5-8649-33adfe07c7ef)
