### PR TITLE
Add touchpad left click as a target button

### DIFF
--- a/HandheldCompanion/Controllers/DInputController.cs
+++ b/HandheldCompanion/Controllers/DInputController.cs
@@ -31,6 +31,9 @@ public class DInputController : IController
         // UI
         DrawUI();
         UpdateUI();
+
+        // Additional controller specific target buttons
+        TargetButtons.Add(ButtonFlags.LeftPadClick);
     }
 
     public override string ToString()

--- a/HandheldCompanion/Controllers/DInputController.cs
+++ b/HandheldCompanion/Controllers/DInputController.cs
@@ -1,4 +1,5 @@
-﻿using SharpDX.DirectInput;
+﻿using HandheldCompanion.Inputs;
+using SharpDX.DirectInput;
 
 namespace HandheldCompanion.Controllers;
 

--- a/HandheldCompanion/Controllers/DS4Controller.cs
+++ b/HandheldCompanion/Controllers/DS4Controller.cs
@@ -31,6 +31,7 @@ public class DS4Controller : JSController
         SourceAxis.Add(AxisLayoutFlags.RightPad);
         SourceAxis.Add(AxisLayoutFlags.Gyroscope);
 
+        // Additional controller specific target buttons
         TargetButtons.Add(ButtonFlags.LeftPadClick);
         TargetButtons.Add(ButtonFlags.LeftPadTouch);
         TargetButtons.Add(ButtonFlags.RightPadTouch);

--- a/HandheldCompanion/Controllers/DualSenseController.cs
+++ b/HandheldCompanion/Controllers/DualSenseController.cs
@@ -24,6 +24,7 @@ public class DualSenseController : JSController
         SourceAxis.Add(AxisLayoutFlags.RightPad);
         SourceAxis.Add(AxisLayoutFlags.Gyroscope);
 
+        // Additional controller specific target buttons
         TargetButtons.Add(ButtonFlags.LeftPadClick);
         TargetButtons.Add(ButtonFlags.LeftPadTouch);
         TargetButtons.Add(ButtonFlags.RightPadTouch);

--- a/HandheldCompanion/Controllers/GordonController.cs
+++ b/HandheldCompanion/Controllers/GordonController.cs
@@ -42,6 +42,7 @@ namespace HandheldCompanion.Controllers
             SourceAxis.Add(AxisLayoutFlags.RightPad);
             SourceAxis.Add(AxisLayoutFlags.Gyroscope);
 
+            // Additional controller specific target buttons
             TargetButtons.Add(ButtonFlags.LeftPadClick);
             TargetButtons.Add(ButtonFlags.RightPadClick);
             TargetButtons.Add(ButtonFlags.LeftPadTouch);

--- a/HandheldCompanion/Controllers/NeptuneController.cs
+++ b/HandheldCompanion/Controllers/NeptuneController.cs
@@ -55,6 +55,7 @@ public class NeptuneController : SteamController
         SourceAxis.Add(AxisLayoutFlags.RightPad);
         SourceAxis.Add(AxisLayoutFlags.Gyroscope);
 
+        // Additional controller specific target buttons
         TargetButtons.Add(ButtonFlags.LeftPadClick);
         TargetButtons.Add(ButtonFlags.RightPadClick);
         TargetButtons.Add(ButtonFlags.LeftPadTouch);

--- a/HandheldCompanion/Controllers/ProController.cs
+++ b/HandheldCompanion/Controllers/ProController.cs
@@ -16,6 +16,9 @@ public class ProController : JSController
         // Additional controller specific source buttons
         SourceButtons.Add(ButtonFlags.Special2);
         SourceAxis.Add(AxisLayoutFlags.Gyroscope);
+
+        // Additional controller specific target buttons
+        TargetButtons.Add(ButtonFlags.LeftPadClick);
     }
 
     public override void UpdateInputs(long ticks)

--- a/HandheldCompanion/Controllers/XInputController.cs
+++ b/HandheldCompanion/Controllers/XInputController.cs
@@ -33,6 +33,9 @@ public class XInputController : IController
         DrawUI();
         UpdateUI();
 
+        // Additional controller specific target buttons
+        TargetButtons.Add(ButtonFlags.LeftPadClick);
+
         string enumerator = Details.GetEnumerator();
         switch (enumerator)
         {


### PR DESCRIPTION
This adds the touchpad left click (single touch click) from DS4 virtual controllers as a target button for DInput, Pro and Xinput controllers.  This is currently available via the touchscreen, but this adds the ability to remap buttons to this function.

This is useful for situations where a game natively supports a DS4 controller on Windows and therefore most likely doesn't use the Share button from the DS4 controller.  On an Xinput device, for example, the default mapping for Back/View is to the Share button, but if a game doesn't support the Share button, this can now be remapped to the touchpad click.

In Modern Warfare, for example, this makes the Back/View button which is previously unusable open the game map instead.

This doesn't change the default mapping for these controllers because there are valid uses for those cases as well.

I also added a comment to the other controller source files, but that was just for consistency for the new lines added elsewhere.

Closes #799 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced controller support across various controllers (DInput, DS4, DualSense, Gordon, Neptune, Pro Controller, XInput) with the addition of new target buttons, improving game interaction and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->