### PR TITLE
Feature: Added a special hotkey to change emulated controller type

### DIFF
--- a/HandheldCompanion/Managers/Hotkeys/Hotkey.cs
+++ b/HandheldCompanion/Managers/Hotkeys/Hotkey.cs
@@ -48,6 +48,13 @@ public class Hotkey
 
         quickControl.QuickButton.Click += async (e, sender) =>
         {
+            // special case HIDmode switch hotkey
+            // required here in order to (immediatly) disable hotkey while HIDmode is being changed to avoid duplicates
+            // this takes care of repeated button clicks
+            if (this.inputsHotkey.Listener == "shortcutChangeHIDMode")
+            {
+                this.IsEnabled = false;
+            }
             // workaround for gamepad navigation
             await Task.Delay(100);
             Summoned?.Invoke(this);

--- a/HandheldCompanion/Managers/Hotkeys/InputsHotkey.cs
+++ b/HandheldCompanion/Managers/Hotkeys/InputsHotkey.cs
@@ -113,6 +113,11 @@ public class InputsHotkey
             new InputsHotkey(InputsHotkeyType.HC, "\uE961", "DesktopLayoutEnabled", "Segoe Fluent Icons", 20, false,
                 true, null, string.Empty, true, true)
         },
+        {
+            32,
+            new InputsHotkey(InputsHotkeyType.HC, "\u243C", "shortcutChangeHIDMode", "PromptFont", 20, false,
+                true, null, string.Empty, true, false)
+        },
 
         // Device specific hotkeys
         {

--- a/HandheldCompanion/Managers/HotkeysManager.cs
+++ b/HandheldCompanion/Managers/HotkeysManager.cs
@@ -50,8 +50,6 @@ public static class HotkeysManager
         InputsManager.TriggerRaised += TriggerRaised;
         SettingsManager.SettingValueChanged += SettingsManager_SettingValueChanged;
         ControllerManager.ControllerSelected += ControllerManager_ControllerSelected;
-        ControllerManager.ControllerPlugged += ControllerManager_ControllerPlugged;
-        ControllerManager.ControllerUnplugged += ControllerManager_ControllerUnplugged;
     }
 
     public static event HotkeyTypeCreatedEventHandler HotkeyTypeCreated;
@@ -153,6 +151,9 @@ public static class HotkeysManager
         IsInitialized = true;
         Initialized?.Invoke();
 
+        ControllerManager.ControllerPlugged += ControllerManager_ControllerPlugged;
+        ControllerManager.ControllerUnplugged += ControllerManager_ControllerUnplugged;
+
         LogManager.LogInformation("{0} has started", "HotkeysManager");
     }
 
@@ -162,6 +163,8 @@ public static class HotkeysManager
             return;
 
         IsInitialized = false;
+        ControllerManager.ControllerPlugged -= ControllerManager_ControllerPlugged;
+        ControllerManager.ControllerUnplugged -= ControllerManager_ControllerUnplugged;
 
         LogManager.LogInformation("{0} has stopped", "HotkeysManager");
     }

--- a/HandheldCompanion/Managers/InputsManager.cs
+++ b/HandheldCompanion/Managers/InputsManager.cs
@@ -158,6 +158,24 @@ public static class InputsManager
                     if (hotkey is null)
                         continue;
 
+                    // special case HIDmode switch hotkey
+                    // required here in order to (immediatly) disable hotkey while HIDmode is being changed to avoid duplicates
+                    // this takes care of repeated keybinds actions
+                    if (hotkey.Listener == "shortcutChangeHIDMode")
+                    {
+                        var inputType = currentChord.InputsType;
+                        if ((inputType == InputsChordType.Click && IsKeyUp) || (inputType == InputsChordType.Long && IsKeyDown))
+                        {
+                            var hidHotkeys = HotkeysManager.Hotkeys.Values.Where(item => item.inputsHotkey.Listener.Equals("shortcutChangeHIDMode"));
+                            foreach (var hidHotkey in hidHotkeys)
+                            {
+                                if (!hidHotkey.IsEnabled)
+                                    return false;
+                                System.Windows.Application.Current.Dispatcher.Invoke(() => { hidHotkey.IsEnabled = false; });
+                            }
+                        }
+                    }
+
                     var chord = Triggers[key];
                     switch (chord.InputsType)
                     {

--- a/HandheldCompanion/Properties/Resources.Designer.cs
+++ b/HandheldCompanion/Properties/Resources.Designer.cs
@@ -3142,6 +3142,24 @@ namespace HandheldCompanion.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Toggle emulated controller type.
+        /// </summary>
+        public static string InputsHotkey_shortcutChangeHIDMode {
+            get {
+                return ResourceManager.GetString("InputsHotkey_shortcutChangeHIDMode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Toggle between Xbox 360 and Dualshock 4 emulated controllers.
+        /// </summary>
+        public static string InputsHotkey_shortcutChangeHIDModeDesc {
+            get {
+                return ResourceManager.GetString("InputsHotkey_shortcutChangeHIDModeDesc", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Display Action center.
         /// </summary>
         public static string InputsHotkey_shortcutControlCenter {

--- a/HandheldCompanion/Properties/Resources.resx
+++ b/HandheldCompanion/Properties/Resources.resx
@@ -2357,4 +2357,10 @@ with motion input enabled, use selected button(s) to disable motion.</value>
   <data name="LayoutPage_SetAsDefault" xml:space="preserve">
     <value>Make this the default layout</value>
   </data>
+  <data name="InputsHotkey_shortcutChangeHIDMode" xml:space="preserve">
+    <value>Toggle emulated controller type</value>
+  </data>
+  <data name="InputsHotkey_shortcutChangeHIDModeDesc" xml:space="preserve">
+    <value>Toggle between Xbox 360 and Dualshock 4 emulated controllers</value>
+  </data>
 </root>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new hotkey for changing between Xbox and DualShock controller emulation modes.
  - Added event handlers to enable or disable hotkeys when controllers are plugged or unplugged.

- **Bug Fixes**
  - Implemented a fix to prevent duplicate actions when changing HID modes by disabling the relevant hotkey.

- **Documentation**
  - Added comments and localized string properties to clarify the purpose of new hotkeys and their actions.

- **Refactor**
  - Updated `HotkeysManager` to handle new hotkey events and settings changes related to controller emulation modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->