### PR TITLE
feat: add support to delay action bindings

### DIFF
--- a/HandheldCompanion/ViewModels/Layout/Mappings/MappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/MappingViewModel.cs
@@ -99,6 +99,19 @@ namespace HandheldCompanion.ViewModels
             }
         }
 
+        public float StartDelay
+        {
+            get => Action is not null ? Action.StartDelay : 0;
+            set
+            {
+                if (Action is not null && value != StartDelay)
+                {
+                    Action.StartDelay = value;
+                    OnPropertyChanged(nameof(StartDelay));
+                }
+            }
+        }
+
         public ObservableCollection<MappingTargetViewModel> Targets { get; set; } = [];
 
         private MappingTargetViewModel? _selectedTarget;

--- a/HandheldCompanion/Views/TemplatesDictionary.xaml
+++ b/HandheldCompanion/Views/TemplatesDictionary.xaml
@@ -1222,6 +1222,28 @@
                         </DockPanel>
                     </ui:SettingsCard>
 
+                    <!--  Start Delay  -->
+                    <ui:SettingsCard Header="Start delay" Visibility="{Binding ActionTypeIndex, Mode=OneWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource IndexToVisibilityConverter}, ConverterParameter=1|3|4|5|6}">
+                        <DockPanel>
+                            <TextBox
+                                HorizontalContentAlignment="Center"
+                                IsReadOnly="True"
+                                Text="{Binding StartDelay, Mode=OneWay, UpdateSourceTrigger=PropertyChanged, StringFormat={}{0} ms}" />
+
+                            <Slider
+                                Margin="3,0,0,0"
+                                VerticalAlignment="Center"
+                                IsMoveToPointEnabled="True"
+                                IsSnapToTickEnabled="True"
+                                Maximum="1000"
+                                Minimum="0"
+                                TickFrequency="1"
+                                TickPlacement="BottomRight"
+                                ToolTip="{Binding Value, StringFormat=N0, RelativeSource={RelativeSource Self}, Mode=OneWay}"
+                                Value="{Binding StartDelay, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        </DockPanel>
+                    </ui:SettingsCard>
+
                     <!--  Interruptable  -->
                     <ui:SettingsCard Header="{x:Static resx:Resources.LayoutPage_Interruptable}" Visibility="{Binding ActionTypeIndex, Mode=OneWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource IndexToVisibilityConverter}, ConverterParameter=1|3|4|5|6}">
                         <ui:ToggleSwitch IsOn="{Binding HasInterruptable, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{DynamicResource InvertedToggleSwitchStyle}" />
@@ -1812,6 +1834,28 @@
                         </DockPanel>
                     </ui:SettingsCard>
 
+                    <!--  Start Delay  -->
+                    <ui:SettingsCard Header="Start delay" Visibility="{Binding Axis2ButtonVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
+                        <DockPanel>
+                            <TextBox
+                                HorizontalContentAlignment="Center"
+                                IsReadOnly="True"
+                                Text="{Binding StartDelay, Mode=OneWay, UpdateSourceTrigger=PropertyChanged, StringFormat={}{0} ms}" />
+
+                            <Slider
+                                Margin="3,0,0,0"
+                                VerticalAlignment="Center"
+                                IsMoveToPointEnabled="True"
+                                IsSnapToTickEnabled="True"
+                                Maximum="1000"
+                                Minimum="0"
+                                TickFrequency="1"
+                                TickPlacement="BottomRight"
+                                ToolTip="{Binding Value, StringFormat=N0, RelativeSource={RelativeSource Self}, Mode=OneWay}"
+                                Value="{Binding StartDelay, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        </DockPanel>
+                    </ui:SettingsCard>
+
                     <!--  Interruptable  -->
                     <ui:SettingsCard Header="{x:Static resx:Resources.LayoutPage_Interruptable}" Visibility="{Binding Axis2ButtonVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
                         <ui:ToggleSwitch IsOn="{Binding HasInterruptable, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{DynamicResource InvertedToggleSwitchStyle}" />
@@ -2140,6 +2184,28 @@
                                 TickPlacement="BottomRight"
                                 ToolTip="{Binding Value, StringFormat=N0, RelativeSource={RelativeSource Self}, Mode=OneWay}"
                                 Value="{Binding TurboDelay, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        </DockPanel>
+                    </ui:SettingsCard>
+
+                    <!--  Start Delay  -->
+                    <ui:SettingsCard Header="Start delay" Visibility="{Binding Axis2ButtonVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
+                        <DockPanel>
+                            <TextBox
+                                HorizontalContentAlignment="Center"
+                                IsReadOnly="True"
+                                Text="{Binding StartDelay, Mode=OneWay, UpdateSourceTrigger=PropertyChanged, StringFormat={}{0} ms}" />
+
+                            <Slider
+                                Margin="3,0,0,0"
+                                VerticalAlignment="Center"
+                                IsMoveToPointEnabled="True"
+                                IsSnapToTickEnabled="True"
+                                Maximum="1000"
+                                Minimum="0"
+                                TickFrequency="1"
+                                TickPlacement="BottomRight"
+                                ToolTip="{Binding Value, StringFormat=N0, RelativeSource={RelativeSource Self}, Mode=OneWay}"
+                                Value="{Binding StartDelay, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                         </DockPanel>
                     </ui:SettingsCard>
 


### PR DESCRIPTION
Fixes #1344 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable start delay for actions (0–1000 ms). Users can set a delay before an action triggers using a new slider and readout UI element available in button, axis, and trigger mapping contexts. Delay is persisted to mappings and shown in mapping editors where applicable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->