### PR TITLE
feat(quicktools): show time

### DIFF
--- a/HandheldCompanion/Views/Windows/OverlayQuickTools.xaml
+++ b/HandheldCompanion/Views/Windows/OverlayQuickTools.xaml
@@ -26,6 +26,7 @@
     ShowInTaskbar="False"
     Topmost="False"
     WindowStyle="ToolWindow"
+    IsVisibleChanged="Window_IsVisibleChanged"
     mc:Ignorable="d">
 
     <Grid>
@@ -85,6 +86,17 @@
                             Margin="4,0,0,0"
                             VerticalAlignment="Center"
                             Style="{StaticResource CaptionTextBlockStyle}" />
+                    </DockPanel>
+                </ui:NavigationViewItem>
+                <ui:NavigationViewItem IsEnabled="False">
+                    <DockPanel VerticalAlignment="Center">
+                        <ui:FontIcon 
+                        Glyph="{x:Static ui:SegoeIcons.Recent}" />
+                        <TextBlock
+                        Name="Time"
+                        Margin="2,0,0,0"
+                        VerticalAlignment="Center"
+                        Style="{StaticResource CaptionTextBlockStyle}" />
                     </DockPanel>
                 </ui:NavigationViewItem>
             </ui:NavigationView.FooterMenuItems>

--- a/HandheldCompanion/Views/Windows/OverlayQuickTools.xaml.cs
+++ b/HandheldCompanion/Views/Windows/OverlayQuickTools.xaml.cs
@@ -29,6 +29,10 @@ using Control = System.Windows.Controls.Control;
 using HandheldCompanion.Views.Classes;
 using ControllerCommon;
 using System.Diagnostics;
+using System.Windows.Threading;
+using ControllerCommon.Managers;
+using System.Globalization;
+using System.Threading;
 
 namespace HandheldCompanion.Views.Windows;
 
@@ -61,6 +65,7 @@ public partial class OverlayQuickTools : GamepadWindow
 
     // page vars
     private readonly Dictionary<string, Page> _pages = new();
+    private readonly DispatcherTimer clockUpdateTimer;
 
     private bool AutoHide;
     private bool isClosing;
@@ -80,6 +85,9 @@ public partial class OverlayQuickTools : GamepadWindow
 
         PreviewKeyDown += HandleEsc;
         Deactivated += OverlayQuickTools_Deactivated;
+
+        clockUpdateTimer = new DispatcherTimer();
+        clockUpdateTimer.Interval = TimeSpan.FromMilliseconds(500);
 
         // create manager(s)
         PowerManager.PowerStatusChanged += PowerManager_PowerStatusChanged;
@@ -486,5 +494,31 @@ public partial class OverlayQuickTools : GamepadWindow
         }
     }
 
+    private void Window_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
+    {
+        if (sender is not GamepadWindow window)
+        {
+            return;
+        }
+
+        if (window.Visibility == Visibility.Visible)
+        {
+            clockUpdateTimer.Start();
+            clockUpdateTimer.Tick += UpdateTime;
+        }
+        else
+        {
+            clockUpdateTimer.Stop();
+            clockUpdateTimer.Tick -= UpdateTime;
+        }
+    }
+
+    private void UpdateTime(object? sender, EventArgs e)
+    {
+        var timeFormat = CultureInfo.InstalledUICulture.DateTimeFormat.ShortTimePattern;
+        Time.Text = DateTime.Now.ToString(timeFormat);
+    }
+
     #endregion
+
 }


### PR DESCRIPTION
resolves #380 

Shows the current time in the QuickTools window while respecting the current culture (requires restart of HC when changing culture)

![image](https://github.com/Valkirie/HandheldCompanion/assets/136121048/1e841ac7-7666-4d0e-8538-28447748ac5c)


