### PR TITLE
Fix AMD GPU vendor check

### DIFF
--- a/HandheldCompanion/Misc/MotherboardInfo.cs
+++ b/HandheldCompanion/Misc/MotherboardInfo.cs
@@ -41,7 +41,7 @@ public static class MotherboardInfo
                 manufacturer = videoController["AdapterCompatibility"].ToString();
                 if (manufacturer.Contains("Intel"))
                     break;
-                else if (manufacturer.Contains("AMD"))
+                else if (manufacturer.Contains("Advanced Micro Devices"))
                     break;
             }
 


### PR DESCRIPTION
The check needs to use "Advanced Micro Devices" to properly identify AMD GPUs. Without this fix, Handheld Companion sometimes fails to start when multiple graphics adapters are present (for instance, when a DisplayLink dock is connected).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved clarity in hardware information comparison by updating terminology used for video controller identification.
	- Minor formatting adjustments for better code readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->