### PR TITLE
Inherit AYANEOAIRPlus from AYANEO.AYANEODeviceCEii

### DIFF
--- a/HandheldCompanion/Devices/AYANEO/AYANEOAIRPlus.cs
+++ b/HandheldCompanion/Devices/AYANEO/AYANEOAIRPlus.cs
@@ -3,7 +3,7 @@ using System.Numerics;
 
 namespace HandheldCompanion.Devices;
 
-public class AYANEOAIRPlus : AYANEOAIR
+public class AYANEOAIRPlus : AYANEO.AYANEODeviceCEii
 {
     public AYANEOAIRPlus()
     {


### PR DESCRIPTION
On my Ayaneo AIR Plus AMD, I find the RGB control is not working, and a few OEM buttons are not correctly recognized.
I don't know how to confirm which protocol the device is using. But, according to comments in AYANEODeviceCEii.cs, it seems AIR Plus are all using CEii protocol.
I tried on my device and they work well now (although left stick RGB control is still not working #1234).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal device architecture structure for AYANEO AIR Plus device support. No functional changes or user-facing impact.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->