### PR TITLE
fix(Layout): Prevent selection of header items in cB_Layouts

### DIFF
--- a/HandheldCompanion/ViewModels/LayoutTemplateViewModel.cs
+++ b/HandheldCompanion/ViewModels/LayoutTemplateViewModel.cs
@@ -1,4 +1,6 @@
 ﻿using HandheldCompanion.Misc;
+using HandheldCompanion.Properties;
+
 using System;
 using System.Windows;
 
@@ -6,6 +8,8 @@ namespace HandheldCompanion.ViewModels
 {
     public class LayoutTemplateViewModel : BaseViewModel
     {
+        public string Header => LayoutTemplate.IsInternal ? Resources.LayoutPage_Templates : Resources.LayoutPage_Community;
+
         private LayoutTemplate _layoutTemplate;
         public LayoutTemplate LayoutTemplate
         {
@@ -14,10 +18,9 @@ namespace HandheldCompanion.ViewModels
             {
                 _layoutTemplate = value;
                 OnPropertyChanged(nameof(LayoutTemplate));
+                OnPropertyChanged(nameof(Header));
             }
         }
-
-        public bool IsHeader { get; set; } = false;
 
         private Guid _guid = Guid.Empty;
         public Guid Guid

--- a/HandheldCompanion/ViewModels/Pages/LayoutPageViewModel.cs
+++ b/HandheldCompanion/ViewModels/Pages/LayoutPageViewModel.cs
@@ -13,25 +13,21 @@ namespace HandheldCompanion.ViewModels
 {
     public class LayoutPageViewModel : BaseViewModel
     {
-        public ObservableCollection<LayoutTemplateViewModel> LayoutList { get; set; } = [];
-        private LayoutTemplateViewModel _layoutTemplates;
-        private LayoutTemplateViewModel _layoutCommunity;
+        private ObservableCollection<LayoutTemplateViewModel> layoutList = [];
+        public ListCollectionView LayoutCollectionView { get; set; }
 
         public LayoutPageViewModel(LayoutPage layoutPage)
         {
             // Enable thread-safe access to the collection
-            BindingOperations.EnableCollectionSynchronization(LayoutList, new object());
+            BindingOperations.EnableCollectionSynchronization(layoutList, new object());
 
             // manage events
             ManagerFactory.layoutManager.Updated += LayoutManager_Updated;
             ManagerFactory.settingsManager.SettingValueChanged += SettingsManager_SettingValueChanged;
             ControllerManager.ControllerSelected += ControllerManager_ControllerSelected;
 
-            _layoutTemplates = new() { IsHeader = true, Name = Resources.LayoutPage_Templates, Guid = new() };
-            _layoutCommunity = new() { IsHeader = true, Name = Resources.LayoutPage_Community, Guid = new() };
-
-            LayoutList.Add(_layoutTemplates);
-            LayoutList.Add(_layoutCommunity);
+            LayoutCollectionView = new ListCollectionView(layoutList);
+            LayoutCollectionView.GroupDescriptions.Add(new PropertyGroupDescription("Header"));
 
             // raise events
             switch (ManagerFactory.layoutManager.Status)
@@ -85,16 +81,15 @@ namespace HandheldCompanion.ViewModels
             lock (lockcollection)
             {
                 int index;
-                LayoutTemplateViewModel? foundPreset = LayoutList.FirstOrDefault(p => p.Guid == layoutTemplate.Guid);
+                LayoutTemplateViewModel? foundPreset = layoutList.FirstOrDefault(p => p.Guid == layoutTemplate.Guid);
                 if (foundPreset is not null)
                 {
-                    index = LayoutList.IndexOf(foundPreset);
+                    index = layoutList.IndexOf(foundPreset);
                     foundPreset = new(layoutTemplate);
                 }
                 else
                 {
-                    index = LayoutList.IndexOf(layoutTemplate.IsInternal ? _layoutTemplates : _layoutCommunity) + 1;
-                    LayoutList.Insert(index, new(layoutTemplate));
+                    layoutList.Insert(0, new(layoutTemplate));
                 }
             }
 
@@ -112,7 +107,7 @@ namespace HandheldCompanion.ViewModels
 
             lock (lockcollection)
             {
-                foreach (LayoutTemplateViewModel layoutTemplate in LayoutList)
+                foreach (LayoutTemplateViewModel layoutTemplate in layoutList)
                 {
                     if (layoutTemplate.ControllerType is not null && FilterOnDevice)
                     {

--- a/HandheldCompanion/Views/Pages/LayoutPage.xaml
+++ b/HandheldCompanion/Views/Pages/LayoutPage.xaml
@@ -108,9 +108,20 @@
                         HorizontalAlignment="Stretch"
                         VerticalAlignment="Center"
                         HorizontalContentAlignment="Left"
-                        ItemsSource="{Binding LayoutList, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
+                        ItemsSource="{Binding LayoutCollectionView, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
                         SelectionChanged="cB_Layouts_SelectionChanged">
-
+                        <ComboBox.GroupStyle>
+                            <GroupStyle>
+                                <GroupStyle.HeaderTemplate>
+                                    <DataTemplate>
+                                        <TextBlock
+                                            Margin="16,0,0,0"
+                                            Style="{StaticResource BaseTextBlockStyle}"
+                                            Text="{Binding Name, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" />
+                                    </DataTemplate>
+                                </GroupStyle.HeaderTemplate>
+                            </GroupStyle>
+                        </ComboBox.GroupStyle>
                         <ComboBox.ItemTemplate>
                             <DataTemplate>
                                 <Grid Width="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=ComboBox}}">
@@ -124,8 +135,7 @@
                                         HorizontalAlignment="Left"
                                         VerticalAlignment="Center"
                                         FontFamily="{DynamicResource SymbolThemeFontFamily}"
-                                        Glyph="&#xE7FC;"
-                                        Visibility="{Binding IsHeader, Converter={StaticResource BooleanToVisibilityConverter}, ConverterParameter=False}" />
+                                        Glyph="&#xE7FC;" />
 
                                     <StackPanel Grid.Column="1" Margin="0,0,50,0">
                                         <Grid>
@@ -133,8 +143,7 @@
                                             <ikw:SimpleStackPanel
                                                 HorizontalAlignment="Right"
                                                 Orientation="Horizontal"
-                                                Spacing="6"
-                                                Visibility="{Binding IsHeader, Converter={StaticResource BooleanToVisibilityConverter}, ConverterParameter=False}">
+                                                Spacing="6">
                                                 <TextBlock
                                                     FontStyle="Italic"
                                                     Style="{StaticResource BaseTextBlockStyle}"
@@ -146,8 +155,7 @@
                                             Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                             Style="{StaticResource CaptionTextBlockStyle}"
                                             Text="{Binding Description, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
-                                            TextWrapping="Wrap"
-                                            Visibility="{Binding IsHeader, Converter={StaticResource BooleanToVisibilityConverter}, ConverterParameter=False}" />
+                                            TextWrapping="Wrap" />
                                     </StackPanel>
                                 </Grid>
                             </DataTemplate>

--- a/HandheldCompanion/Views/Pages/LayoutPage.xaml
+++ b/HandheldCompanion/Views/Pages/LayoutPage.xaml
@@ -166,11 +166,6 @@
                                 <Setter Property="IsEnabled" Value="True" />
                                 <Setter Property="Visibility" Value="{Binding Visibility, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" />
                                 <Setter Property="Width" Value="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=ComboBox}}" />
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding IsHeader}" Value="True">
-                                        <Setter Property="IsEnabled" Value="False" />
-                                    </DataTrigger>
-                                </Style.Triggers>
                             </Style>
                         </ComboBox.ItemContainerStyle>
                     </ComboBox>


### PR DESCRIPTION
Users could select a header item in cB_Layouts, causing the program to crash. I have fixed this issue.

Steps to reproduce:

1. Reopen the program.
2. Navigate to the ProfilePage.
3. Click the "Controller layout" button at the bottom of the page to enter the LayoutPage.
4. Click on a blank area of the LayoutPage.
5. Press Tab to focus on the cB_Layouts ComboBox.
6. Press the Down Arrow key to select the "Template" header item.
7. Click "Apply Template" → "Yes", and the program will crash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- ComboBox on the layout page now displays layouts grouped under headers, improving organization and navigation.
- **Improvements**
	- Layout headers are now automatically generated and localized, enhancing clarity for internal and community layouts.
- **Refactor**
	- Conditional visibility and item disabling based on layout headers have been removed, simplifying the interface and ensuring all layout details are always visible.
	- Internal data handling updated to use grouped collection views for better performance and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->