### PR TITLE
Add 80% battery charge limit for Legion Go

### DIFF
--- a/HandheldCompanion/App.config
+++ b/HandheldCompanion/App.config
@@ -275,6 +275,9 @@
    <setting name="LegionControllerGyroIndex" serializeAs="String">
     <value>0</value>
    </setting>
+   <setting name="LegionBatteryChargeLimit" serializeAs="String">
+    <value>False</value>
+   </setting>
   </HandheldCompanion.Properties.Settings>
 	</userSettings>
 </configuration>

--- a/HandheldCompanion/Devices/Lenovo/LegionGo.cs
+++ b/HandheldCompanion/Devices/Lenovo/LegionGo.cs
@@ -224,12 +224,6 @@ public class LegionGo : IDevice
         DefaultLayout.ButtonLayout[ButtonFlags.B8] = new List<IActions>() { new MouseActions { MouseType = MouseActionsType.ScrollDown } };
 
         SettingsManager.SettingValueChanged += SettingsManager_SettingValueChanged;
-        UpdateSettings();
-
-        /*
-        Task<bool> task = Task.Run(async () => await GetFanFullSpeedAsync());
-        bool FanFullSpeed = task.Result;
-        */
     }
 
     private void PowerProfileManager_Applied(PowerProfile profile, UpdateSource source)
@@ -441,11 +435,6 @@ public class LegionGo : IDevice
         }
 
         return defaultGlyph;
-    }
-
-    protected void UpdateSettings()
-    {
-        SetBatteryChargeLimit(SettingsManager.GetBoolean("LegionBatteryChargeLimit"));
     }
 
     private void SettingsManager_SettingValueChanged(string name, object value)

--- a/HandheldCompanion/Devices/Lenovo/LegionGo.cs
+++ b/HandheldCompanion/Devices/Lenovo/LegionGo.cs
@@ -97,6 +97,18 @@ public class LegionGo : IDevice
                 { "value", limit },
             });
 
+    // InstantBootAc (0x03010001) controls the 80% power charge limit.
+    // https://github.com/aarron-lee/LegionGoRemapper/blob/ab823f2042fc857cca856687a385a033d68c58bf/py_modules/legion_space.py#L138
+    public Task SetBatteryChargeLimit(bool enabled) =>
+        WMI.CallAsync("root\\WMI",
+            $"SELECT * FROM LENOVO_OTHER_METHOD",
+            "SetFeatureValue",
+            new()
+            {
+                { "IDs", (int)CapabilityID.InstantBootAc },
+                { "value", enabled ? 1 : 0 },
+            });
+
     public const byte INPUT_HID_ID = 0x04;
 
     public override bool IsOpen => hidDevices.ContainsKey(INPUT_HID_ID) && hidDevices[INPUT_HID_ID].IsOpen;
@@ -210,6 +222,9 @@ public class LegionGo : IDevice
         DefaultLayout.ButtonLayout[ButtonFlags.B6] = new List<IActions>() { new MouseActions { MouseType = MouseActionsType.MiddleButton } };
         DefaultLayout.ButtonLayout[ButtonFlags.B7] = new List<IActions>() { new MouseActions { MouseType = MouseActionsType.ScrollUp } };
         DefaultLayout.ButtonLayout[ButtonFlags.B8] = new List<IActions>() { new MouseActions { MouseType = MouseActionsType.ScrollDown } };
+
+        SettingsManager.SettingValueChanged += SettingsManager_SettingValueChanged;
+        UpdateSettings();
 
         /*
         Task<bool> task = Task.Run(async () => await GetFanFullSpeedAsync());
@@ -426,5 +441,20 @@ public class LegionGo : IDevice
         }
 
         return defaultGlyph;
+    }
+
+    protected void UpdateSettings()
+    {
+        SetBatteryChargeLimit(SettingsManager.GetBoolean("LegionBatteryChargeLimit"));
+    }
+
+    private void SettingsManager_SettingValueChanged(string name, object value)
+    {
+        switch (name)
+        {
+            case "LegionBatteryChargeLimit":
+                SetBatteryChargeLimit(Convert.ToBoolean(value));
+                break;
+        }
     }
 }

--- a/HandheldCompanion/Properties/Resources.Designer.cs
+++ b/HandheldCompanion/Properties/Resources.Designer.cs
@@ -1070,6 +1070,24 @@ namespace HandheldCompanion.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to 80% Battery Charge Limit.
+        /// </summary>
+        public static string DevicePage_LegionBatteryChargeLimit {
+            get {
+                return ResourceManager.GetString("DevicePage_LegionBatteryChargeLimit", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sets the maximum charge level of the battery to 80%.
+        /// </summary>
+        public static string DevicePage_LegionBatteryChargeLimit_Desc {
+            get {
+                return ResourceManager.GetString("DevicePage_LegionBatteryChargeLimit_Desc", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Auto Sleep Time.
         /// </summary>
         public static string DevicePage_Lenovo_ControllerAutoSleepTime {

--- a/HandheldCompanion/Properties/Resources.resx
+++ b/HandheldCompanion/Properties/Resources.resx
@@ -2994,4 +2994,10 @@ Motion input toggle: press selected button(s) to switch motion state.</value>
   <data name="PowerProfileMSIClawBetterPerformanceDesc" xml:space="preserve">
     <value>The best system settings that MSI recommends.</value>
   </data>
+  <data name="DevicePage_LegionBatteryChargeLimit" xml:space="preserve">
+    <value>80% Battery Charge Limit</value>
+  </data>
+  <data name="DevicePage_LegionBatteryChargeLimit_Desc" xml:space="preserve">
+    <value>Sets the maximum charge level of the battery to 80%</value>
+  </data>
 </root>

--- a/HandheldCompanion/Properties/Settings.Designer.cs
+++ b/HandheldCompanion/Properties/Settings.Designer.cs
@@ -1103,5 +1103,20 @@ namespace HandheldCompanion.Properties
                 this["LegionControllerGyroIndex"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool LegionBatteryChargeLimit
+        {
+            get
+            {
+                return ((bool)(this["LegionBatteryChargeLimit"]));
+            }
+            set
+            {
+                this["LegionBatteryChargeLimit"] = value;
+            }
+        }
     }
 }

--- a/HandheldCompanion/Properties/Settings.settings
+++ b/HandheldCompanion/Properties/Settings.settings
@@ -272,5 +272,8 @@
     <Setting Name="LegionControllerGyroIndex" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">0</Value>
     </Setting>
+    <Setting Name="LegionBatteryChargeLimit" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/HandheldCompanion/Views/Pages/AboutPage.xaml
+++ b/HandheldCompanion/Views/Pages/AboutPage.xaml
@@ -193,7 +193,7 @@
                                     Margin="0,0,0,5"
                                     Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                     Style="{StaticResource BodyTextBlockStyle}"
-                                    Text="Nefarius, CasperH2O, B-Core, Frank东, Toomy, Havner, CoryManson, MSeys, ShadowFlare, trippyone, MiguelLedesmaC, Cheng77777, thororen1234, fighterguard, micdah, Geckon01, Bagboii, MeikoMenmaHonma, cerahmed, indiesaudi, Radther, Staubgeborener, twjmy, m33ts4k0z, howanghk, Creaous, xerootg, quangmach, MrCivsteR, 0SkillAllLuck, DevL0rd, romracer, JT" />
+                                    Text="Nefarius, CasperH2O, B-Core, Frank东, Toomy, Havner, CoryManson, MSeys, ShadowFlare, trippyone, MiguelLedesmaC, Cheng77777, thororen1234, fighterguard, micdah, Geckon01, Bagboii, MeikoMenmaHonma, cerahmed, indiesaudi, Radther, Staubgeborener, twjmy, m33ts4k0z, howanghk, Creaous, xerootg, quangmach, MrCivsteR, 0SkillAllLuck, DevL0rd, romracer, JT, PlasmidEve" />
 
                                 <!--  Description  -->
                                 <TextBlock

--- a/HandheldCompanion/Views/Pages/DevicePage.xaml
+++ b/HandheldCompanion/Views/Pages/DevicePage.xaml
@@ -863,6 +863,44 @@
                 </Border>
 
                 <Border
+                    Name="BatteryChargeLimit"
+                    Padding="15,12,12,12"
+                    Background="{DynamicResource ExpanderHeaderBackground}"
+                    CornerRadius="{DynamicResource ControlCornerRadius}">
+
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="8*" MinWidth="200" />
+                            <ColumnDefinition Width="2*" MinWidth="200" />
+                        </Grid.ColumnDefinitions>
+
+                        <DockPanel>
+                            <ui:FontIcon
+                                Height="40"
+                                HorizontalAlignment="Center"
+                                FontFamily="{DynamicResource SymbolThemeFontFamily}"
+                                Glyph="&#xE862;" />
+
+                            <ui:SimpleStackPanel Margin="12,0,0,0" VerticalAlignment="Center">
+                                <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{x:Static resx:Resources.DevicePage_LegionBatteryChargeLimit}" />
+                                <TextBlock
+                                    Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                                    Style="{StaticResource CaptionTextBlockStyle}"
+                                    Text="{x:Static resx:Resources.DevicePage_LegionBatteryChargeLimit_Desc}"
+                                    TextWrapping="Wrap" />
+                            </ui:SimpleStackPanel>
+                        </DockPanel>
+
+                        <ui:ToggleSwitch
+                            Name="Toggle_LegionBatteryChargeLimit"
+                            Grid.Column="1"
+                            HorizontalAlignment="Right"
+                            Style="{DynamicResource InvertedToggleSwitchStyle}"
+                            Toggled="Toggle_LegionBatteryChargeLimit_Toggled" />
+                    </Grid>
+                </Border>
+
+                <Border
                     Name="GyroController"
                     Padding="15,12,12,12"
                     Background="{DynamicResource ExpanderHeaderBackground}"

--- a/HandheldCompanion/Views/Pages/DevicePage.xaml.cs
+++ b/HandheldCompanion/Views/Pages/DevicePage.xaml.cs
@@ -505,6 +505,14 @@ namespace HandheldCompanion.Views.Pages
             SettingsManager.SetProperty("LegionControllerPassthrough", Toggle_TouchpadPassthrough.IsOn);
         }
 
+        private void Toggle_LegionBatteryChargeLimit_Toggled(object sender, RoutedEventArgs e)
+        {
+            if (!IsLoaded)
+                return;
+
+            SettingsManager.SetProperty("LegionBatteryChargeLimit", Toggle_LegionBatteryChargeLimit.IsOn);
+        }
+
         private void ComboBox_GyroController_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             if (!IsLoaded)


### PR DESCRIPTION
Adds 80% battery charge limit toggle for the Legion Go. 

Initially, I was trying to do this through a function located in the SapientiaUSB.dll but I was unable to find anything of use. I did however find out through another project (LegionGoRemapper) that 0x03010001 handles the enabling or disabling of the 80% battery charge limit.

If there is an alternative way of doing this that makes more sense, please let me know!

![image](https://github.com/Valkirie/HandheldCompanion/assets/22126651/8efa775b-229f-4ca1-8daf-6168f0f5eaa1)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a battery charge limit setting for Lenovo Legion devices, allowing users to cap battery charge at 80% to extend battery lifespan.
  - Added a toggle switch in the device settings page to enable or disable the battery charge limit feature.

- **UI Enhancements**
  - Added a new section in the device settings page for managing the battery charge limit, including descriptive text and icons.

- **Acknowledgements**
  - Added "PlasmidEve" to the list of contributors on the About page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->