### PR TITLE
Add support for OneXPlayer 2 Pro 7840U (non-EVA version).

### DIFF
--- a/HandheldCompanion/Devices/IDevice.cs
+++ b/HandheldCompanion/Devices/IDevice.cs
@@ -273,6 +273,7 @@ public abstract class IDevice
                                 }
                                 break;
                             }
+                        case "ONEXPLAYER 2 PRO ARP23P":
                         case "ONEXPLAYER 2 PRO ARP23P EVA-01":
                             switch (Version)
                             {


### PR DESCRIPTION
ONE-NETBOOK have released a non-EVA variant of the OneXPlayer 2 Pro. The hardware is identical to the EVA version.