### PR TITLE
Add an option to use seperated TDP when device power on Battery Mode

### DIFF
--- a/HandheldCompanion/Managers/PerformanceManager.cs
+++ b/HandheldCompanion/Managers/PerformanceManager.cs
@@ -2,12 +2,15 @@ using HandheldCompanion.Misc;
 using HandheldCompanion.Processors;
 using HandheldCompanion.Utils;
 using HandheldCompanion.Views;
+using HandheldCompanion.Views.Pages;
+using Microsoft.Win32;
 using RTSSSharedMemoryNET;
 using System;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using System.Timers;
+using System.Windows.Forms;
 using Timer = System.Timers.Timer;
 
 namespace HandheldCompanion.Managers;
@@ -99,6 +102,9 @@ public class PerformanceManager : Manager
         autoWatchdog = new Timer { Interval = INTERVAL_AUTO, AutoReset = true, Enabled = false };
         autoWatchdog.Elapsed += AutoTDPWatchdog_Elapsed;
 
+        // Monitor Power Status
+        SystemEvents.PowerModeChanged += SystemEvents_PowerModeChanged;
+
         ProfileManager.Applied += ProfileManager_Applied;
         ProfileManager.Discarded += ProfileManager_Discarded;
 
@@ -113,6 +119,11 @@ public class PerformanceManager : Manager
 
         currentCoreCount = Environment.ProcessorCount;
         MaxDegreeOfParallelism = Convert.ToInt32(Environment.ProcessorCount / 2);
+    }
+
+    private void SystemEvents_PowerModeChanged(object sender, PowerModeChangedEventArgs e)
+    {
+        ProfilesPage.RequestUpdate();
     }
 
     private void SettingsManagerOnSettingValueChanged(string name, object value)
@@ -140,10 +151,16 @@ public class PerformanceManager : Manager
         // apply profile defined TDP
         if (profile.TDPOverrideEnabled && profile.TDPOverrideValues is not null)
         {
+            double[] TDPOverrideValues;
+            // Check if using TDP on Battery & is not Plugged in
+            bool PluggedInStatus = SystemInformation.PowerStatus.PowerLineStatus == PowerLineStatus.Online;
+            if (profile.TDPOnBatteryEnabled && profile.TDPOnBatteryValues is not null && !PluggedInStatus) TDPOverrideValues = profile.TDPOnBatteryValues;
+            else TDPOverrideValues = profile.TDPOverrideValues;
+
             if (!profile.AutoTDPEnabled)
             {
                 // Manual TDP is set, use it and set max limit
-                RequestTDP(profile.TDPOverrideValues);
+                RequestTDP(TDPOverrideValues);
                 StartTDPWatchdog();
                 AutoTDPMax = SettingsManager.GetInt("ConfigurableTDPOverrideUp");
             }
@@ -151,7 +168,7 @@ public class PerformanceManager : Manager
             {
                 // Both manual TDP and AutoTDP are on,
                 // use manual slider as the max limit for AutoTDP
-                AutoTDPMax = profile.TDPOverrideValues[0];
+                AutoTDPMax = TDPOverrideValues[0];
                 StopTDPWatchdog(true);
             }
         }

--- a/HandheldCompanion/Misc/Profile.cs
+++ b/HandheldCompanion/Misc/Profile.cs
@@ -123,6 +123,8 @@ public partial class Profile : ICloneable, IComparable
     // power
     public bool TDPOverrideEnabled { get; set; }
     public double[] TDPOverrideValues { get; set; }
+    public bool TDPOnBatteryEnabled { get; set; }
+    public double[] TDPOnBatteryValues { get; set; }
 
     public bool GPUOverrideEnabled { get; set; }
     public double GPUOverrideValue { get; set; }

--- a/HandheldCompanion/Properties/Resources.Designer.cs
+++ b/HandheldCompanion/Properties/Resources.Designer.cs
@@ -4987,6 +4987,24 @@ namespace HandheldCompanion.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to TDP settings On Battery.
+        /// </summary>
+        public static string ProfilesPage_TDPOnBattery {
+            get {
+                return ResourceManager.GetString("ProfilesPage_TDPOnBattery", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Using seperated TDP settings when On Battery.
+        /// </summary>
+        public static string ProfilesPage_TDPOnBatteryDesc {
+            get {
+                return ResourceManager.GetString("ProfilesPage_TDPOnBatteryDesc", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Thermal Power (TDP) limit.
         /// </summary>
         public static string ProfilesPage_TDPOverride {

--- a/HandheldCompanion/Properties/Resources.resx
+++ b/HandheldCompanion/Properties/Resources.resx
@@ -2357,4 +2357,10 @@ with motion input enabled, use selected button(s) to disable motion.</value>
   <data name="LayoutPage_SetAsDefault" xml:space="preserve">
     <value>Make this the default layout</value>
   </data>
+  <data name="ProfilesPage_TDPOnBattery" xml:space="preserve">
+    <value>TDP settings On Battery</value>
+  </data>
+  <data name="ProfilesPage_TDPOnBatteryDesc" xml:space="preserve">
+    <value>Using seperated TDP settings when On Battery</value>
+  </data>
 </root>

--- a/HandheldCompanion/Views/Pages/ProfilesPage.xaml
+++ b/HandheldCompanion/Views/Pages/ProfilesPage.xaml
@@ -657,7 +657,68 @@
                                         </DockPanel>
                                     </StackPanel>
                                 </Grid>
+                                <!--  TDP On Battery limit  -->
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="9*" MinWidth="200" />
+                                        <ColumnDefinition MinWidth="200" />
+                                    </Grid.ColumnDefinitions>
 
+                                    <StackPanel Orientation="Vertical">
+                                        <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{x:Static resx:Resources.ProfilesPage_TDPOnBattery}" />
+                                        <TextBlock
+                                            Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                                            Style="{StaticResource CaptionTextBlockStyle}"
+                                            Text="{x:Static resx:Resources.ProfilesPage_TDPOnBatteryDesc}"
+                                            TextWrapping="Wrap" />
+                                    </StackPanel>
+
+                                    <ui:ToggleSwitch
+                                        Name="TDPOnBatteryToggle"
+                                        IsEnabled="{Binding ElementName=TDPToggle, Path=IsOn}"
+                                        Grid.Column="1"
+                                        HorizontalAlignment="Right"
+                                        Style="{DynamicResource InvertedToggleSwitchStyle}"
+                                        Toggled="TDPOnBatteryToggle_Toggled" />
+                                </Grid>
+                                <!--  Content  -->
+                                <Grid IsEnabled="{Binding ElementName=TDPToggle, Path=IsOn}">
+
+                                    <StackPanel>
+                                        <TextBlock
+                                            HorizontalAlignment="Left"
+                                            VerticalAlignment="Center"
+                                            Text="{x:Static resx:Resources.ProfilesPage_PowerLimitTarget}" />
+
+                                        <DockPanel ScrollViewer.PanningMode="HorizontalOnly">
+                                            <TextBlock
+                                                Width="35"
+                                                VerticalAlignment="Center"
+                                                Text="{Binding Value, StringFormat=N0, ElementName=TDPOnBatterySlider, Mode=OneWay}"
+                                                TextAlignment="Center" />
+                                            <TextBlock
+                                                Width="30"
+                                                HorizontalAlignment="Left"
+                                                VerticalAlignment="Center"
+                                                Text="{x:Static resx:Resources.QuickPerformancePage_TDPUnitWatt}" />
+                                            <Slider IsEnabled="{Binding ElementName=TDPOnBatteryToggle, Path=IsOn}"
+                                                x:Name="TDPOnBatterySlider"
+                                                Margin="6,0,0,0"
+                                                VerticalAlignment="Center"
+                                                AutoToolTipPrecision="0"
+                                                IsMoveToPointEnabled="True"
+                                                IsSnapToTickEnabled="True"
+                                                LargeChange="5"
+                                                Maximum="30"
+                                                Minimum="5"
+                                                SmallChange="1"
+                                                Style="{DynamicResource SliderStyle1}"
+                                                TickFrequency="1"
+                                                TickPlacement="BottomRight"
+                                                ValueChanged="TDPOnBatterySlider_ValueChanged" />
+                                        </DockPanel>
+                                    </StackPanel>
+                                </Grid>
                                 <!--  Separator  -->
                                 <Separator
                                     Margin="-46,0,-16,0"

--- a/HandheldCompanion/Views/Pages/ProfilesPage.xaml.cs
+++ b/HandheldCompanion/Views/Pages/ProfilesPage.xaml.cs
@@ -130,6 +130,7 @@ public partial class ProfilesPage : Page
                         using (new ScopedLock(updateLock))
                         {
                             TDPSlider.Minimum = (double)value;
+                            TDPOnBatterySlider.Minimum = (double)value;
                         }
                     }
                     break;
@@ -138,6 +139,7 @@ public partial class ProfilesPage : Page
                         using (new ScopedLock(updateLock))
                         {
                             TDPSlider.Maximum = (double)value;
+                            TDPOnBatterySlider.Maximum = (double)value;
                         }
                     }
                     break;
@@ -401,6 +403,17 @@ public partial class ProfilesPage : Page
                 TDPSlider.Minimum = SettingsManager.GetInt("ConfigurableTDPOverrideDown");
                 TDPSlider.Maximum = SettingsManager.GetInt("ConfigurableTDPOverrideUp");
 
+                // Sustained TDP On Battery settings (slow, stapm, long)
+                TDPOnBatteryToggle.IsOn = selectedProfile.TDPOnBatteryEnabled;
+                var TDPOnBattery = selectedProfile.TDPOnBatteryValues is not null
+                    ? selectedProfile.TDPOnBatteryValues
+                    : MainWindow.CurrentDevice.nTDP;
+                TDPOnBatterySlider.Value = TDPOnBattery[(int)PowerType.Slow];
+
+                // define slider(s) min and max values based on device specifications
+                TDPOnBatterySlider.Minimum = SettingsManager.GetInt("ConfigurableTDPOverrideDown");
+                TDPOnBatterySlider.Maximum = SettingsManager.GetInt("ConfigurableTDPOverrideUp");
+
                 // Automatic TDP
                 AutoTDPToggle.IsOn = selectedProfile.AutoTDPEnabled;
                 AutoTDPSlider.Value = (int)selectedProfile.AutoTDPRequestedFPS;
@@ -568,6 +581,34 @@ public partial class ProfilesPage : Page
             (int)TDPSlider.Value,
             (int)TDPSlider.Value,
             (int)TDPSlider.Value
+        };
+        RequestUpdate();
+    }
+
+    private void TDPOnBatteryToggle_Toggled(object sender, RoutedEventArgs e)
+    {
+        // wait until lock is released
+        if (updateLock)
+            return;
+
+        selectedProfile.TDPOnBatteryEnabled = TDPOnBatteryToggle.IsOn;
+        RequestUpdate();
+    }
+
+    private void TDPOnBatterySlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+    {
+        if (!TDPOnBatterySlider.IsInitialized)
+            return;
+
+        // wait until lock is released
+        if (updateLock)
+            return;
+
+        selectedProfile.TDPOnBatteryValues = new double[3]
+        {
+            (int)TDPOnBatterySlider.Value,
+            (int)TDPOnBatterySlider.Value,
+            (int)TDPOnBatterySlider.Value
         };
         RequestUpdate();
     }

--- a/HandheldCompanion/Views/QuickPages/QuickProfilesPage.xaml
+++ b/HandheldCompanion/Views/QuickPages/QuickProfilesPage.xaml
@@ -231,9 +231,68 @@
                                     TickPlacement="BottomRight"
                                     ValueChanged="TDPSlider_ValueChanged" />
                             </DockPanel>
+
+                        <!--  TDP On Battery Limit  -->
+                            <Grid Margin="0,8,0,0" d:Visibility="Visible" Visibility="{Binding ElementName=TDPToggle, Path=IsOn, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                <DockPanel>
+                                    <ui:FontIcon
+                                        Height="40"
+                                        HorizontalAlignment="Center"
+                                        FontFamily="{DynamicResource SymbolThemeFontFamily}"
+                                        Glyph="&#xEBA9;" />
+
+                                    <ui:SimpleStackPanel Margin="12,0,0,0" VerticalAlignment="Center">
+                                        <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{x:Static resx:Resources.ProfilesPage_TDPOnBattery}" />
+                                        <TextBlock
+                                            Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                                            Style="{StaticResource CaptionTextBlockStyle}"
+                                            Text="{x:Static resx:Resources.ProfilesPage_TDPOnBatteryDesc}"
+                                            TextWrapping="Wrap" />
+                                    </ui:SimpleStackPanel>
+                                </DockPanel>
+
+                                <ui:ToggleSwitch
+                                    Name="TDPOnBatteryToggle"
+                                    Grid.Column="1"
+                                    HorizontalAlignment="Right"
+                                    Style="{DynamicResource InvertedToggleSwitchStyle}" 
+                                    Toggled="TDPOnBatteryToggle_Toggled"/>
+                            </Grid>
+
+                            <StackPanel d:Visibility="Visible" Visibility="{Binding ElementName=TDPOnBatteryToggle, Path=IsOn, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                <TextBlock
+                                    HorizontalAlignment="Left"
+                                    VerticalAlignment="Center"
+                                    Text="{x:Static resx:Resources.QuickProfilesPage_PowerLimitTarget}" />
+                                <DockPanel Margin="8,0,0,0" ScrollViewer.PanningMode="HorizontalOnly">
+                                    <TextBlock
+                                        Width="35"
+                                        VerticalAlignment="Center"
+                                        Text="{Binding Value, StringFormat=N0, ElementName=TDPOnBatterySlider, Mode=OneWay}"
+                                        TextAlignment="Center" />
+                                    <TextBlock
+                                        Width="30"
+                                        HorizontalAlignment="Left"
+                                        VerticalAlignment="Center"
+                                        Text="{x:Static resx:Resources.QuickPerformancePage_TDPUnitWatt}" />
+                                    <Slider
+                                        x:Name="TDPOnBatterySlider"
+                                        Margin="8,0,0,0"
+                                        HorizontalAlignment="Stretch"
+                                        VerticalAlignment="Center"
+                                        AutoToolTipPrecision="0"
+                                        IsMoveToPointEnabled="True"
+                                        IsSnapToTickEnabled="True"
+                                        LargeChange="5"
+                                        SmallChange="1"
+                                        Style="{DynamicResource SliderStyle1}"
+                                        TickFrequency="1"
+                                        TickPlacement="BottomRight"
+                                        ValueChanged="TDPOnBatterySlider_ValueChanged" />
+                                </DockPanel>
+                            </StackPanel>
                         </StackPanel>
                     </ui:SimpleStackPanel>
-
                     <Separator Background="{DynamicResource ExpanderHeaderBackground}" />
 
                     <!--  Auto TDP  -->

--- a/HandheldCompanion/Views/QuickPages/QuickProfilesPage.xaml.cs
+++ b/HandheldCompanion/Views/QuickPages/QuickProfilesPage.xaml.cs
@@ -11,6 +11,8 @@ using System;
 using System.Timers;
 using System.Windows;
 using System.Windows.Controls;
+using Microsoft.Win32;
+
 using Page = System.Windows.Controls.Page;
 
 namespace HandheldCompanion.Views.QuickPages;
@@ -260,6 +262,7 @@ public partial class QuickProfilesPage : Page
     private void HotkeysManager_CommandExecuted(string listener)
     {
         // UI thread (async)
+        bool PluggedInStatus = System.Windows.Forms.SystemInformation.PowerStatus.PowerLineStatus == System.Windows.Forms.PowerLineStatus.Online;
         Application.Current.Dispatcher.BeginInvoke(() =>
         {
             switch (listener)
@@ -268,16 +271,16 @@ public partial class QuickProfilesPage : Page
                     {
                         if (currentProfile is null || !currentProfile.TDPOverrideEnabled)
                             return;
-
-                        TDPSlider.Value++;
+                        if(!PluggedInStatus && currentProfile.TDPOnBatteryEnabled) TDPOnBatterySlider.Value++;
+                        else TDPSlider.Value++;
                     }
                     break;
                 case "decreaseTDP":
                     {
                         if (currentProfile is null || !currentProfile.TDPOverrideEnabled)
                             return;
-
-                        TDPSlider.Value--;
+                        if (!PluggedInStatus && currentProfile.TDPOnBatteryEnabled) TDPOnBatterySlider.Value--;
+                        else TDPSlider.Value--;
                     }
                     break;
             }
@@ -296,6 +299,7 @@ public partial class QuickProfilesPage : Page
                         using (new ScopedLock(updateLock))
                         {
                             TDPSlider.Minimum = (double)value;
+                            TDPOnBatterySlider.Minimum = (double)value;
                         }
                     }
                     break;
@@ -304,6 +308,7 @@ public partial class QuickProfilesPage : Page
                         using (new ScopedLock(updateLock))
                         {
                             TDPSlider.Maximum = (double)value;
+                            TDPOnBatterySlider.Maximum = (double)value;
                         }
                     }
                     break;
@@ -385,6 +390,13 @@ public partial class QuickProfilesPage : Page
                         ? currentProfile.TDPOverrideValues
                         : MainWindow.CurrentDevice.nTDP;
                     TDPSlider.Value = TDP[(int)PowerType.Slow];
+
+                    // TDP On Battery
+                    TDPOnBatteryToggle.IsOn = currentProfile.TDPOnBatteryEnabled;
+                    var TDPOnBattery = currentProfile.TDPOnBatteryValues is not null
+                        ? currentProfile.TDPOnBatteryValues
+                        : MainWindow.CurrentDevice.nTDP;
+                    TDPOnBatterySlider.Value = TDPOnBattery[(int)PowerType.Slow];
 
                     // GPU
                     GPUToggle.IsOn = currentProfile.GPUOverrideEnabled;
@@ -487,6 +499,7 @@ public partial class QuickProfilesPage : Page
         currentProfile.Layout = (ProfileManager.GetProfileWithDefaultLayout()?.Layout ?? LayoutTemplate.DefaultLayout.Layout).Clone() as Layout;
         currentProfile.LayoutTitle = LayoutTemplate.DesktopLayout.Name;
         currentProfile.TDPOverrideValues = MainWindow.CurrentDevice.nTDP;
+        currentProfile.TDPOnBatteryValues = MainWindow.CurrentDevice.nTDP;
 
         // if an update is pending, execute it and stop timer
         if (UpdateTimer.Enabled)
@@ -585,6 +598,34 @@ public partial class QuickProfilesPage : Page
                 (int)TDPSlider.Value,
                 (int)TDPSlider.Value,
                 (int)TDPSlider.Value
+        };
+        RequestUpdate();
+    }
+    private void TDPOnBatteryToggle_Toggled(object sender, RoutedEventArgs e)
+    {
+        if (currentProfile is null)
+            return;
+
+        if (updateLock)
+            return;
+
+        currentProfile.TDPOnBatteryEnabled = TDPOnBatteryToggle.IsOn;
+        RequestUpdate();
+    }
+
+    private void TDPOnBatterySlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+    {
+        if (currentProfile is null)
+            return;
+
+        if (updateLock)
+            return;
+
+        currentProfile.TDPOnBatteryValues = new double[3]
+        {
+                (int)TDPOnBatterySlider.Value,
+                (int)TDPOnBatterySlider.Value,
+                (int)TDPOnBatterySlider.Value
         };
         RequestUpdate();
     }


### PR DESCRIPTION
I add an option to use seperated TDP when device power on Battery Mode. I tested and it works nicely on my device, reusing all current UI component, UI still clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced power management settings for adjusting Thermal Design Power (TDP) when the device is on battery.
  - Added UI components for TDP settings, including a toggle switch and a slider for on-battery configuration.
  - Implemented event handlers to manage power mode changes and update TDP settings accordingly.

- **Enhancements**
  - Improved power management logic to dynamically adjust TDP based on power status.

- **Documentation**
  - Added new localized strings for TDP on battery settings descriptions.

- **Bug Fixes**
  - Ensured TDP settings are correctly applied when switching between power states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->