### PR TITLE
Feature: Add Intel Endurance Gaming to Power profile options

### DIFF
--- a/HandheldCompanion/Devices/IDevice.cs
+++ b/HandheldCompanion/Devices/IDevice.cs
@@ -38,6 +38,7 @@ public enum DeviceCapabilities : ushort
     FanOverride = 512,
     OEMCPU = 1024,
     OEMGPU = 2048,
+    IntelEnduranceGaming = 4096,
 }
 
 public enum TDPMethod
@@ -1073,4 +1074,7 @@ public abstract class IDevice
 
         return defaultGlyph;
     }
+
+    public virtual void setEnduranceGamingModePreset(int controlMode = 0, int enduranceGamingPreset = 0)
+    { }
 }

--- a/HandheldCompanion/Managers/PerformanceManager.cs
+++ b/HandheldCompanion/Managers/PerformanceManager.cs
@@ -365,6 +365,8 @@ public static class PerformanceManager
                 IDevice.GetCurrent().SetFanControl(true);
                 break;
         }
+
+        IDevice.GetCurrent().setEnduranceGamingModePreset((int)profile.IntelEnduranceGamingProfile.control, (int)profile.IntelEnduranceGamingProfile.mode);
     }
 
     private static void PowerProfileManager_Discarded(PowerProfile profile)
@@ -415,6 +417,9 @@ public static class PerformanceManager
 
         // restore default Fan mode
         IDevice.GetCurrent().SetFanControl(false, profile.OEMPowerMode);
+
+        // restore Intel Endurance Gaming profile to defaults which is off
+        IDevice.GetCurrent().setEnduranceGamingModePreset(0, 0);
     }
 
     private static void RestoreTDP(bool immediate)

--- a/HandheldCompanion/Misc/IntelEnduranceGamingProfile.cs
+++ b/HandheldCompanion/Misc/IntelEnduranceGamingProfile.cs
@@ -1,0 +1,63 @@
+﻿using HandheldCompanion.Devices;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HandheldCompanion.Misc
+{
+    public enum EnduranceGamingControl
+    {
+        Off = 0,    // Endurance Gaming disable
+        On = 1,     // Endurance Gaming enable
+        Auto = 2,   // Endurance Gaming auto
+    }
+
+    public enum EnduranceGamingMode
+    {
+        Performance = 0,        // Endurance Gaming better performance mode
+        Balanced = 1,           // Endurance Gaming balanced mode
+        MaximumBattery = 2,     // Endurance Gaming maximum battery mode
+    }
+
+    [Serializable]
+    public class IntelEnduranceGamingProfile
+    {
+        public EnduranceGamingControl control = EnduranceGamingControl.Off;
+        public EnduranceGamingMode mode = EnduranceGamingMode.Performance;
+
+        // A public constructor
+        public IntelEnduranceGamingProfile()
+        {
+   
+        }
+
+        // A public constructor that takes an Endurance Gaming parameters as argument
+        public IntelEnduranceGamingProfile(EnduranceGamingControl control, EnduranceGamingMode mode) : this()
+        {
+            this.control = control;
+            this.mode = mode;
+        }
+
+        // A public method that sets Intel Gaming Endurance Mode and its preset
+        public void setEnduranceGamingControlMode(EnduranceGamingControl control, EnduranceGamingMode mode)
+        {
+            this.control = control;
+            this.mode = mode;
+        }
+
+        // A public method that returns the fan speed based on average temperature by linear interpolation
+        public EnduranceGamingControl GetEnduranceGamingControl()
+        {
+            return this.control;
+        }
+
+        // A public method that returns the fan speed based on average temperature by linear interpolation
+        public EnduranceGamingMode GetEnduranceGamingMode()
+        {
+            return this.mode;
+        }
+    }
+}

--- a/HandheldCompanion/Misc/PowerProfile.cs
+++ b/HandheldCompanion/Misc/PowerProfile.cs
@@ -45,6 +45,8 @@ namespace HandheldCompanion.Misc
 
         public FanProfile FanProfile { get; set; } = new();
 
+        public IntelEnduranceGamingProfile IntelEnduranceGamingProfile { get; set; } = new();
+
         public int OEMPowerMode { get; set; } = 0xFF;
         public Guid OSPowerMode { get; set; } = Managers.OSPowerMode.BetterPerformance;
 

--- a/HandheldCompanion/Properties/Resources.Designer.cs
+++ b/HandheldCompanion/Properties/Resources.Designer.cs
@@ -6717,6 +6717,24 @@ namespace HandheldCompanion.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Intel&apos;s GPU Auto TDP based on desired FPS target.
+        /// </summary>
+        public static string PerformancePage_EnduranceGaming_Desc {
+            get {
+                return ResourceManager.GetString("PerformancePage_EnduranceGaming_Desc", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Intel Endurance Gaming.
+        /// </summary>
+        public static string PerformancePage_EnduranceGaming_Title {
+            get {
+                return ResourceManager.GetString("PerformancePage_EnduranceGaming_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Change the power profile fan mode.
         /// </summary>
         public static string PerformancePage_FanMode_Desc {
@@ -8965,6 +8983,42 @@ namespace HandheldCompanion.Properties {
         public static string QuickPerformancePage_CPUUnit {
             get {
                 return ResourceManager.GetString("QuickPerformancePage_CPUUnit", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Balanced - 45 FPS.
+        /// </summary>
+        public static string QuickPerformancePage_EnduranceGamingBalancedPreset {
+            get {
+                return ResourceManager.GetString("QuickPerformancePage_EnduranceGamingBalancedPreset", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Efficiency - 30 FPS.
+        /// </summary>
+        public static string QuickPerformancePage_EnduranceGamingEfficiencyPreset {
+            get {
+                return ResourceManager.GetString("QuickPerformancePage_EnduranceGamingEfficiencyPreset", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Performance - 60 FPS.
+        /// </summary>
+        public static string QuickPerformancePage_EnduranceGamingPerformancePreset {
+            get {
+                return ResourceManager.GetString("QuickPerformancePage_EnduranceGamingPerformancePreset", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Extends your gaming sessions by balancing frame rate and power consumption.
+        /// </summary>
+        public static string QuickPerformancePage_EnduranceGamingPresetDesc {
+            get {
+                return ResourceManager.GetString("QuickPerformancePage_EnduranceGamingPresetDesc", resourceCulture);
             }
         }
         

--- a/HandheldCompanion/Properties/Resources.de-DE.resx
+++ b/HandheldCompanion/Properties/Resources.de-DE.resx
@@ -2805,6 +2805,9 @@ Wenn die Bewegungseingabe aktiviert ist, verwenden Sie die ausgewählte(n) Taste
   <data name="AboutPage_UnsupportedDevice" xml:space="preserve">
     <value />
   </data>
+  <data name="PerformancePage_FanMode_Desc" type="System.Resources.ResXNullRef, System.Windows.Forms">
+    <value />
+  </data>
   <data name="ControllerPage_ControllerManagement_Attempt" xml:space="preserve">
     <value />
   </data>
@@ -2859,8 +2862,8 @@ Wenn die Bewegungseingabe aktiviert ist, verwenden Sie die ausgewählte(n) Taste
   <data name="PerformancePage_CPUParkingMode" xml:space="preserve">
     <value />
   </data>
-  <data name="PerformancePage_CPUParkingModeDesc" xml:space="preserve">
-    <value />
+  <data name="PerformancePage_EnduranceGaming_Desc" xml:space="preserve">
+    <value>Intel's GPU Auto TDP based on desired FPS target</value>
   </data>
   <data name="SettingsPage_Priority" xml:space="preserve">
     <value />
@@ -3056,5 +3059,23 @@ Wenn die Bewegungseingabe aktiviert ist, verwenden Sie die ausgewählte(n) Taste
   </data>
   <data name="SettingsPage_VirtualKeyboardDesc" xml:space="preserve">
     <value />
+  </data>
+  <data name="PerformancePage_EnduranceGaming_Title" xml:space="preserve">
+    <value>Intel Endurance Gaming</value>
+  </data>
+  <data name="PerformancePage_CPUParkingModeDesc" xml:space="preserve">
+    <value />
+  </data>
+  <data name="QuickPerformancePage_EnduranceGamingPresetDesc" xml:space="preserve">
+    <value>Extends your gaming sessions by balancing frame rate and power consumption</value>
+  </data>
+  <data name="QuickPerformancePage_EnduranceGamingPerformancePreset" xml:space="preserve">
+    <value>Performance - 60 FPS</value>
+  </data>
+  <data name="QuickPerformancePage_EnduranceGamingBalancedPreset" xml:space="preserve">
+    <value>Balanced - 45 FPS</value>
+  </data>
+  <data name="QuickPerformancePage_EnduranceGamingEfficiencyPreset" xml:space="preserve">
+    <value>Efficiency - 30 FPS</value>
   </data>
 </root>

--- a/HandheldCompanion/Properties/Resources.es-ES.resx
+++ b/HandheldCompanion/Properties/Resources.es-ES.resx
@@ -2860,8 +2860,8 @@
   <data name="PerformancePage_CPUParkingMode" xml:space="preserve">
     <value />
   </data>
-  <data name="PerformancePage_CPUParkingModeDesc" xml:space="preserve">
-    <value />
+  <data name="PerformancePage_EnduranceGaming_Desc" xml:space="preserve">
+    <value>Intel's GPU Auto TDP based on desired FPS target</value>
   </data>
   <data name="SettingsPage_Priority" xml:space="preserve">
     <value />
@@ -3057,5 +3057,23 @@
   </data>
   <data name="SettingsPage_VirtualKeyboardDesc" xml:space="preserve">
     <value />
+  </data>
+  <data name="PerformancePage_EnduranceGaming_Title" xml:space="preserve">
+    <value>Intel Endurance Gaming</value>
+  </data>
+  <data name="PerformancePage_CPUParkingModeDesc" xml:space="preserve">
+    <value />
+  </data>
+  <data name="QuickPerformancePage_EnduranceGamingPresetDesc" xml:space="preserve">
+    <value>Extends your gaming sessions by balancing frame rate and power consumption</value>
+  </data>
+  <data name="QuickPerformancePage_EnduranceGamingPerformancePreset" xml:space="preserve">
+    <value>Performance - 60 FPS</value>
+  </data>
+  <data name="QuickPerformancePage_EnduranceGamingBalancedPreset" xml:space="preserve">
+    <value>Balanced - 45 FPS</value>
+  </data>
+  <data name="QuickPerformancePage_EnduranceGamingEfficiencyPreset" xml:space="preserve">
+    <value>Efficiency - 30 FPS</value>
   </data>
 </root>

--- a/HandheldCompanion/Properties/Resources.fr-FR.resx
+++ b/HandheldCompanion/Properties/Resources.fr-FR.resx
@@ -2862,8 +2862,8 @@ with motion input enabled, use selected button(s) to disable motion.</value>
   <data name="PerformancePage_CPUParkingMode" xml:space="preserve">
     <value />
   </data>
-  <data name="PerformancePage_CPUParkingModeDesc" xml:space="preserve">
-    <value />
+  <data name="PerformancePage_EnduranceGaming_Desc" xml:space="preserve">
+    <value>Intel's GPU Auto TDP based on desired FPS target</value>
   </data>
   <data name="SettingsPage_Priority" xml:space="preserve">
     <value />
@@ -3059,5 +3059,23 @@ with motion input enabled, use selected button(s) to disable motion.</value>
   </data>
   <data name="SettingsPage_VirtualKeyboardDesc" xml:space="preserve">
     <value />
+  </data>
+  <data name="PerformancePage_EnduranceGaming_Title" xml:space="preserve">
+    <value>Intel Endurance Gaming</value>
+  </data>
+  <data name="PerformancePage_CPUParkingModeDesc" xml:space="preserve">
+    <value />
+  </data>
+  <data name="QuickPerformancePage_EnduranceGamingPresetDesc" xml:space="preserve">
+    <value>Extends your gaming sessions by balancing frame rate and power consumption</value>
+  </data>
+  <data name="QuickPerformancePage_EnduranceGamingPerformancePreset" xml:space="preserve">
+    <value>Performance - 60 FPS</value>
+  </data>
+  <data name="QuickPerformancePage_EnduranceGamingBalancedPreset" xml:space="preserve">
+    <value>Balanced - 45 FPS</value>
+  </data>
+  <data name="QuickPerformancePage_EnduranceGamingEfficiencyPreset" xml:space="preserve">
+    <value>Efficiency - 30 FPS</value>
   </data>
 </root>

--- a/HandheldCompanion/Properties/Resources.it-IT.resx
+++ b/HandheldCompanion/Properties/Resources.it-IT.resx
@@ -2860,8 +2860,8 @@
   <data name="PerformancePage_CPUParkingMode" xml:space="preserve">
     <value />
   </data>
-  <data name="PerformancePage_CPUParkingModeDesc" xml:space="preserve">
-    <value />
+  <data name="PerformancePage_EnduranceGaming_Desc" xml:space="preserve">
+    <value>Intel's GPU Auto TDP based on desired FPS target</value>
   </data>
   <data name="SettingsPage_Priority" xml:space="preserve">
     <value />
@@ -3057,5 +3057,23 @@
   </data>
   <data name="SettingsPage_VirtualKeyboardDesc" xml:space="preserve">
     <value />
+  </data>
+  <data name="PerformancePage_EnduranceGaming_Title" xml:space="preserve">
+    <value>Intel Endurance Gaming</value>
+  </data>
+  <data name="PerformancePage_CPUParkingModeDesc" xml:space="preserve">
+    <value />
+  </data>
+  <data name="QuickPerformancePage_EnduranceGamingPresetDesc" xml:space="preserve">
+    <value>Extends your gaming sessions by balancing frame rate and power consumption</value>
+  </data>
+  <data name="QuickPerformancePage_EnduranceGamingPerformancePreset" xml:space="preserve">
+    <value>Performance - 60 FPS</value>
+  </data>
+  <data name="QuickPerformancePage_EnduranceGamingBalancedPreset" xml:space="preserve">
+    <value>Balanced - 45 FPS</value>
+  </data>
+  <data name="QuickPerformancePage_EnduranceGamingEfficiencyPreset" xml:space="preserve">
+    <value>Efficiency - 30 FPS</value>
   </data>
 </root>

--- a/HandheldCompanion/Properties/Resources.ja-JP.resx
+++ b/HandheldCompanion/Properties/Resources.ja-JP.resx
@@ -2900,8 +2900,8 @@
   <data name="PerformancePage_CPUParkingMode" xml:space="preserve">
     <value />
   </data>
-  <data name="PerformancePage_CPUParkingModeDesc" xml:space="preserve">
-    <value />
+  <data name="PerformancePage_EnduranceGaming_Desc" xml:space="preserve">
+    <value>Intel's GPU Auto TDP based on desired FPS target</value>
   </data>
   <data name="SettingsPage_Priority" xml:space="preserve">
     <value />
@@ -3097,5 +3097,23 @@
   </data>
   <data name="SettingsPage_VirtualKeyboardDesc" xml:space="preserve">
     <value />
+  </data>
+  <data name="PerformancePage_EnduranceGaming_Title" xml:space="preserve">
+    <value>Intel Endurance Gaming</value>
+  </data>
+  <data name="PerformancePage_CPUParkingModeDesc" xml:space="preserve">
+    <value />
+  </data>
+  <data name="QuickPerformancePage_EnduranceGamingPresetDesc" xml:space="preserve">
+    <value>Extends your gaming sessions by balancing frame rate and power consumption</value>
+  </data>
+  <data name="QuickPerformancePage_EnduranceGamingPerformancePreset" xml:space="preserve">
+    <value>Performance - 60 FPS</value>
+  </data>
+  <data name="QuickPerformancePage_EnduranceGamingBalancedPreset" xml:space="preserve">
+    <value>Balanced - 45 FPS</value>
+  </data>
+  <data name="QuickPerformancePage_EnduranceGamingEfficiencyPreset" xml:space="preserve">
+    <value>Efficiency - 30 FPS</value>
   </data>
 </root>

--- a/HandheldCompanion/Properties/Resources.ko-KR.resx
+++ b/HandheldCompanion/Properties/Resources.ko-KR.resx
@@ -3038,6 +3038,9 @@ HC를 사용해 주시고 더 나은 서비스를 제공할 수 있도록 도와
   <data name="ProfilesPage_SuspendOnSleep" xml:space="preserve">
     <value>시스템이 대기 상태에 들어가거나 나올 때 애플리케이션을 일시 중지하고 재개합니다.</value>
   </data>
+  <data name="PerformancePage_EnduranceGaming_Desc" xml:space="preserve">
+    <value>Intel's GPU Auto TDP based on desired FPS target</value>
+  </data>
   <data name="QuickDevicePage_DeviceSettings" xml:space="preserve">
     <value />
   </data>
@@ -3059,6 +3062,18 @@ HC를 사용해 주시고 더 나은 서비스를 제공할 수 있도록 도와
   <data name="QuickDevicePage_NightLightDesc" xml:space="preserve">
     <value />
   </data>
+  <data name="SettingsPage_VirtualTrackpad" xml:space="preserve">
+    <value />
+  </data>
+  <data name="SettingsPage_VirtualTrackpadDesc" xml:space="preserve">
+    <value />
+  </data>
+  <data name="SettingsPage_VirtualKeyboard" xml:space="preserve">
+    <value />
+  </data>
+  <data name="SettingsPage_VirtualKeyboardDesc" xml:space="preserve">
+    <value />
+  </data>
   <data name="ControllerPage_VibrationStrengthExpl" xml:space="preserve">
     <value>컨트롤러의 진동의 세기를 변경</value>
   </data>
@@ -3071,16 +3086,19 @@ HC를 사용해 주시고 더 나은 서비스를 제공할 수 있도록 도와
   <data name="AboutPage_UnsupportedDeviceDesc" xml:space="preserve">
     <value>아직 장치가 지원되지 않는 것 같습니다. 소프트웨어가 예상대로 실행되지 않을 수 있습니다.</value>
   </data>
-  <data name="SettingsPage_VirtualTrackpad" xml:space="preserve">
-    <value />
+  <data name="PerformancePage_EnduranceGaming_Title" xml:space="preserve">
+    <value>Intel Endurance Gaming</value>
   </data>
-  <data name="SettingsPage_VirtualTrackpadDesc" xml:space="preserve">
-    <value />
+  <data name="QuickPerformancePage_EnduranceGamingPresetDesc" xml:space="preserve">
+    <value>Extends your gaming sessions by balancing frame rate and power consumption</value>
   </data>
-  <data name="SettingsPage_VirtualKeyboard" xml:space="preserve">
-    <value />
+  <data name="QuickPerformancePage_EnduranceGamingPerformancePreset" xml:space="preserve">
+    <value>Performance - 60 FPS</value>
   </data>
-  <data name="SettingsPage_VirtualKeyboardDesc" xml:space="preserve">
-    <value />
+  <data name="QuickPerformancePage_EnduranceGamingBalancedPreset" xml:space="preserve">
+    <value>Balanced - 45 FPS</value>
+  </data>
+  <data name="QuickPerformancePage_EnduranceGamingEfficiencyPreset" xml:space="preserve">
+    <value>Efficiency - 30 FPS</value>
   </data>
 </root>

--- a/HandheldCompanion/Properties/Resources.pt-BR.resx
+++ b/HandheldCompanion/Properties/Resources.pt-BR.resx
@@ -3345,8 +3345,8 @@ Obrigado por utilizar o Handheld Companion e nos ajudá-lo a torná-lo melhor.</
   <data name="PerformancePage_CPUParkingMode" xml:space="preserve">
     <value />
   </data>
-  <data name="PerformancePage_CPUParkingModeDesc" xml:space="preserve">
-    <value />
+  <data name="PerformancePage_EnduranceGaming_Desc" xml:space="preserve">
+    <value>Intel's GPU Auto TDP based on desired FPS target</value>
   </data>
   <data name="SettingsPage_Priority" xml:space="preserve">
     <value />
@@ -3539,5 +3539,23 @@ Obrigado por utilizar o Handheld Companion e nos ajudá-lo a torná-lo melhor.</
   </data>
   <data name="SettingsPage_VirtualKeyboardDesc" xml:space="preserve">
     <value />
+  </data>
+  <data name="PerformancePage_EnduranceGaming_Title" xml:space="preserve">
+    <value>Intel Endurance Gaming</value>
+  </data>
+  <data name="PerformancePage_CPUParkingModeDesc" xml:space="preserve">
+    <value />
+  </data>
+  <data name="QuickPerformancePage_EnduranceGamingPresetDesc" xml:space="preserve">
+    <value>Extends your gaming sessions by balancing frame rate and power consumption</value>
+  </data>
+  <data name="QuickPerformancePage_EnduranceGamingPerformancePreset" xml:space="preserve">
+    <value>Performance - 60 FPS</value>
+  </data>
+  <data name="QuickPerformancePage_EnduranceGamingBalancedPreset" xml:space="preserve">
+    <value>Balanced - 45 FPS</value>
+  </data>
+  <data name="QuickPerformancePage_EnduranceGamingEfficiencyPreset" xml:space="preserve">
+    <value>Efficiency - 30 FPS</value>
   </data>
 </root>

--- a/HandheldCompanion/Properties/Resources.resx
+++ b/HandheldCompanion/Properties/Resources.resx
@@ -3366,8 +3366,8 @@ Thank you for using HC and helping us make it better.</value>
   <data name="PerformancePage_CPUParkingMode" xml:space="preserve">
     <value>CPU parking mode</value>
   </data>
-  <data name="PerformancePage_CPUParkingModeDesc" xml:space="preserve">
-    <value>Set current CPU parking mode</value>
+  <data name="PerformancePage_EnduranceGaming_Desc" xml:space="preserve">
+    <value>Intel's GPU Auto TDP based on desired FPS target</value>
   </data>
   <data name="SettingsPage_Priority" xml:space="preserve">
     <value>Priority</value>
@@ -3629,5 +3629,23 @@ Thank you for using HC and helping us make it better.</value>
   </data>
   <data name="SettingsPage_VirtualKeyboardDesc" xml:space="preserve">
     <value>Display virtual keyboard shorcut</value>
+  </data>
+  <data name="PerformancePage_EnduranceGaming_Title" xml:space="preserve">
+    <value>Intel Endurance Gaming</value>
+  </data>
+  <data name="PerformancePage_CPUParkingModeDesc" xml:space="preserve">
+    <value>Set current CPU parking mode</value>
+  </data>
+  <data name="QuickPerformancePage_EnduranceGamingPresetDesc" xml:space="preserve">
+    <value>Extends your gaming sessions by balancing frame rate and power consumption</value>
+  </data>
+  <data name="QuickPerformancePage_EnduranceGamingPerformancePreset" xml:space="preserve">
+    <value>Performance - 60 FPS</value>
+  </data>
+  <data name="QuickPerformancePage_EnduranceGamingBalancedPreset" xml:space="preserve">
+    <value>Balanced - 45 FPS</value>
+  </data>
+  <data name="QuickPerformancePage_EnduranceGamingEfficiencyPreset" xml:space="preserve">
+    <value>Efficiency - 30 FPS</value>
   </data>
 </root>

--- a/HandheldCompanion/Properties/Resources.ru-RU.resx
+++ b/HandheldCompanion/Properties/Resources.ru-RU.resx
@@ -2852,8 +2852,8 @@
   <data name="PerformancePage_CPUParkingMode" xml:space="preserve">
     <value />
   </data>
-  <data name="PerformancePage_CPUParkingModeDesc" xml:space="preserve">
-    <value />
+  <data name="PerformancePage_EnduranceGaming_Desc" xml:space="preserve">
+    <value>Intel's GPU Auto TDP based on desired FPS target</value>
   </data>
   <data name="SettingsPage_Priority" xml:space="preserve">
     <value />
@@ -3049,5 +3049,23 @@
   </data>
   <data name="SettingsPage_VirtualKeyboardDesc" xml:space="preserve">
     <value />
+  </data>
+  <data name="PerformancePage_EnduranceGaming_Title" xml:space="preserve">
+    <value>Intel Endurance Gaming</value>
+  </data>
+  <data name="PerformancePage_CPUParkingModeDesc" xml:space="preserve">
+    <value />
+  </data>
+  <data name="QuickPerformancePage_EnduranceGamingPresetDesc" xml:space="preserve">
+    <value>Extends your gaming sessions by balancing frame rate and power consumption</value>
+  </data>
+  <data name="QuickPerformancePage_EnduranceGamingPerformancePreset" xml:space="preserve">
+    <value>Performance - 60 FPS</value>
+  </data>
+  <data name="QuickPerformancePage_EnduranceGamingBalancedPreset" xml:space="preserve">
+    <value>Balanced - 45 FPS</value>
+  </data>
+  <data name="QuickPerformancePage_EnduranceGamingEfficiencyPreset" xml:space="preserve">
+    <value>Efficiency - 30 FPS</value>
   </data>
 </root>

--- a/HandheldCompanion/Properties/Resources.zh-Hans.resx
+++ b/HandheldCompanion/Properties/Resources.zh-Hans.resx
@@ -3125,8 +3125,8 @@
   <data name="PerformancePage_CPUParkingMode" xml:space="preserve">
     <value>CPU核心调度</value>
   </data>
-  <data name="PerformancePage_CPUParkingModeDesc" xml:space="preserve">
-    <value>设置CPU核心调度模式</value>
+  <data name="PerformancePage_EnduranceGaming_Desc" xml:space="preserve">
+    <value>Intel's GPU Auto TDP based on desired FPS target</value>
   </data>
   <data name="SettingsPage_Priority" xml:space="preserve">
     <value>进程优先级</value>
@@ -3379,5 +3379,23 @@
   </data>
   <data name="SettingsPage_VirtualKeyboardDesc" xml:space="preserve">
     <value />
+  </data>
+  <data name="PerformancePage_EnduranceGaming_Title" xml:space="preserve">
+    <value>Intel Endurance Gaming</value>
+  </data>
+  <data name="PerformancePage_CPUParkingModeDesc" xml:space="preserve">
+    <value>设置CPU核心调度模式</value>
+  </data>
+  <data name="QuickPerformancePage_EnduranceGamingPresetDesc" xml:space="preserve">
+    <value>Extends your gaming sessions by balancing frame rate and power consumption</value>
+  </data>
+  <data name="QuickPerformancePage_EnduranceGamingPerformancePreset" xml:space="preserve">
+    <value>Performance - 60 FPS</value>
+  </data>
+  <data name="QuickPerformancePage_EnduranceGamingBalancedPreset" xml:space="preserve">
+    <value>Balanced - 45 FPS</value>
+  </data>
+  <data name="QuickPerformancePage_EnduranceGamingEfficiencyPreset" xml:space="preserve">
+    <value>Efficiency - 30 FPS</value>
   </data>
 </root>

--- a/HandheldCompanion/Properties/Resources.zh-Hant.resx
+++ b/HandheldCompanion/Properties/Resources.zh-Hant.resx
@@ -3338,6 +3338,9 @@
   <data name="HotkeysPage_Hotkeys" type="System.Resources.ResXNullRef, System.Windows.Forms">
     <value />
   </data>
+  <data name="PerformancePage_EnduranceGaming_Desc" xml:space="preserve">
+    <value>Intel's GPU Auto TDP based on desired FPS target</value>
+  </data>
   <data name="SettingsPage_QuickToolsBackdropHeader" xml:space="preserve">
     <value>工具窗口背景</value>
   </data>
@@ -3517,5 +3520,20 @@
   </data>
   <data name="SettingsPage_VirtualKeyboardDesc" xml:space="preserve">
     <value />
+  </data>
+  <data name="PerformancePage_EnduranceGaming_Title" xml:space="preserve">
+    <value>Intel Endurance Gaming</value>
+  </data>
+  <data name="QuickPerformancePage_EnduranceGamingPresetDesc" xml:space="preserve">
+    <value>Extends your gaming sessions by balancing frame rate and power consumption</value>
+  </data>
+  <data name="QuickPerformancePage_EnduranceGamingPerformancePreset" xml:space="preserve">
+    <value>Performance - 60 FPS</value>
+  </data>
+  <data name="QuickPerformancePage_EnduranceGamingBalancedPreset" xml:space="preserve">
+    <value>Balanced - 45 FPS</value>
+  </data>
+  <data name="QuickPerformancePage_EnduranceGamingEfficiencyPreset" xml:space="preserve">
+    <value>Efficiency - 30 FPS</value>
   </data>
 </root>

--- a/HandheldCompanion/ViewModels/Pages/PerformancePageViewModel.cs
+++ b/HandheldCompanion/ViewModels/Pages/PerformancePageViewModel.cs
@@ -94,6 +94,7 @@ namespace HandheldCompanion.ViewModels
         public double CPUCoreMaximum => MotherboardInfo.NumberOfCores;
 
         public bool SupportsSoftwareFanMode => IDevice.GetCurrent().Capabilities.HasFlag(Devices.DeviceCapabilities.FanControl);
+        public bool SupportsIntelEnduranceGaming => IDevice.GetCurrent().Capabilities.HasFlag(Devices.DeviceCapabilities.IntelEnduranceGaming);
 
         public bool SupportsAutoTDP
         {
@@ -379,6 +380,45 @@ namespace HandheldCompanion.ViewModels
                 {
                     SelectedPreset.FanProfile.fanMode = (FanMode)value;
                     OnPropertyChanged(nameof(FanMode));
+                }
+            }
+        }
+
+        public bool EnduranceGamingEnabled
+        {
+            get => (bool)(SelectedPreset.IntelEnduranceGamingProfile.control == EnduranceGamingControl.Auto);
+            set
+            {
+                if (value != EnduranceGamingEnabled)
+                {
+                    if (value)
+                    {
+                        SelectedPreset.IntelEnduranceGamingProfile.control = EnduranceGamingControl.Auto;
+                    }
+                    else
+                    {
+                        SelectedPreset.IntelEnduranceGamingProfile.control = EnduranceGamingControl.Off;
+                    }
+
+                    IDevice.GetCurrent().setEnduranceGamingModePreset((int)SelectedPreset.IntelEnduranceGamingProfile.control, (int)SelectedPreset.IntelEnduranceGamingProfile.mode);
+
+                    OnPropertyChanged(nameof(EnduranceGamingEnabled));
+                }
+            }
+        }
+
+        public int IntelEnduranceGamingPreset
+        {
+            get => (int)SelectedPreset.IntelEnduranceGamingProfile.mode;
+            set
+            {
+                if (value != IntelEnduranceGamingPreset)
+                {
+                    SelectedPreset.IntelEnduranceGamingProfile.mode = (EnduranceGamingMode)value;
+
+                    IDevice.GetCurrent().setEnduranceGamingModePreset((int)SelectedPreset.IntelEnduranceGamingProfile.control, (int)SelectedPreset.IntelEnduranceGamingProfile.mode);
+
+                    OnPropertyChanged(nameof(IntelEnduranceGamingPreset));
                 }
             }
         }

--- a/HandheldCompanion/Views/Pages/PerformancePage.xaml
+++ b/HandheldCompanion/Views/Pages/PerformancePage.xaml
@@ -148,6 +148,37 @@
             <TextBlock Style="{StaticResource BaseTextBlockStyle}" Text="{l:Static resx:Resources.ProfilesPage_PowerSettings}" />
             <ikw:SimpleStackPanel IsEnabled="{Binding CanChangePreset, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" Spacing="3">
 
+
+                <!--  Intel Endurance Gaming  -->
+                <ui:SettingsExpander
+                    Description="{l:Static resx:Resources.PerformancePage_EnduranceGaming_Desc}"
+                    Header="{l:Static resx:Resources.PerformancePage_EnduranceGaming_Title}"
+                    IsEnabled="{Binding SupportsIntelEnduranceGaming, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
+                    IsExpanded="{Binding ElementName=EnduranceGamingToggle, Path=IsOn, Mode=TwoWay}">
+                    <ui:SettingsExpander.HeaderIcon>
+                        <ui:FontIcon FontFamily="{DynamicResource SymbolThemeFontFamily}" Glyph="&#xe964;" />
+                    </ui:SettingsExpander.HeaderIcon>
+
+                    <ui:ToggleSwitch Name="EnduranceGamingToggle" IsOn="{Binding EnduranceGamingEnabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+
+                    <ui:SettingsExpander.Items>
+                        <ui:SettingsCard Description="{l:Static resx:Resources.QuickPerformancePage_EnduranceGamingPresetDesc}" Header="{l:Static resx:Resources.QuickPerformancePage_EnduranceGamingPreset}">
+                            <ui:SettingsCard.HeaderIcon>
+                                <ui:FontIcon FontFamily="{DynamicResource SymbolThemeFontFamily}" Glyph="&#xec0a;" />
+                            </ui:SettingsCard.HeaderIcon>
+
+                            <ComboBox
+                                HorizontalAlignment="Stretch"
+                                VerticalAlignment="Center"
+                                SelectedIndex="{Binding IntelEnduranceGamingPreset, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                                <ComboBoxItem Name="EnduranceGamingPerformance" Content="{l:Static resx:Resources.QuickPerformancePage_EnduranceGamingPerformancePreset}" />
+                                <ComboBoxItem Name="EnduranceGamingBalanced" Content="{l:Static resx:Resources.QuickPerformancePage_EnduranceGamingBalancedPreset}" />
+                                <ComboBoxItem Name="EnduranceGamingEfficiency" Content="{l:Static resx:Resources.QuickPerformancePage_EnduranceGamingEfficiencyPreset}" />
+                            </ComboBox>
+                        </ui:SettingsCard>
+                    </ui:SettingsExpander.Items>
+                </ui:SettingsExpander>
+                
                 <!--  Maximum CPU Count (already updated)  -->
                 <ui:SettingsExpander
                     Description="{l:Static resx:Resources.PerformancePage_MaxCPU_Desc}"

--- a/HandheldCompanion/Views/QuickPages/QuickPerformancePage.xaml
+++ b/HandheldCompanion/Views/QuickPages/QuickPerformancePage.xaml
@@ -23,6 +23,36 @@
         <ikw:SimpleStackPanel IsEnabled="{Binding CanChangePreset, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" Spacing="3">
             <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="Power settings" />
 
+            <!--  Intel Endurance Gaming  -->
+            <ui:SettingsExpander
+                Description="{l:Static resx:Resources.PerformancePage_EnduranceGaming_Desc}"
+                Header="{l:Static resx:Resources.PerformancePage_EnduranceGaming_Title}"
+                IsEnabled="{Binding SupportsIntelEnduranceGaming, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
+                IsExpanded="{Binding ElementName=EnduranceGamingToggle, Path=IsOn, Mode=TwoWay}">
+                <ui:SettingsExpander.HeaderIcon>
+                    <ui:FontIcon FontFamily="{DynamicResource SymbolThemeFontFamily}" Glyph="&#xe964;" />
+                </ui:SettingsExpander.HeaderIcon>
+
+                <ui:ToggleSwitch Name="EnduranceGamingToggle" IsOn="{Binding EnduranceGamingEnabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+
+                <ui:SettingsExpander.Items>
+                    <ui:SettingsCard Description="{l:Static resx:Resources.QuickPerformancePage_EnduranceGamingPresetDesc}" Header="{l:Static resx:Resources.QuickPerformancePage_EnduranceGamingPreset}">
+                        <ui:SettingsCard.HeaderIcon>
+                            <ui:FontIcon FontFamily="{DynamicResource SymbolThemeFontFamily}" Glyph="&#xec0a;" />
+                        </ui:SettingsCard.HeaderIcon>
+
+                        <ComboBox
+                HorizontalAlignment="Stretch"
+                VerticalAlignment="Center"
+                SelectedIndex="{Binding IntelEnduranceGamingPreset, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                            <ComboBoxItem Name="EnduranceGamingPerformance" Content="{l:Static resx:Resources.QuickPerformancePage_EnduranceGamingPerformancePreset}" />
+                            <ComboBoxItem Name="EnduranceGamingBalanced" Content="{l:Static resx:Resources.QuickPerformancePage_EnduranceGamingBalancedPreset}" />
+                            <ComboBoxItem Name="EnduranceGamingEfficiency" Content="{l:Static resx:Resources.QuickPerformancePage_EnduranceGamingEfficiencyPreset}" />
+                        </ComboBox>
+                    </ui:SettingsCard>
+                </ui:SettingsExpander.Items>
+            </ui:SettingsExpander>
+            
             <!--  Maximum CPU Count  -->
             <ui:SettingsExpander
                 Description="Controls CPU unparked core count limit"


### PR DESCRIPTION
Give the user the option to control and configure Intel's Endurance Gaming in both Profile and Quick Menu.

By default "Super Batter Saver" turns on Endurance Gaming with "Efficiency, which reduces the frame rate to 30 fps.

This gives the user granular control the power saving of Inte's tuning based on FPS.