### PR TITLE
Feature: Motion Toggle

### DIFF
--- a/HandheldCompanion/Actions/GyroActions.cs
+++ b/HandheldCompanion/Actions/GyroActions.cs
@@ -9,6 +9,8 @@ namespace HandheldCompanion.Actions
     {
         public MotionInput MotionInput = MotionInput.JoystickCamera;
         public MotionMode MotionMode = MotionMode.Off;
+        public bool MotionToggleStatus = false;
+        public bool MotionTogglePressed = false; // for debouncing
 
         public ButtonState MotionTrigger = new();
 

--- a/HandheldCompanion/Controls/Mapping/GyroMapping.xaml
+++ b/HandheldCompanion/Controls/Mapping/GyroMapping.xaml
@@ -91,10 +91,9 @@
                                     Name="cB_Input"
                                     Grid.Column="1"
                                     Margin="12,0,0,0"
-                                    HorizontalAlignment="Stretch"
                                     VerticalAlignment="Center"
                                     HorizontalContentAlignment="Left"
-                                    SelectionChanged="cB_Input_SelectionChanged" />
+                                    SelectionChanged="cB_Input_SelectionChanged" Width="371" />
                             </Grid>
 
                             <!--  Separator  -->
@@ -136,6 +135,7 @@
                                         SelectionChanged="cB_UMC_MotionDefaultOffOn_SelectionChanged">
                                         <ComboBoxItem Content="{x:Static resx:Resources.ProfilesPage_UMCMotionOff}" />
                                         <ComboBoxItem Content="{x:Static resx:Resources.ProfilesPage_UMCMotionOn}" />
+                                        <ComboBoxItem Content="{x:Static resx:Resources.ProfilesPage_UMCMotionToggle}" />
                                     </ComboBox>
                                 </ui:SimpleStackPanel>
                             </Grid>

--- a/HandheldCompanion/Controls/Mapping/GyroMapping.xaml
+++ b/HandheldCompanion/Controls/Mapping/GyroMapping.xaml
@@ -91,9 +91,10 @@
                                     Name="cB_Input"
                                     Grid.Column="1"
                                     Margin="12,0,0,0"
+                                    HorizontalAlignment="Stretch"
                                     VerticalAlignment="Center"
                                     HorizontalContentAlignment="Left"
-                                    SelectionChanged="cB_Input_SelectionChanged" Width="371" />
+                                    SelectionChanged="cB_Input_SelectionChanged" />
                             </Grid>
 
                             <!--  Separator  -->

--- a/HandheldCompanion/Managers/MotionManager.cs
+++ b/HandheldCompanion/Managers/MotionManager.cs
@@ -146,7 +146,7 @@ namespace HandheldCompanion.Managers
 
             // update timestamp
             double TotalMilliseconds = TimerManager.Stopwatch.Elapsed.TotalMilliseconds;
-            DeltaSeconds = (TotalMilliseconds - PreviousTotalMilliseconds) / 1000L;
+            DeltaSeconds = (TotalMilliseconds - PreviousTotalMilliseconds) / 1000;
             PreviousTotalMilliseconds = TotalMilliseconds;
 
             //toggle motion when trigger is pressed

--- a/HandheldCompanion/Managers/MotionManager.cs
+++ b/HandheldCompanion/Managers/MotionManager.cs
@@ -149,10 +149,31 @@ namespace HandheldCompanion.Managers
             DeltaSeconds = (TotalMilliseconds - PreviousTotalMilliseconds) / 1000L;
             PreviousTotalMilliseconds = TotalMilliseconds;
 
-            // check if motion trigger is pressed
+            //toggle motion when trigger is pressed
+            if (gyroAction.MotionMode == MotionMode.Toggle)
+            {
+                if (gyroAction.MotionTogglePressed)
+                {
+                    if (!controllerState.ButtonState.ContainsTrue(gyroAction.MotionTrigger))
+                    {
+                        gyroAction.MotionTogglePressed = false; // disable debounce flag
+                    }
+                }
+                else
+                {
+                    if (controllerState.ButtonState.ContainsTrue(gyroAction.MotionTrigger))
+                    {
+                        gyroAction.MotionToggleStatus = !gyroAction.MotionToggleStatus;
+                        gyroAction.MotionTogglePressed = true; // enable debounce flag
+                    }
+                }
+            }
+
+            // check if motion input is active
             bool MotionTriggered =
                 (gyroAction.MotionMode == MotionMode.Off && controllerState.ButtonState.ContainsTrue(gyroAction.MotionTrigger)) ||
-                (gyroAction.MotionMode == MotionMode.On && !controllerState.ButtonState.ContainsTrue(gyroAction.MotionTrigger));
+                (gyroAction.MotionMode == MotionMode.On && !controllerState.ButtonState.ContainsTrue(gyroAction.MotionTrigger)) ||
+                (gyroAction.MotionMode == MotionMode.Toggle && gyroAction.MotionToggleStatus);
 
             bool MotionMapped = action?.ActionType != ActionType.Disabled;
 

--- a/HandheldCompanion/Properties/Resources.Designer.cs
+++ b/HandheldCompanion/Properties/Resources.Designer.cs
@@ -5122,12 +5122,22 @@ namespace HandheldCompanion.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to With motion input disabled, use selected button(s) to enable motion,
-        ///with motion input enabled, use selected button(s) to disable motion..
+        ///   Looks up a localized string similar to With motion input disabled, hold selected button(s) to enable motion,
+        ///with motion input enabled, hold selected button(s) to disable motion,
+        ///with motion input toggle, press selected button(s) to switch from enabled to disabled and viceversa..
         /// </summary>
         public static string ProfilesPage_UMCMotionOnOffDesc {
             get {
                 return ResourceManager.GetString("ProfilesPage_UMCMotionOnOffDesc", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Toggle between enabled or disabled with button(s).
+        /// </summary>
+        public static string ProfilesPage_UMCMotionToggle {
+            get {
+                return ResourceManager.GetString("ProfilesPage_UMCMotionToggle", resourceCulture);
             }
         }
         

--- a/HandheldCompanion/Properties/Resources.resx
+++ b/HandheldCompanion/Properties/Resources.resx
@@ -763,12 +763,16 @@
   <data name="ProfilesPage_UMCMotionOn" xml:space="preserve">
     <value>Enabled, turn off with button(s)</value>
   </data>
+	<data name="ProfilesPage_UMCMotionToggle" xml:space="preserve">
+    <value>Toggle between enabled or disabled with button(s)</value>
+  </data>
   <data name="ProfilesPage_UMCMotionOnOff" xml:space="preserve">
     <value>Motion activation</value>
   </data>
   <data name="ProfilesPage_UMCMotionOnOffDesc" xml:space="preserve">
-    <value>With motion input disabled, use selected button(s) to enable motion,
-with motion input enabled, use selected button(s) to disable motion.</value>
+    <value>With motion input disabled, hold selected button(s) to enable motion,
+with motion input enabled, hold selected button(s) to disable motion,
+with motion input toggle, press selected button(s) to switch from enabled to disabled and viceversa.</value>
   </data>
   <data name="ProfilesPage_UMCSelectionRightLeftDesc" xml:space="preserve">
     <value>Select the device that will receive the motion commands</value>

--- a/HandheldCompanion/Utils/InputUtils.cs
+++ b/HandheldCompanion/Utils/InputUtils.cs
@@ -33,7 +33,8 @@ public enum MotionOuput
 public enum MotionMode
 {
     Off = 0,
-    On = 1
+    On = 1,
+    Toggle = 2
 }
 
 public enum OverlayModelMode

--- a/HandheldCompanion/Views/QuickPages/QuickProfilesPage.xaml
+++ b/HandheldCompanion/Views/QuickPages/QuickProfilesPage.xaml
@@ -581,6 +581,7 @@
                                 SelectionChanged="cB_UMC_MotionDefaultOffOn_SelectionChanged">
                                 <ComboBoxItem Content="{x:Static resx:Resources.ProfilesPage_UMCMotionOff}" />
                                 <ComboBoxItem Content="{x:Static resx:Resources.ProfilesPage_UMCMotionOn}" />
+                                <ComboBoxItem Content="{x:Static resx:Resources.ProfilesPage_UMCMotionToggle}" />
                             </ComboBox>
                         </Grid>
 


### PR DESCRIPTION
This Pull Request adds a feature to allow switching motion action on or off by pressing the trigger once instead of having to hold it to enable/disable

![Screenshot 2023-11-22 193307](https://github.com/Valkirie/HandheldCompanion/assets/5727579/d709d5d8-f421-4b05-88ca-468b9521046f)
![Screenshot 2023-11-22 193335](https://github.com/Valkirie/HandheldCompanion/assets/5727579/a270bfa0-95d1-4883-9b48-79f3fa2b50d0)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new motion toggle feature for the gyroscopic controls, allowing users to switch motion on or off with button presses.
  - Added a "Toggle" option to the motion settings, providing users with an alternative way to control motion input.

- **Enhancements**
  - Updated the user interface to include a new option for motion toggling in the settings menu.
  - Improved motion input handling with debouncing support for more accurate toggle actions.

- **Localization**
  - Modified and added localized strings to better describe the new motion input behaviors and instructions for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->