### PR TITLE
fix AYANEO SLIDE max cTDP

### DIFF
--- a/HandheldCompanion/Devices/AYANEO/AYANEOSLIDE.cs
+++ b/HandheldCompanion/Devices/AYANEO/AYANEOSLIDE.cs
@@ -12,7 +12,7 @@ public class AYANEOSlide : AYANEO.AYANEODeviceCEii
 
         // https://www.amd.com/en/products/apu/amd-ryzen-7-7840u
         this.nTDP = new double[] { 15, 15, 20 };
-        this.cTDP = new double[] { 3, 54 };
+        this.cTDP = new double[] { 3, 28 };
         this.GfxClock = new double[] { 100, 2700 };
         this.CpuClock = 5100;
 


### PR DESCRIPTION
ayaneo slide's max tdp is 28w

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the `cTDP` values for AYANEO SLIDE devices to enhance performance and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->