### PR TITLE
fix: quicktools autohide not working

### DIFF
--- a/HandheldCompanion/Views/Windows/OverlayQuickTools.xaml.cs
+++ b/HandheldCompanion/Views/Windows/OverlayQuickTools.xaml.cs
@@ -297,14 +297,6 @@ public partial class OverlayQuickTools : GamepadWindow
                 }
                 break;
 
-            case WM_ACTIVATE:
-                {
-                    // WA_INACTIVE
-                    if (wParam == 0)
-                        handled = true;
-                }
-                break;
-
             case WM_MOUSEACTIVATE:
                 {
                     handled = true;


### PR DESCRIPTION
Handling this caused the Deactivated_Event to never be called

fix #759 