### PR TITLE
Don't restart IMU on ROG Ally

### DIFF
--- a/HandheldCompanion/Views/Windows/MainWindow.xaml.cs
+++ b/HandheldCompanion/Views/Windows/MainWindow.xaml.cs
@@ -183,7 +183,6 @@ public partial class MainWindow : GamepadWindow
         switch (currentDeviceType)
         {
             case "AYANEOAIRPlus":
-            case "ROGAlly":
                 {
                     LogManager.LogInformation("Restarting: {0}", CurrentDevice.InternalSensorName);
 


### PR DESCRIPTION
Not needed since Bosch drivers 1.0.1.7 released many moons ago (mid-July). Might also not be needed on AYA NEO Air Plus if those drivers worked on that device, but I don't own one to test it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified device type handling by removing specific case for "ROGAlly".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->