### PR TITLE
implementation of connect to newest discovered device

### DIFF
--- a/HandheldCompanion/App.config
+++ b/HandheldCompanion/App.config
@@ -225,7 +225,7 @@
     <value>False</value>
    </setting>
    <setting name="LEDUseSecondColor" serializeAs="String">
-   	<value>False</value>
+    <value>False</value>
    </setting>
    <setting name="LEDSettingsLevel" serializeAs="String">
     <value>0</value>
@@ -250,6 +250,12 @@
    </setting>
    <setting name="LastOnScreenDisplayLevel" serializeAs="String">
     <value>2</value>
+   </setting>
+   <setting name="HIDConnectLast" serializeAs="String">
+    <value>False</value>
+   </setting>
+   <setting name="HIDConnectLastNotHide" serializeAs="String">
+    <value>False</value>
    </setting>
   </HandheldCompanion.Properties.Settings>
 	</userSettings>

--- a/HandheldCompanion/Managers/ControllerManager.cs
+++ b/HandheldCompanion/Managers/ControllerManager.cs
@@ -560,6 +560,25 @@ public static class ControllerManager
         // remove controller from powercyclers
         PowerCyclers.TryRemove(controller.GetContainerInstancePath(), out _);
 
+        // connect to last controller as soon as its discovered
+        if (SettingsManager.GetBoolean("HIDConnectLast"))
+        {
+            SetTargetController(controller.GetContainerInstancePath(), IsPowerCycling);
+        }
+        if (SettingsManager.GetBoolean("HIDConnectLastNotHide"))
+        {
+            if (GetControllers().Count > 2)
+            {
+                foreach (var controllersUnhide in GetControllers())
+                {
+                    if (controllersUnhide.GetContainerInstancePath() != controller.GetContainerInstancePath())
+                    {
+                        controllersUnhide.Unhide(false);
+                    }
+                }
+            }
+        }
+
         // new controller logic
         if (DeviceManager.IsInitialized)
         {
@@ -620,6 +639,23 @@ public static class ControllerManager
 
         // raise event
         ControllerUnplugged?.Invoke(controller, IsPowerCycling);
+
+        // connect to previous last controller as soon as main one is unplugged
+        try
+        {
+            if (SettingsManager.GetBoolean("HIDConnectLast"))
+            {
+                SetTargetController(GetControllers()[GetControllers().Count - 2].Details.baseContainerDeviceInstanceId, IsPowerCycling);
+            }
+            if (SettingsManager.GetBoolean("HIDConnectLast"))
+            {
+                if (GetControllers().Count == 2)
+                {
+                    SetTargetController(GetControllers()[1].Details.baseContainerDeviceInstanceId, IsPowerCycling);
+                }
+            }
+        }
+        catch { LogManager.LogInformation("Could not find a controller to retroactively connect"); }
     }
 
     private static void watchdogThreadLoop(object? obj)
@@ -793,6 +829,25 @@ public static class ControllerManager
         // remove controller from powercyclers
         PowerCyclers.TryRemove(controller.GetContainerInstancePath(), out _);
 
+        // connect to last controller as soon as its discovered
+        if (SettingsManager.GetBoolean("HIDConnectLast"))
+        {
+            SetTargetController(controller.GetContainerInstancePath(), IsPowerCycling);
+        }
+        if (SettingsManager.GetBoolean("HIDConnectLastNotHide"))
+        {
+            if (GetControllers().Count > 2)
+            {
+                foreach (var controllersUnhide in GetControllers())
+                {
+                    if (controllersUnhide.GetContainerInstancePath() != controller.GetContainerInstancePath())
+                    {
+                        controllersUnhide.Unhide(false);
+                    }
+                }
+            }
+        }
+
         // new controller logic
         if (DeviceManager.IsInitialized)
         {
@@ -854,6 +909,23 @@ public static class ControllerManager
 
         // raise event
         ControllerUnplugged?.Invoke(controller, IsPowerCycling);
+
+        // connect to previous last controller as soon as main one is unplugged
+        try
+        {
+            if (SettingsManager.GetBoolean("HIDConnectLast"))
+            {
+                SetTargetController(GetControllers()[GetControllers().Count - 2].Details.baseContainerDeviceInstanceId, IsPowerCycling);
+            }
+            if (SettingsManager.GetBoolean("HIDConnectLast"))
+            {
+                if (GetControllers().Count == 2)
+                {
+                    SetTargetController(GetControllers()[1].Details.baseContainerDeviceInstanceId, IsPowerCycling);
+                }
+            }
+        }
+        catch { LogManager.LogInformation("Could not find a controller to retroactively connect"); }
     }
 
     private static object targetLock = new object();

--- a/HandheldCompanion/Managers/ControllerManager.cs
+++ b/HandheldCompanion/Managers/ControllerManager.cs
@@ -646,9 +646,6 @@ public static class ControllerManager
             if (SettingsManager.GetBoolean("HIDConnectLast"))
             {
                 SetTargetController(GetControllers()[GetControllers().Count - 2].Details.baseContainerDeviceInstanceId, IsPowerCycling);
-            }
-            if (SettingsManager.GetBoolean("HIDConnectLast"))
-            {
                 if (GetControllers().Count == 2)
                 {
                     SetTargetController(GetControllers()[1].Details.baseContainerDeviceInstanceId, IsPowerCycling);
@@ -916,9 +913,6 @@ public static class ControllerManager
             if (SettingsManager.GetBoolean("HIDConnectLast"))
             {
                 SetTargetController(GetControllers()[GetControllers().Count - 2].Details.baseContainerDeviceInstanceId, IsPowerCycling);
-            }
-            if (SettingsManager.GetBoolean("HIDConnectLast"))
-            {
                 if (GetControllers().Count == 2)
                 {
                     SetTargetController(GetControllers()[1].Details.baseContainerDeviceInstanceId, IsPowerCycling);

--- a/HandheldCompanion/Properties/Resources.Designer.cs
+++ b/HandheldCompanion/Properties/Resources.Designer.cs
@@ -404,6 +404,33 @@ namespace HandheldCompanion.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Connect to the newest device.
+        /// </summary>
+        public static string ControllerPage_ConnectLast {
+            get {
+                return ResourceManager.GetString("ControllerPage_ConnectLast", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Connect to the last controller detected by HC.
+        /// </summary>
+        public static string ControllerPage_ConnectLastDesc {
+            get {
+                return ResourceManager.GetString("ControllerPage_ConnectLastDesc", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unhide the other connected controllers.
+        /// </summary>
+        public static string ControllerPage_ConnectLastNotHideDesc {
+            get {
+                return ResourceManager.GetString("ControllerPage_ConnectLastNotHideDesc", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Controller.
         /// </summary>
         public static string ControllerPage_Controller {

--- a/HandheldCompanion/Properties/Resources.resx
+++ b/HandheldCompanion/Properties/Resources.resx
@@ -2811,4 +2811,13 @@ Motion input toggle: press selected button(s) to switch motion state.</value>
   <data name="QuickSettingsPage_ResScaleExclusiveFullscreen" xml:space="preserve">
     <value>1/1 only supports Exclusive Fullscreen.</value>
   </data>
+  <data name="ControllerPage_ConnectLast" xml:space="preserve">
+    <value>Connect to the newest device</value>
+  </data>
+  <data name="ControllerPage_ConnectLastDesc" xml:space="preserve">
+    <value>Connect to the last controller detected by HC</value>
+  </data>
+  <data name="ControllerPage_ConnectLastNotHideDesc" xml:space="preserve">
+    <value>Unhide the other connected controllers</value>
+  </data>
 </root>

--- a/HandheldCompanion/Properties/Settings.Designer.cs
+++ b/HandheldCompanion/Properties/Settings.Designer.cs
@@ -7,13 +7,14 @@
 //     the code is regenerated.
 // </auto-generated>
 //------------------------------------------------------------------------------
-using System.Configuration;
+
 namespace HandheldCompanion.Properties {
-
-
-    [SettingsProvider(typeof(CustomSettingsProvider))]
-    internal sealed partial class Settings : ApplicationSettingsBase
-    {
+    
+    
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.8.0.0")]
+    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
+        
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
         
         public static Settings Default {
@@ -1001,6 +1002,30 @@ namespace HandheldCompanion.Properties {
             }
             set {
                 this["LastOnScreenDisplayLevel"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool HIDConnectLast {
+            get {
+                return ((bool)(this["HIDConnectLast"]));
+            }
+            set {
+                this["HIDConnectLast"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool HIDConnectLastNotHide {
+            get {
+                return ((bool)(this["HIDConnectLastNotHide"]));
+            }
+            set {
+                this["HIDConnectLastNotHide"] = value;
             }
         }
     }

--- a/HandheldCompanion/Properties/Settings.settings
+++ b/HandheldCompanion/Properties/Settings.settings
@@ -218,9 +218,9 @@
     <Setting Name="LEDAmbilightVerticalBlackBarDetection" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
-	<Setting Name="LEDUseSecondColor" Type="System.Boolean" Scope="User">
-	  <Value Profile="(Default)">False</Value>
-	</Setting>
+    <Setting Name="LEDUseSecondColor" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
     <Setting Name="LEDSettingsLevel" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">0</Value>
     </Setting>
@@ -247,6 +247,12 @@
     </Setting>
     <Setting Name="LastOnScreenDisplayLevel" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">2</Value>
+    </Setting>
+    <Setting Name="HIDConnectLast" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="HIDConnectLastNotHide" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/HandheldCompanion/Views/Pages/ControllerPage.xaml
+++ b/HandheldCompanion/Views/Pages/ControllerPage.xaml
@@ -475,9 +475,87 @@
                                 Toggled="Toggle_ControllerManagement_Toggled" />
                         </Grid>
                     </Border>
+
+                    <!--  Connect to last detected controller  -->
+                    <Expander
+                        Name="LastConnect"
+                        HorizontalAlignment="Stretch"
+                        Expanded="Expander_Expanded">
+
+                        <Expander.Header>
+                            <DockPanel Margin="0,12,12,12">
+                                <ui:FontIcon
+                                    Height="40"
+                                    HorizontalAlignment="Center"
+                                    FontFamily="{DynamicResource SymbolThemeFontFamily}"
+                                    Glyph="&#xE8CB;" />
+
+                                <ui:SimpleStackPanel Margin="12,0,0,0" VerticalAlignment="Center">
+                                    
+                                    <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{x:Static resx:Resources.ControllerPage_ConnectLast}" />
+                                    <TextBlock
+                                        Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                                        Style="{StaticResource CaptionTextBlockStyle}"
+                                        Text="{x:Static resx:Resources.ControllerPage_ConnectLastDesc}"
+                                        TextWrapping="Wrap" />
+                                </ui:SimpleStackPanel>
+                            </DockPanel>
+                        </Expander.Header>
+                        <Expander.Content>
+                            <ui:SimpleStackPanel Margin="30,0,0,0" Spacing="12">
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="5*" MinWidth="200" />
+                                        <ColumnDefinition Width="5*" MinWidth="200" />
+                                    </Grid.ColumnDefinitions>
+
+                                    <TextBlock
+                                        VerticalAlignment="Center"
+                                        Style="{StaticResource BodyTextBlockStyle}"
+                                        Text="{x:Static resx:Resources.ControllerPage_ConnectLast}" />
+
+                                    <ui:ToggleSwitch
+                                        Name="Toggle_ConnectLast"
+                                        Grid.Column="1"
+                                        HorizontalAlignment="Right"
+                                        Style="{DynamicResource InvertedToggleSwitchStyle}"
+                                        Toggled="Toggle_ConnectLast_Toggled" />
+                                </Grid>
+
+                                <StackPanel d:Visibility="Visible" Visibility="{Binding ElementName=Toggle_ConnectLast, Path=IsOn, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                    <!--  Separator  -->
+                                    <Separator
+                                        Margin="-46,0,-16,0"
+                                        BorderBrush="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
+                                        BorderThickness="0,1,0,0" />
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="5*" MinWidth="200" />
+                                            <ColumnDefinition Width="5*" MinWidth="200" />
+                                        </Grid.ColumnDefinitions>
+
+                                        <TextBlock
+                                            VerticalAlignment="Center"
+                                            Style="{StaticResource BodyTextBlockStyle}"
+                                            Text="{x:Static resx:Resources.ControllerPage_ConnectLastNotHideDesc}" />
+
+                                        <ui:ToggleSwitch
+                                            Name="Toggle_ConnectLastNotHide"
+                                            Grid.Column="1"
+                                            HorizontalAlignment="Right"
+                                            Style="{DynamicResource InvertedToggleSwitchStyle}"
+                                            Toggled="Toggle_ConnectLastNotHide_Toggled" />
+                                    </Grid>
+                                </StackPanel>
+                            </ui:SimpleStackPanel>
+                        </Expander.Content>
+                    </Expander>
                 </ui:SimpleStackPanel>
 
-                <!--  Non-game controller layouts  -->
+                
+
+
+                    <!--  Non-game controller layouts  -->
                 <ui:SimpleStackPanel Spacing="6">
                     <TextBlock Style="{StaticResource BaseTextBlockStyle}" Text="{x:Static resx:Resources.ControllerPage_NonGameControllerLayouts}" />
 
@@ -493,7 +571,7 @@
                                     HorizontalAlignment="Center"
                                     FontFamily="{DynamicResource SymbolThemeFontFamily}"
                                     Glyph="&#xE713;" />
-
+                                
                                 <ui:SimpleStackPanel Margin="12,0,0,0" VerticalAlignment="Center">
                                     <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{x:Static resx:Resources.ControllerPage_DesktopLayout}" />
                                     <TextBlock

--- a/HandheldCompanion/Views/Pages/ControllerPage.xaml.cs
+++ b/HandheldCompanion/Views/Pages/ControllerPage.xaml.cs
@@ -86,6 +86,12 @@ public partial class ControllerPage : Page
                 case "HIDvibrateonconnect":
                     Toggle_Vibrate.IsOn = Convert.ToBoolean(value);
                     break;
+                case "HIDConnectLast":
+                    Toggle_ConnectLast.IsOn = Convert.ToBoolean(value);
+                    break;
+                case "HIDConnectLastNotHide":
+                    Toggle_ConnectLastNotHide.IsOn = Convert.ToBoolean(value);
+                    break;
                 case "ControllerManagement":
                     Toggle_ControllerManagement.IsOn = Convert.ToBoolean(value);
                     break;
@@ -479,6 +485,16 @@ public partial class ControllerPage : Page
         SettingsManager.SetProperty("HIDvibrateonconnect", Toggle_Vibrate.IsOn);
     }
 
+    private void Toggle_ConnectLast_Toggled(object sender, RoutedEventArgs e)
+    {
+        if (!IsLoaded)
+            return;
+        if (!Toggle_ConnectLast.IsOn)
+            SettingsManager.SetProperty("HIDConnectLastNotHide", false);
+
+        SettingsManager.SetProperty("HIDConnectLast", Toggle_ConnectLast.IsOn);
+    }
+
     private void Toggle_ControllerManagement_Toggled(object sender, RoutedEventArgs e)
     {
         if (!IsLoaded)
@@ -522,5 +538,13 @@ public partial class ControllerPage : Page
             return;
 
         SettingsManager.SetProperty("LegionControllerPassthrough", Toggle_TouchpadPassthrough.IsOn);
+    }
+
+    private void Toggle_ConnectLastNotHide_Toggled(object sender, RoutedEventArgs e)
+    {
+        if (!IsLoaded)
+            return;
+
+        SettingsManager.SetProperty("HIDConnectLastNotHide", Toggle_ConnectLastNotHide.IsOn);
     }
 }


### PR DESCRIPTION
Added 2 simple functionalities:

1. Connect the virtual controller to any controller discovered by HC
2. Unhide other controllers when autoconnecting

Both options togglable in the main controller menus:
![image](https://github.com/Valkirie/HandheldCompanion/assets/13962266/8cb526cf-7b16-44fc-af6b-9394429a69f9)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced settings to automatically connect to the last used controller and manage controller reconnections more seamlessly.
	- Added localization support for new controller connection features.

- **Enhancements**
	- Improved user interface on the controller page with new settings for better device management.

- **Bug Fixes**
	- Addressed issues related to controller disconnection events and enhanced error logging for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->