### PR TITLE
Fix manual TDP being set too frequent

### DIFF
--- a/HandheldCompanion/Managers/PerformanceManager.cs
+++ b/HandheldCompanion/Managers/PerformanceManager.cs
@@ -32,7 +32,7 @@ public static class PowerMode
 
 public class PerformanceManager : Manager
 {
-    private const short INTERVAL_DEFAULT = 1000; // default interval between value scans
+    private const short INTERVAL_DEFAULT = 3000; // default interval between value scans
     private const short INTERVAL_AUTO = 1010; // default interval between value scans
     private const short INTERVAL_DEGRADED = 5000; // degraded interval between value scans
     public static int MaxDegreeOfParallelism = 4;


### PR DESCRIPTION
Manual TDP was set every 1000 msec, in practice the SMU cannot handle faster then 1 Hz. Due to timing inaccuracies of the interval, sometimes this would be faster then 1000 msec, resulting odd issues like TDP not applying or worse, BSOD.

Side note, this is also what AutoTDP is set to 1010 msec.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Adjusted the default interval for performance-related operations to enhance efficiency and reduce system load. Users may notice a slight change in the timing of these operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->