### PR TITLE
Feature: Add controls for Intel Endurance Gaming

### DIFF
--- a/HandheldCompanion/GraphicsProcessingUnit/GPU.cs
+++ b/HandheldCompanion/GraphicsProcessingUnit/GPU.cs
@@ -22,6 +22,9 @@ namespace HandheldCompanion.GraphicsProcessingUnit
         public event GPUScalingChangedEvent GPUScalingChanged;
         public delegate void GPUScalingChangedEvent(bool Supported, bool Enabled, int Mode);
 
+        public event GPUEnduranceGamingChangedEvent GPUEnduranceGamingChanged;
+        public delegate void GPUEnduranceGamingChangedEvent(bool Supported, bool Enabled, int enduranceGamingPreset);
+
         // true: GPU is busy, false: GPU is free
         public event StatusChangedEvent StatusChanged;
         public delegate void StatusChangedEvent(bool status);
@@ -42,6 +45,10 @@ namespace HandheldCompanion.GraphicsProcessingUnit
         protected bool prevGPUScalingSupport = false;
         protected bool prevGPUScaling = false;
         protected int prevScalingMode = -1;
+
+        protected bool prevGPUEnduranceGamingSupport = false;
+        protected bool prevEnduranceGaming = false;
+        protected int prevEnduranceGamingPreset = -1;
 
         protected bool prevIntegerScalingSupport = false;
         protected bool prevIntegerScaling = false;
@@ -91,6 +98,7 @@ namespace HandheldCompanion.GraphicsProcessingUnit
             RadeonImageSharpening,
             IntegerScaling,
             AFMF,
+            EnduranceGaming
         }
 
         /// <summary>
@@ -246,6 +254,15 @@ namespace HandheldCompanion.GraphicsProcessingUnit
             prevScalingMode = mode;
         }
 
+        protected virtual void OnEnduranceGamingPresetChanged(bool supported, bool enabled, int enduranceGamingPreset)
+        {
+            GPUEnduranceGamingChanged?.Invoke(supported, enabled, enduranceGamingPreset);
+
+            prevGPUEnduranceGamingSupport = supported;
+            prevEnduranceGaming = enabled;
+            prevEnduranceGamingPreset = enduranceGamingPreset;
+        }
+
         public virtual bool SetImageSharpening(bool enabled)
         {
             return false;
@@ -281,6 +298,27 @@ namespace HandheldCompanion.GraphicsProcessingUnit
             return false;
         }
 
+        public virtual bool SetEnduranceGamingPreset(int enduranceGamingPreset)
+        {
+            return false;
+        }
+
+        public virtual int getEnduranceGamingPreset()
+        {
+            return 0;
+        }
+
+        public virtual bool HasEnduranceGamingSupport()
+        {
+            return false;
+        }
+
+        public virtual bool GetEnduranceGaming()
+        {
+            return false;
+        }
+
+
         public virtual bool GetImageSharpening()
         {
             return false;
@@ -302,6 +340,11 @@ namespace HandheldCompanion.GraphicsProcessingUnit
         }
 
         public virtual int GetScalingMode()
+        {
+            return 0;
+        }
+
+        public virtual int GetEnduranceGamingPreset()
         {
             return 0;
         }
@@ -424,6 +467,7 @@ namespace HandheldCompanion.GraphicsProcessingUnit
                 IntegerScalingChanged = null;
                 ImageSharpeningChanged = null;
                 GPUScalingChanged = null;
+                GPUEnduranceGamingChanged = null;
                 StatusChanged = null;
             }
 

--- a/HandheldCompanion/GraphicsProcessingUnit/IntelGPU.cs
+++ b/HandheldCompanion/GraphicsProcessingUnit/IntelGPU.cs
@@ -46,6 +46,38 @@ namespace HandheldCompanion.GraphicsProcessingUnit
             return Execute(() => IGCLBackend.GetGPUScaling(deviceIdx, 0), false);
         }
 
+        public override bool HasEnduranceGamingSupport()
+        {
+            if (!IsInitialized)
+                return false;
+
+            return Execute(() => IGCLBackend.HasEnduranceGamingSupport(deviceIdx, 0), false);
+        }
+
+        public override bool GetEnduranceGaming()
+        {
+            if (!IsInitialized)
+                return false;
+
+            return Execute(() => IGCLBackend.GetEnduranceGaming(deviceIdx, 0), false);
+        }
+
+        public override bool SetEnduranceGamingPreset(int enduranceGamingPreset)
+        {
+            if (!IsInitialized)
+                return false;
+
+            return Execute(() => IGCLBackend.SetEnduranceGamingPreset(deviceIdx, 0, enduranceGamingPreset), false);
+        }
+
+        public override int getEnduranceGamingPreset()
+        {
+            if (!IsInitialized)
+                return 0;
+
+            return Execute(() => IGCLBackend.getEnduranceGamingPreset(deviceIdx, 0), 0);
+        }
+
         public override bool GetImageSharpening()
         {
             if (!IsInitialized)

--- a/HandheldCompanion/IGCL/IGCLBackend.cs
+++ b/HandheldCompanion/IGCL/IGCLBackend.cs
@@ -182,6 +182,47 @@ namespace HandheldCompanion.IGCL
             public ctl_scaling_type_flag_t SupportedScaling;   // [out] Supported scaling types. Refer ::ctl_scaling_type_flag_t
         }
 
+        [StructLayout(LayoutKind.Sequential)]
+        public struct ctl_property_info_enum_t
+        {
+            long SupportedTypes;                        ///< [out] Supported possible values represented as a bitmask
+            int DefaultType;                           ///< [out] Default type
+        }
+
+        enum ctl_3d_endurance_gaming_control_t
+        {
+            CTL_3D_ENDURANCE_GAMING_CONTROL_TURN_OFF = 0,   // Endurance Gaming disable
+            CTL_3D_ENDURANCE_GAMING_CONTROL_TURN_ON = 1,    // Endurance Gaming enable
+            CTL_3D_ENDURANCE_GAMING_CONTROL_AUTO = 2,       // Endurance Gaming auto
+            CTL_3D_ENDURANCE_GAMING_CONTROL_MAX
+
+        };
+
+        enum ctl_3d_endurance_gaming_mode_t
+        {
+            CTL_3D_ENDURANCE_GAMING_MODE_BETTER_PERFORMANCE = 0,// Endurance Gaming better performance mode
+            CTL_3D_ENDURANCE_GAMING_MODE_BALANCED = 1,      // Endurance Gaming balanced mode
+            CTL_3D_ENDURANCE_GAMING_MODE_MAXIMUM_BATTERY = 2,   // Endurance Gaming maximum battery mode
+            CTL_3D_ENDURANCE_GAMING_MODE_MAX
+
+        };
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct ctl_endurance_gaming_caps_t
+        {
+            ctl_property_info_enum_t EGControlCaps;         ///< [out] Endurance Gaming control capability
+            ctl_property_info_enum_t EGModeCaps;            ///< [out] Endurance Gaming mode capability
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        struct ctl_endurance_gaming_t
+        {
+            ctl_3d_endurance_gaming_control_t EGControl;    ///< [in,out] Endurance Gaming control - Off/On/Auto
+            ctl_3d_endurance_gaming_mode_t EGMode;          ///< [in,out] Endurance Gaming mode - Better Performance/Balanced/Maximum
+                                                            ///< Battery
+
+        }
+
         // Define the delegate type for the done function pointer
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate void doneDelegate(IntPtr thisobj);
@@ -349,6 +390,11 @@ namespace HandheldCompanion.IGCL
         private delegate ctl_result_t SetSharpnessSettingsDelegate(ctl_device_adapter_handle_t hDevice, uint idx, ctl_sharpness_settings_t SetSharpness);
         private delegate ctl_result_t GetTelemetryDataDelegate(ctl_device_adapter_handle_t hDevice, ref ctl_telemetry_data TelemetryData);
 
+        private delegate ctl_result_t GetEnduranceGamingCapsDelegate(ctl_device_adapter_handle_t hDevice, uint idx, ref ctl_endurance_gaming_caps_t EnduranceGamingCaps);
+        private delegate ctl_result_t GetEnduranceGamingDelegate(ctl_device_adapter_handle_t hDevice, uint idx, ref ctl_endurance_gaming_t EnduranceGamingSettings);
+        private delegate ctl_result_t SetEnduranceGamingDelegate(ctl_device_adapter_handle_t hDevice, uint idx, ctl_endurance_gaming_t EnduranceGamingSettings);
+
+
         // Define the function pointers
         private static InitializeIgclDelegate? InitializeIgcl;
         private static CloseIgclDelegate? CloseIgcl;
@@ -364,6 +410,11 @@ namespace HandheldCompanion.IGCL
         private static GetSharpnessSettingsDelegate? GetSharpnessSettings;
         private static SetSharpnessSettingsDelegate? SetSharpnessSettings;
         private static GetTelemetryDataDelegate? GetTelemetryData;
+
+        private static GetEnduranceGamingCapsDelegate? GetEnduranceGamingCaps;
+        private static SetEnduranceGamingDelegate? SetEnduranceGamingSettings;
+        private static GetEnduranceGamingDelegate? GetEnduranceGamingSettings;
+
 
         public static IntPtr[] devices = new IntPtr[1] { IntPtr.Zero };
         private static IntPtr pDll = IntPtr.Zero;
@@ -410,7 +461,9 @@ namespace HandheldCompanion.IGCL
                         GetSharpnessSettings = (GetSharpnessSettingsDelegate)GetDelegate("GetSharpnessSettings", typeof(GetSharpnessSettingsDelegate));
                         SetSharpnessSettings = (SetSharpnessSettingsDelegate)GetDelegate("SetSharpnessSettings", typeof(SetSharpnessSettingsDelegate));
                         GetTelemetryData = (GetTelemetryDataDelegate)GetDelegate("GetTelemetryData", typeof(GetTelemetryDataDelegate));
-
+                        GetEnduranceGamingCaps = (GetEnduranceGamingCapsDelegate)GetDelegate("GetEnduranceGamingCaps", typeof(GetEnduranceGamingCapsDelegate));
+                        GetEnduranceGamingSettings = (GetEnduranceGamingDelegate)GetDelegate("GetEnduranceGamingSettings", typeof(GetEnduranceGamingDelegate));
+                        SetEnduranceGamingSettings = (SetEnduranceGamingDelegate)GetDelegate("SetEnduranceGamingSettings", typeof(SetEnduranceGamingDelegate));
                         status = IGCLStatus.DLL_INITIALIZE_SUCCESS;
                     }
                     catch
@@ -431,6 +484,10 @@ namespace HandheldCompanion.IGCL
                         GetSharpnessSettings = null;
                         SetSharpnessSettings = null;
                         GetTelemetryData = null;
+                        GetEnduranceGamingCaps = null;
+                        GetEnduranceGamingSettings = null;
+                        SetEnduranceGamingSettings = null;
+
                     }
                 }
             }
@@ -583,6 +640,27 @@ namespace HandheldCompanion.IGCL
                 return false;
 
             return ScalingSettings.Enable == enabled;
+        }
+
+        internal static bool HasEnduranceGamingSupport(nint deviceIdx, uint displayIdx)
+        {
+            // BN: To be implemented
+            return false;
+        }
+        internal static bool GetEnduranceGaming(nint deviceIdx, uint displayIdx)
+        {
+            // BN: To be implemented
+            return false;
+        }
+        internal static bool SetEnduranceGamingPreset(nint deviceIdx, uint displayIdx, int enduranceGamingPreset = 0)
+        {
+            // BN: To be implemented
+            return false;
+        }
+        internal static int getEnduranceGamingPreset(nint deviceIdx, uint displayIdx)
+        {
+            // BN: To be implemented
+            return 0;
         }
 
         internal static bool SetImageSharpening(nint deviceIdx, uint displayIdx, bool enable)

--- a/HandheldCompanion/Misc/Profile.cs
+++ b/HandheldCompanion/Misc/Profile.cs
@@ -143,6 +143,8 @@ public partial class Profile : ICloneable, IComparable
     public bool RISEnabled { get; set; }
     public int RISSharpness { get; set; } = 80; // default AMD value
     public bool AFMFEnabled { get; set; }
+    public bool EnduranceGaming { get; set; }
+    public int EnduranceGamingPreset { get; set; } = 0;  // default Intel Value
 
     // AppCompatFlags
     public bool FullScreenOptimization { get; set; } = true;

--- a/HandheldCompanion/Properties/Resources.Designer.cs
+++ b/HandheldCompanion/Properties/Resources.Designer.cs
@@ -7671,6 +7671,24 @@ namespace HandheldCompanion.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Endurance Gaming.
+        /// </summary>
+        public static string ProfilesPage_EnduranceGaming {
+            get {
+                return ResourceManager.GetString("ProfilesPage_EnduranceGaming", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Endurance Gaming Mode extends your gaming sessions by balancing frame rate and power consumption.
+        /// </summary>
+        public static string ProfilesPage_EnduranceGamingDesc {
+            get {
+                return ResourceManager.GetString("ProfilesPage_EnduranceGamingDesc", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Energy performance preference (EPP).
         /// </summary>
         public static string ProfilesPage_EPP {

--- a/HandheldCompanion/Properties/Resources.de-DE.resx
+++ b/HandheldCompanion/Properties/Resources.de-DE.resx
@@ -2691,8 +2691,14 @@ Wenn die Bewegungseingabe aktiviert ist, verwenden Sie die ausgewählte(n) Taste
   <data name="ProfilesPage_GPUScaling" xml:space="preserve">
     <value>GPU Scaling</value>
   </data>
-  <data name="ProfilesPage_GPUScalingDesc" xml:space="preserve">
+	<data name="ProfilesPage_GPUScalingDesc" xml:space="preserve">
     <value>GPU will scale up lower resolutions to fit the display</value>
+  </data>
+	<data name="ProfilesPage_EnduranceGaming" xml:space="preserve">
+    <value>Endurance Gaming</value>
+  </data>
+	<data name="ProfilesPage_EnduranceGamingDesc" xml:space="preserve">
+    <value>Endurance Gaming Mode extends your gaming sessions by balancing frame rate and power consumption</value>
   </data>
   <data name="ProfilesPage_ImageSharpening" xml:space="preserve">
     <value>Image Sharpening</value>

--- a/HandheldCompanion/Properties/Resources.es-ES.resx
+++ b/HandheldCompanion/Properties/Resources.es-ES.resx
@@ -2695,6 +2695,12 @@
   <data name="ProfilesPage_GPUScalingDesc" xml:space="preserve">
     <value>GPU will scale up lower resolutions to fit the display</value>
   </data>
+	<data name="ProfilesPage_EnduranceGaming" xml:space="preserve">
+    <value>Endurance Gaming</value>
+  </data>
+	<data name="ProfilesPage_EnduranceGamingDesc" xml:space="preserve">
+    <value>Endurance Gaming Mode extends your gaming sessions by balancing frame rate and power consumption</value>
+  </data>
   <data name="ProfilesPage_ImageSharpening" xml:space="preserve">
     <value>Image Sharpening</value>
   </data>

--- a/HandheldCompanion/Properties/Resources.fr-FR.resx
+++ b/HandheldCompanion/Properties/Resources.fr-FR.resx
@@ -2693,6 +2693,12 @@ with motion input enabled, use selected button(s) to disable motion.</value>
   <data name="ProfilesPage_GPUScalingDesc" xml:space="preserve">
     <value>GPU will scale up lower resolutions to fit the display</value>
   </data>
+	<data name="ProfilesPage_EnduranceGaming" xml:space="preserve">
+    <value>Endurance Gaming</value>
+  </data>
+	<data name="ProfilesPage_EnduranceGamingDesc" xml:space="preserve">
+    <value>Endurance Gaming Mode extends your gaming sessions by balancing frame rate and power consumption</value>
+  </data>
   <data name="ProfilesPage_ImageSharpening" xml:space="preserve">
     <value>Image Sharpening</value>
   </data>

--- a/HandheldCompanion/Properties/Resources.it-IT.resx
+++ b/HandheldCompanion/Properties/Resources.it-IT.resx
@@ -2695,6 +2695,12 @@
   <data name="ProfilesPage_GPUScalingDesc" xml:space="preserve">
     <value>GPU will scale up lower resolutions to fit the display</value>
   </data>
+	<data name="ProfilesPage_EnduranceGaming" xml:space="preserve">
+    <value>Endurance Gaming</value>
+  </data>
+	<data name="ProfilesPage_EnduranceGamingDesc" xml:space="preserve">
+    <value>Endurance Gaming Mode extends your gaming sessions by balancing frame rate and power consumption</value>
+  </data>
   <data name="ProfilesPage_ImageSharpening" xml:space="preserve">
     <value>Image Sharpening</value>
   </data>

--- a/HandheldCompanion/Properties/Resources.ja-JP.resx
+++ b/HandheldCompanion/Properties/Resources.ja-JP.resx
@@ -2696,6 +2696,12 @@
   <data name="ProfilesPage_GPUScalingDesc" xml:space="preserve">
     <value>GPU will scale up lower resolutions to fit the display</value>
   </data>
+	<data name="ProfilesPage_EnduranceGaming" xml:space="preserve">
+    <value>Endurance Gaming</value>
+  </data>
+	<data name="ProfilesPage_EnduranceGamingDesc" xml:space="preserve">
+    <value>Endurance Gaming Mode extends your gaming sessions by balancing frame rate and power consumption</value>
+  </data>
   <data name="ProfilesPage_ImageSharpening" xml:space="preserve">
     <value>Image Sharpening</value>
   </data>

--- a/HandheldCompanion/Properties/Resources.ko-KR.resx
+++ b/HandheldCompanion/Properties/Resources.ko-KR.resx
@@ -2690,6 +2690,12 @@
   <data name="ProfilesPage_GPUScalingDesc" xml:space="preserve">
     <value>GPU는 낮은 해상도를 스크린에 맞게 확대합니다</value>
   </data>
+	<data name="ProfilesPage_EnduranceGaming" xml:space="preserve">
+    <value>Endurance Gaming</value>
+  </data>
+	<data name="ProfilesPage_EnduranceGamingDesc" xml:space="preserve">
+    <value>Endurance Gaming Mode extends your gaming sessions by balancing frame rate and power consumption</value>
+  </data>
   <data name="ProfilesPage_ImageSharpening" xml:space="preserve">
     <value>이미지 선명화</value>
   </data>

--- a/HandheldCompanion/Properties/Resources.pt-BR.resx
+++ b/HandheldCompanion/Properties/Resources.pt-BR.resx
@@ -2730,6 +2730,12 @@ Entrada de movimento alternada: Pressione o(s) botão(ões) selecionado(s) para 
   <data name="ProfilesPage_GPUScalingDesc" xml:space="preserve">
     <value>A GPU irá escalonar resoluções mais baixas para preencher na tela</value>
   </data>
+	<data name="ProfilesPage_EnduranceGaming" xml:space="preserve">
+    <value>Endurance Gaming</value>
+  </data>
+	<data name="ProfilesPage_EnduranceGamingDesc" xml:space="preserve">
+    <value>Endurance Gaming Mode extends your gaming sessions by balancing frame rate and power consumption</value>
+  </data>
   <data name="ProfilesPage_ImageSharpening" xml:space="preserve">
     <value>Nitidez de Imagem Radeon</value>
   </data>

--- a/HandheldCompanion/Properties/Resources.resx
+++ b/HandheldCompanion/Properties/Resources.resx
@@ -2730,6 +2730,12 @@ Motion input toggle: press selected button(s) to switch motion state.</value>
   <data name="ProfilesPage_GPUScalingDesc" xml:space="preserve">
     <value>GPU will scale up lower resolutions to fit the display</value>
   </data>
+	<data name="ProfilesPage_EnduranceGaming" xml:space="preserve">
+    <value>Endurance Gaming</value>
+  </data>
+	<data name="ProfilesPage_EnduranceGamingDesc" xml:space="preserve">
+    <value>Endurance Gaming Mode extends your gaming sessions by balancing frame rate and power consumption</value>
+  </data>
   <data name="ProfilesPage_ImageSharpening" xml:space="preserve">
     <value>Image Sharpening</value>
   </data>

--- a/HandheldCompanion/Properties/Resources.ru-RU.resx
+++ b/HandheldCompanion/Properties/Resources.ru-RU.resx
@@ -2686,6 +2686,12 @@
   <data name="ProfilesPage_GPUScalingDesc" xml:space="preserve">
     <value>GPU will scale up lower resolutions to fit the display</value>
   </data>
+	<data name="ProfilesPage_EnduranceGaming" xml:space="preserve">
+    <value>Endurance Gaming</value>
+  </data>
+	<data name="ProfilesPage_EnduranceGamingDesc" xml:space="preserve">
+    <value>Endurance Gaming Mode extends your gaming sessions by balancing frame rate and power consumption</value>
+  </data>
   <data name="ProfilesPage_ImageSharpening" xml:space="preserve">
     <value>Image Sharpening</value>
   </data>

--- a/HandheldCompanion/Properties/Resources.zh-Hans.resx
+++ b/HandheldCompanion/Properties/Resources.zh-Hans.resx
@@ -2708,6 +2708,12 @@
   <data name="ProfilesPage_GPUScalingDesc" xml:space="preserve">
     <value>分辨率较低时，使用GPU放大以适应屏幕</value>
   </data>
+	<data name="ProfilesPage_EnduranceGaming" xml:space="preserve">
+    <value>Endurance Gaming</value>
+  </data>
+	<data name="ProfilesPage_EnduranceGamingDesc" xml:space="preserve">
+    <value>Endurance Gaming Mode extends your gaming sessions by balancing frame rate and power consumption</value>
+  </data>
   <data name="ProfilesPage_ImageSharpening" xml:space="preserve">
     <value>图像锐化</value>
   </data>

--- a/HandheldCompanion/Properties/Resources.zh-Hant.resx
+++ b/HandheldCompanion/Properties/Resources.zh-Hant.resx
@@ -2710,6 +2710,12 @@
   <data name="ProfilesPage_GPUScalingDesc" xml:space="preserve">
     <value>GPU將放大較低的解析度以適應螢幕</value>
   </data>
+	<data name="ProfilesPage_EnduranceGaming" xml:space="preserve">
+    <value>Endurance Gaming</value>
+  </data>
+	<data name="ProfilesPage_EnduranceGamingDesc" xml:space="preserve">
+    <value>Endurance Gaming Mode extends your gaming sessions by balancing frame rate and power consumption</value>
+  </data>
   <data name="ProfilesPage_ImageSharpening" xml:space="preserve">
     <value>圖像銳化</value>
   </data>

--- a/HandheldCompanion/Views/Pages/ProfilesPage.xaml
+++ b/HandheldCompanion/Views/Pages/ProfilesPage.xaml
@@ -715,6 +715,70 @@
                                         </StackPanel>
                                     </ikw:SimpleStackPanel>
 
+
+                                    <!--  Endurance Gaming  -->
+                                    <ikw:SimpleStackPanel
+                                         Name="StackProfileEnduranceGaming"
+                                         IsEnabled="False"
+                                         Spacing="3">
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="5*" />
+                                                <ColumnDefinition Width="5*" />
+                                            </Grid.ColumnDefinitions>
+
+                                            <ikw:SimpleStackPanel VerticalAlignment="Center">
+                                                <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{l:Static resx:Resources.ProfilesPage_EnduranceGaming}" />
+                                                <TextBlock
+                                                     Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                                                     Style="{StaticResource CaptionTextBlockStyle}"
+                                                     Text="{l:Static resx:Resources.ProfilesPage_EnduranceGamingDesc}"
+                                                     TextWrapping="Wrap" />
+                                            </ikw:SimpleStackPanel>
+
+                                            <ui:ToggleSwitch
+                                                 Name="EnduranceGamingToggle"
+                                                 Grid.Column="1"
+                                                 Margin="12,0,0,0"
+                                                 HorizontalAlignment="Right"
+                                                 VerticalAlignment="Center"
+                                                 Style="{DynamicResource InvertedToggleSwitchStyle}"
+                                                 Toggled="EnduranceGamingg_Toggled" />
+                                        </Grid>
+
+                                        <Separator Background="{DynamicResource ExpanderHeaderBackground}" Visibility="{Binding ElementName=EnduranceGamingToggle, Path=IsOn, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
+                                        <StackPanel d:Visibility="Visible" Visibility="{Binding ElementName=EnduranceGamingToggle, Path=IsOn, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                            <Grid>
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="5*" />
+                                                    <ColumnDefinition Width="5*" />
+                                                </Grid.ColumnDefinitions>
+
+                                                <ikw:SimpleStackPanel VerticalAlignment="Center">
+                                                    <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{l:Static resx:Resources.ProfilesPage_EnduranceGamingPreset}" />
+                                                    <TextBlock
+                                                         Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                                                         Style="{StaticResource CaptionTextBlockStyle}"
+                                                         Text="{l:Static resx:Resources.ProfilesPage_EnduranceGamingPresetDesc}"
+                                                         TextWrapping="Wrap" />
+                                                </ikw:SimpleStackPanel>
+
+                                                <ComboBox
+                                                     Name="EnduranceGamingComboBox"
+                                                     Grid.Column="1"
+                                                     Margin="12,0,0,0"
+                                                     HorizontalAlignment="Stretch"
+                                                     VerticalAlignment="Center"
+                                                     SelectionChanged="EnduranceGamingComboBox_SelectionChanged">
+                                                    <ComboBoxItem Content="{l:Static resx:Resources.ProfilesPage_EnduranceGaming_Efficiency}" />
+                                                    <ComboBoxItem Content="{l:Static resx:Resources.ProfilesPage_EnduranceGaming_Balanced}" />
+                                                    <ComboBoxItem Content="{l:Static resx:Resources.ProfilesPage_EnduranceGaming_Performance}" IsEnabled="{Binding ElementName=EnduranceGamingToggle, Path=IsOn, Converter={StaticResource InvertBooleanConverter}}" />
+                                                </ComboBox>
+                                            </Grid>
+                                        </StackPanel>
+                                    </ikw:SimpleStackPanel>
+
                                     <!--  Separator  -->
                                     <Separator
                                         Margin="-46,0,-16,0"

--- a/HandheldCompanion/Views/QuickPages/QuickProfilesPage.xaml
+++ b/HandheldCompanion/Views/QuickPages/QuickProfilesPage.xaml
@@ -769,7 +769,74 @@
                                     </StackPanel>
                                 </ikw:SimpleStackPanel>
 
-                                <!--  Separator  -->
+
+                                <ikw:SimpleStackPanel Margin="0,-10,0,-4" Spacing="3">
+                                    <!--  Endurance Gaming  -->
+                                    <ikw:SimpleStackPanel
+                                        Name="StackProfileEnduranceGaming"
+                                        IsEnabled="False"
+                                        Spacing="3">
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="5*" />
+                                                <ColumnDefinition Width="5*" />
+                                            </Grid.ColumnDefinitions>
+
+                                            <ikw:SimpleStackPanel VerticalAlignment="Center">
+                                                <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{l:Static resx:Resources.ProfilesPage_EnduranceGaming}" />
+                                                <TextBlock
+                                                    Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                                                    Style="{StaticResource CaptionTextBlockStyle}"
+                                                    Text="{l:Static resx:Resources.ProfilesPage_EnduranceGamingDesc}"
+                                                    TextWrapping="Wrap" />
+                                            </ikw:SimpleStackPanel>
+
+                                            <ui:ToggleSwitch
+                                                Name="EnduranceGamingToggle"
+                                                Grid.Column="1"
+                                                Margin="12,0,0,0"
+                                                HorizontalAlignment="Right"
+                                                VerticalAlignment="Center"
+                                                Style="{DynamicResource InvertedToggleSwitchStyle}"
+                                                Toggled="EnduranceGaming_Toggled" />
+                                        </Grid>
+                                    </ikw:SimpleStackPanel>
+                                    
+                                    <Separator Background="{DynamicResource ExpanderHeaderBackground}" Visibility="{Binding ElementName=EnduranceGamingToggle, Path=IsOn, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
+                                        <StackPanel d:Visibility="Visible" Visibility="{Binding ElementName=EnduranceGamingToggle, Path=IsOn, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                            <Grid>
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="5*" />
+                                                    <ColumnDefinition Width="5*" />
+                                                </Grid.ColumnDefinitions>
+
+                                                <ikw:SimpleStackPanel VerticalAlignment="Center">
+                                                    <TextBlock Style="{StaticResource BodyTextBlockStyle}" Text="{l:Static resx:Resources.ProfilesPage_EnduranceGamingPreset}" />
+                                                    <TextBlock
+                                                        Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                                                        Style="{StaticResource CaptionTextBlockStyle}"
+                                                        Text="{l:Static resx:Resources.ProfilesPage_EnduranceGamingPresetDesc}"
+                                                        TextWrapping="Wrap" />
+                                                </ikw:SimpleStackPanel>
+
+                                                <ComboBox
+                                                    Name="EnduranceGamingComboBox"
+                                                    Grid.Column="1"
+                                                    Margin="12,0,0,0"
+                                                    HorizontalAlignment="Stretch"
+                                                    VerticalAlignment="Center"
+                                                    SelectionChanged="EnduranceGamingComboBox_SelectionChanged">
+                                                    <ComboBoxItem Content="{l:Static resx:Resources.ProfilesPage_EnduranceGaming_Performance}" />
+                                                    <ComboBoxItem Content="{l:Static resx:Resources.ProfilesPage_EnduranceGaming_Balanced}" />
+                                                <ComboBoxItem Content="{l:Static resx:Resources.ProfilesPage_EnduranceGaming_Efficiency}" IsEnabled="{Binding ElementName=EnduranceGamingToggle, Path=IsOn, Converter={StaticResource InvertBooleanConverter}}" />
+                                                </ComboBox>
+                                            </Grid>
+                                        </StackPanel>
+                                    </ikw:SimpleStackPanel>
+                                    
+
+                                    <!--  Separator  -->
                                 <Separator Margin="-16,0,-16,0" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}" />
 
                                 <!--  RSR (AMD)  -->


### PR DESCRIPTION
Give the user the option to control and configure Intel's Endurance Gaming in both Profile and Quick Menu.

By default "Super Batter Saver" turns on Endurance Gaming with "Efficiency, which reduces the frame rate to 30 fps.

This gives the user granular control the power saving of Inte's tuning based on FPS, yet still target various fps rates such as 45 in balanced and 60 in performance.