### PR TITLE
Add RtkUWP.exe to ignore list

### DIFF
--- a/HandheldCompanion/Managers/ProcessManager.cs
+++ b/HandheldCompanion/Managers/ProcessManager.cs
@@ -321,6 +321,7 @@ public static class ProcessManager
             case "lockapp.exe":
             case "asusosd.exe":
             case "gamepadcustomizeosd":
+            case "rtkuwp.exe":
                 return ProcessFilter.Desktop;
 
             default:


### PR DESCRIPTION
Add RtkUWP.exe to ignore list, pops up when plugging in headphones on ROG Ally