### PR TITLE
Fix XG Mobile hotkey toggle and capability detection

### DIFF
--- a/HandheldCompanion/Commands/Functions/Performance/RogGPU.cs
+++ b/HandheldCompanion/Commands/Functions/Performance/RogGPU.cs
@@ -11,6 +11,9 @@ namespace HandheldCompanion.Commands.Functions.Performance
     [Serializable]
     public class RogGPU : FunctionCommands
     {
+        private static bool? xgMobileSupported;
+        private bool isToggled;
+
         public RogGPU()
         {
             Name = Properties.Resources.Hotkey_XGMobile;
@@ -37,39 +40,63 @@ namespace HandheldCompanion.Commands.Functions.Performance
             "RC73XA", // ROG Xbox Ally X
         };
 
-        private static bool IsSupported
+        private static bool IsSupported()
         {
-            get
+            if (xgMobileSupported.HasValue)
+                return xgMobileSupported.Value && AsusACPI.Open();
+
+            IDevice device = IDevice.GetCurrent();
+
+            if (!device.ManufacturerName.Equals("ASUSTEK COMPUTER INC.", StringComparison.OrdinalIgnoreCase) ||
+                IncompatibleAsusProducts.Contains(device.ProductName))
             {
-                IDevice device = IDevice.GetCurrent();
-
-                if (!device.ManufacturerName.Equals("ASUSTEK COMPUTER INC.", StringComparison.OrdinalIgnoreCase) ||
-                    IncompatibleAsusProducts.Contains(device.ProductName))
-                    return false;
-
-                if (device.Capabilities.HasFlag(DeviceCapabilities.XGMobile))
-                    return AsusACPI.Open();
-
-                // The XG Mobile ACPI endpoint is present on every compatible ASUS host,
-                // including Flow laptops which currently use DefaultDevice in HC.
-                bool isSupported = AsusACPI.Open() && AsusACPI.IsSupported(AsusACPI.GPUXG);
-                if (isSupported)
-                    device.Capabilities |= DeviceCapabilities.XGMobile;
-
-                return isSupported;
+                xgMobileSupported = false;
+                return false;
             }
+
+            if (device.Capabilities.HasFlag(DeviceCapabilities.XGMobile))
+            {
+                xgMobileSupported = true;
+                return AsusACPI.Open();
+            }
+
+            if (!AsusACPI.Open())
+                return false;
+
+            // The XG Mobile ACPI endpoint is present on every compatible ASUS host,
+            // including Flow laptops which currently use DefaultDevice in HC.
+            xgMobileSupported = AsusACPI.IsSupported(AsusACPI.GPUXG);
+            if (xgMobileSupported.Value)
+                device.Capabilities |= DeviceCapabilities.XGMobile;
+
+            return xgMobileSupported.Value;
         }
 
-        public override bool IsToggled => IsSupported && AsusACPI.DeviceGet(AsusACPI.GPUXG) == 1;
+        private static bool TryGetState(out bool toggled)
+        {
+            toggled = false;
+            if (!IsSupported())
+                return false;
+
+            int state = AsusACPI.DeviceGet(AsusACPI.GPUXG);
+            if (state < 0)
+                return false;
+
+            toggled = state == 1;
+            return true;
+        }
+
+        public override bool IsToggled => isToggled;
 
         public override void Execute(bool IsKeyDown, bool IsKeyUp, bool IsBackground)
         {
-            if (IsSupported)
+            if (TryGetState(out bool toggled))
             {
-                bool enable = !IsToggled;
+                bool enable = !toggled;
 
                 if (!enable) XGM.Reset();
-                AsusACPI.SetXGMode(enable);
+                if (AsusACPI.DeviceSet(AsusACPI.GPUXG, enable ? 1 : 0) == 0)
+                    isToggled = enable;
                 if (enable) XGM.Init();
             }
 
@@ -78,7 +105,8 @@ namespace HandheldCompanion.Commands.Functions.Performance
 
         public void Update(HIDmode profileMode = HIDmode.NotSelected)
         {
-            IsEnabled = IsSupported;
+            IsEnabled = TryGetState(out bool toggled);
+            isToggled = IsEnabled && toggled;
 
             base.Update();
         }

--- a/HandheldCompanion/Commands/Functions/Performance/RogGPU.cs
+++ b/HandheldCompanion/Commands/Functions/Performance/RogGPU.cs
@@ -4,6 +4,7 @@ using HandheldCompanion.Managers;
 using HandheldCompanion.Utils;
 using SharpDX.Direct3D9;
 using System;
+using System.Collections.Generic;
 
 namespace HandheldCompanion.Commands.Functions.Performance
 {
@@ -17,7 +18,6 @@ namespace HandheldCompanion.Commands.Functions.Performance
             FontFamily = "Segoe UI Symbol";
             Glyph = "\u2796";
             OnKeyDown = true;
-            deviceType = typeof(ROGAlly);
 
             Update();
 
@@ -30,15 +30,47 @@ namespace HandheldCompanion.Commands.Functions.Performance
             Update();
         }
 
-        public override bool IsToggled => IDevice.GetCurrent() is ROGAlly rOGAlly && AsusACPI.DeviceGet(AsusACPI.GPUXG) == 1;
+        private static readonly HashSet<string> IncompatibleAsusProducts = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "RC72LA", // ROG Ally X
+            "RC73YA", // ROG Xbox Ally
+            "RC73XA", // ROG Xbox Ally X
+        };
+
+        private static bool IsSupported
+        {
+            get
+            {
+                IDevice device = IDevice.GetCurrent();
+
+                if (!device.ManufacturerName.Equals("ASUSTEK COMPUTER INC.", StringComparison.OrdinalIgnoreCase) ||
+                    IncompatibleAsusProducts.Contains(device.ProductName))
+                    return false;
+
+                if (device.Capabilities.HasFlag(DeviceCapabilities.XGMobile))
+                    return AsusACPI.Open();
+
+                // The XG Mobile ACPI endpoint is present on every compatible ASUS host,
+                // including Flow laptops which currently use DefaultDevice in HC.
+                bool isSupported = AsusACPI.Open() && AsusACPI.IsSupported(AsusACPI.GPUXG);
+                if (isSupported)
+                    device.Capabilities |= DeviceCapabilities.XGMobile;
+
+                return isSupported;
+            }
+        }
+
+        public override bool IsToggled => IsSupported && AsusACPI.DeviceGet(AsusACPI.GPUXG) == 1;
 
         public override void Execute(bool IsKeyDown, bool IsKeyUp, bool IsBackground)
         {
-            if (IDevice.GetCurrent() is ROGAlly rOGAlly)
+            if (IsSupported)
             {
-                if (!IsToggled) XGM.Reset();
-                AsusACPI.SetXGMode(IsToggled);
-                if (IsToggled) XGM.Init();
+                bool enable = !IsToggled;
+
+                if (!enable) XGM.Reset();
+                AsusACPI.SetXGMode(enable);
+                if (enable) XGM.Init();
             }
 
             base.Execute(IsKeyDown, IsKeyUp, false);
@@ -46,7 +78,7 @@ namespace HandheldCompanion.Commands.Functions.Performance
 
         public void Update(HIDmode profileMode = HIDmode.NotSelected)
         {
-            IsEnabled = IDevice.GetCurrent() is ROGAlly rOGAlly && AsusACPI.IsXGConnected() == true;
+            IsEnabled = IsSupported;
 
             base.Update();
         }

--- a/HandheldCompanion/Commands/Functions/Performance/RogGPU.cs
+++ b/HandheldCompanion/Commands/Functions/Performance/RogGPU.cs
@@ -4,16 +4,12 @@ using HandheldCompanion.Managers;
 using HandheldCompanion.Utils;
 using SharpDX.Direct3D9;
 using System;
-using System.Collections.Generic;
 
 namespace HandheldCompanion.Commands.Functions.Performance
 {
     [Serializable]
     public class RogGPU : FunctionCommands
     {
-        private static bool? xgMobileSupported;
-        private bool isToggled;
-
         public RogGPU()
         {
             Name = Properties.Resources.Hotkey_XGMobile;
@@ -33,43 +29,9 @@ namespace HandheldCompanion.Commands.Functions.Performance
             Update();
         }
 
-        private static readonly HashSet<string> IncompatibleAsusProducts = new(StringComparer.OrdinalIgnoreCase)
-        {
-            "RC72LA", // ROG Ally X
-            "RC73YA", // ROG Xbox Ally
-            "RC73XA", // ROG Xbox Ally X
-        };
-
         private static bool IsSupported()
         {
-            if (xgMobileSupported.HasValue)
-                return xgMobileSupported.Value && AsusACPI.Open();
-
-            IDevice device = IDevice.GetCurrent();
-
-            if (!device.ManufacturerName.Equals("ASUSTEK COMPUTER INC.", StringComparison.OrdinalIgnoreCase) ||
-                IncompatibleAsusProducts.Contains(device.ProductName))
-            {
-                xgMobileSupported = false;
-                return false;
-            }
-
-            if (device.Capabilities.HasFlag(DeviceCapabilities.XGMobile))
-            {
-                xgMobileSupported = true;
-                return AsusACPI.Open();
-            }
-
-            if (!AsusACPI.Open())
-                return false;
-
-            // The XG Mobile ACPI endpoint is present on every compatible ASUS host,
-            // including Flow laptops which currently use DefaultDevice in HC.
-            xgMobileSupported = AsusACPI.IsSupported(AsusACPI.GPUXG);
-            if (xgMobileSupported.Value)
-                device.Capabilities |= DeviceCapabilities.XGMobile;
-
-            return xgMobileSupported.Value;
+            return IDevice.GetCurrent().Capabilities.HasFlag(DeviceCapabilities.XGMobile);
         }
 
         private static bool TryGetState(out bool toggled)
@@ -86,7 +48,7 @@ namespace HandheldCompanion.Commands.Functions.Performance
             return true;
         }
 
-        public override bool IsToggled => isToggled;
+        public override bool IsToggled => AsusACPI.DeviceGet(AsusACPI.GPUXG) == 1;
 
         public override void Execute(bool IsKeyDown, bool IsKeyUp, bool IsBackground)
         {
@@ -95,8 +57,7 @@ namespace HandheldCompanion.Commands.Functions.Performance
                 bool enable = !toggled;
 
                 if (!enable) XGM.Reset();
-                if (AsusACPI.DeviceSet(AsusACPI.GPUXG, enable ? 1 : 0) == 0)
-                    isToggled = enable;
+                AsusACPI.DeviceSet(AsusACPI.GPUXG, enable ? 1 : 0);
                 if (enable) XGM.Init();
             }
 
@@ -105,8 +66,7 @@ namespace HandheldCompanion.Commands.Functions.Performance
 
         public void Update(HIDmode profileMode = HIDmode.NotSelected)
         {
-            IsEnabled = TryGetState(out bool toggled);
-            isToggled = IsEnabled && toggled;
+            IsEnabled = TryGetState(out _);
 
             base.Update();
         }

--- a/HandheldCompanion/Devices/ASUS/ASUS.cs
+++ b/HandheldCompanion/Devices/ASUS/ASUS.cs
@@ -1,0 +1,19 @@
+using HandheldCompanion.Devices;
+
+namespace HandheldCompanion.Devices.ASUS;
+
+public class ASUS : IDevice
+{
+    public override bool IsOpen => DeviceOpen && AsusACPI.IsOpen;
+
+    public override bool Open()
+    {
+        if (!base.Open() || !AsusACPI.Open())
+            return false;
+
+        if (AsusACPI.IsSupported(AsusACPI.GPUXG))
+            Capabilities |= DeviceCapabilities.XGMobile;
+
+        return true;
+    }
+}

--- a/HandheldCompanion/Devices/ASUS/AsusACPI.cs
+++ b/HandheldCompanion/Devices/ASUS/AsusACPI.cs
@@ -104,7 +104,9 @@ namespace HandheldCompanion.Devices.ASUS
         private const uint FILE_SHARE_READ = 1;
         private const uint FILE_SHARE_WRITE = 2;
 
-        private static IntPtr handle;
+        private static readonly IntPtr INVALID_HANDLE_VALUE = new(-1);
+        private static readonly object handleLock = new();
+        private static IntPtr handle = INVALID_HANDLE_VALUE;
 
         // Event handling attempt
 
@@ -114,7 +116,7 @@ namespace HandheldCompanion.Devices.ASUS
         [DllImport("kernel32.dll", SetLastError = true)]
         private static extern bool WaitForSingleObject(IntPtr hHandle, int dwMilliseconds);
 
-        public static bool IsOpen => handle != new IntPtr(-1);
+        public static bool IsOpen => handle != IntPtr.Zero && handle != INVALID_HANDLE_VALUE;
 
         private static void Control(uint dwIoControlCode, byte[] lpInBuffer, byte[] lpOutBuffer)
         {
@@ -133,29 +135,40 @@ namespace HandheldCompanion.Devices.ASUS
 
         public static bool Open()
         {
-            handle = CreateFile(
-                FILE_NAME,
-                GENERIC_READ | GENERIC_WRITE,
-                FILE_SHARE_READ | FILE_SHARE_WRITE,
-                IntPtr.Zero,
-                OPEN_EXISTING,
-                FILE_ATTRIBUTE_NORMAL,
-                IntPtr.Zero
-            );
-
-            if (!IsOpen)
+            lock (handleLock)
             {
-                LogManager.LogError("Can't connect to Asus ACPI");
-                return false;
-            }
+                if (IsOpen)
+                    return true;
 
-            return true;
+                handle = CreateFile(
+                    FILE_NAME,
+                    GENERIC_READ | GENERIC_WRITE,
+                    FILE_SHARE_READ | FILE_SHARE_WRITE,
+                    IntPtr.Zero,
+                    OPEN_EXISTING,
+                    FILE_ATTRIBUTE_NORMAL,
+                    IntPtr.Zero
+                );
+
+                if (!IsOpen)
+                {
+                    LogManager.LogError("Can't connect to Asus ACPI");
+                    return false;
+                }
+
+                return true;
+            }
         }
 
         public static void Close()
         {
-            if (IsOpen)
-                CloseHandle(handle);
+            lock (handleLock)
+            {
+                if (IsOpen)
+                    CloseHandle(handle);
+
+                handle = INVALID_HANDLE_VALUE;
+            }
         }
 
         public static byte[] CallMethod(uint MethodID, byte[] args)
@@ -215,6 +228,11 @@ namespace HandheldCompanion.Devices.ASUS
             byte[] status = CallMethod(DSTS, args);
 
             return BitConverter.ToInt32(status, 0) - 65536;
+        }
+
+        public static bool IsSupported(uint DeviceID)
+        {
+            return IsOpen && DeviceGet(DeviceID) >= 0;
         }
 
         public static byte[] DeviceGetBuffer(uint DeviceID, uint Status = 0)

--- a/HandheldCompanion/Devices/ASUS/AsusACPI.cs
+++ b/HandheldCompanion/Devices/ASUS/AsusACPI.cs
@@ -120,17 +120,23 @@ namespace HandheldCompanion.Devices.ASUS
 
         private static void Control(uint dwIoControlCode, byte[] lpInBuffer, byte[] lpOutBuffer)
         {
-            uint lpBytesReturned = 0;
-            DeviceIoControl(
-                handle,
-                dwIoControlCode,
-                lpInBuffer,
-                (uint)lpInBuffer.Length,
-                lpOutBuffer,
-                (uint)lpOutBuffer.Length,
-                ref lpBytesReturned,
-                IntPtr.Zero
-            );
+            lock (handleLock)
+            {
+                if (!IsOpen)
+                    return;
+
+                uint lpBytesReturned = 0;
+                DeviceIoControl(
+                    handle,
+                    dwIoControlCode,
+                    lpInBuffer,
+                    (uint)lpInBuffer.Length,
+                    lpOutBuffer,
+                    (uint)lpOutBuffer.Length,
+                    ref lpBytesReturned,
+                    IntPtr.Zero
+                );
+            }
         }
 
         public static bool Open()

--- a/HandheldCompanion/Devices/ASUS/ROGAlly.cs
+++ b/HandheldCompanion/Devices/ASUS/ROGAlly.cs
@@ -115,6 +115,11 @@ public class ROGAlly : IDevice
         Capabilities |= DeviceCapabilities.BatteryChargeLimitPercent;
         Capabilities |= DeviceCapabilities.OEMCPU;
 
+        // Only the original RC71L has the proprietary XG Mobile connector.
+        // Derived Ally X and Xbox Ally models use USB4 instead.
+        if (GetType() == typeof(ROGAlly))
+            Capabilities |= DeviceCapabilities.XGMobile;
+
         // dynamic lighting capacities
         DynamicLightingCapabilities |= LEDLevel.SolidColor;
         DynamicLightingCapabilities |= LEDLevel.Breathing;

--- a/HandheldCompanion/Devices/ASUS/ROGAlly.cs
+++ b/HandheldCompanion/Devices/ASUS/ROGAlly.cs
@@ -14,10 +14,11 @@ using System.Windows.Media;
 using WindowsInput.Events;
 using static HandheldCompanion.Utils.DeviceUtils;
 using Task = System.Threading.Tasks.Task;
+using AsusDevice = HandheldCompanion.Devices.ASUS.ASUS;
 
 namespace HandheldCompanion.Devices;
 
-public class ROGAlly : IDevice
+public class ROGAlly : AsusDevice
 {
     private readonly Dictionary<byte, ButtonFlags> keyMapping = new()
     {
@@ -36,7 +37,7 @@ public class ROGAlly : IDevice
     static byte[] MESSAGE_APPLY = { AURA_HID_ID, 0xb4 };
     static byte[] MESSAGE_SET = { AURA_HID_ID, 0xb5, 0, 0, 0 };
 
-    public override bool IsOpen => hidDevices.ContainsKey(INPUT_HID_ID) && hidDevices[INPUT_HID_ID].IsOpen && AsusACPI.IsOpen;
+    public override bool IsOpen => hidDevices.ContainsKey(INPUT_HID_ID) && hidDevices[INPUT_HID_ID].IsOpen && base.IsOpen;
 
     private enum AuraMode
     {
@@ -114,11 +115,6 @@ public class ROGAlly : IDevice
         Capabilities |= DeviceCapabilities.BatteryChargeLimit;
         Capabilities |= DeviceCapabilities.BatteryChargeLimitPercent;
         Capabilities |= DeviceCapabilities.OEMCPU;
-
-        // Only the original RC71L has the proprietary XG Mobile connector.
-        // Derived Ally X and Xbox Ally models use USB4 instead.
-        if (GetType() == typeof(ROGAlly))
-            Capabilities |= DeviceCapabilities.XGMobile;
 
         // dynamic lighting capacities
         DynamicLightingCapabilities |= LEDLevel.SolidColor;
@@ -213,16 +209,6 @@ public class ROGAlly : IDevice
     private byte[] commitReset3of4 = new byte[] { 0x5A, 0xD1, 0x04, 0x04, 0x00, 0x64, 0x00, 0x64 };
     private byte[] commitReset4of4 = new byte[] { 0x5A, 0xD1, 0x05, 0x04, 0x00, 0x64, 0x00, 0x64 };
     #endregion
-
-    public override bool Open()
-    {
-        bool success = base.Open();
-        if (!success)
-            return false;
-
-        // open Asus ACPI
-        return AsusACPI.Open();
-    }
 
     public override void OpenEvents()
     {

--- a/HandheldCompanion/Devices/IDevice.cs
+++ b/HandheldCompanion/Devices/IDevice.cs
@@ -2,6 +2,7 @@ using HandheldCompanion.Commands.Functions.HC;
 using HandheldCompanion.Commands.Functions.Windows;
 using HandheldCompanion.Controllers;
 using HandheldCompanion.Devices.AYANEO;
+using HandheldCompanion.Devices.ASUS;
 using HandheldCompanion.Devices.Lenovo;
 using HandheldCompanion.Devices.MSI;
 using HandheldCompanion.Devices.OneXPlayer;
@@ -29,6 +30,7 @@ using Windows.Devices.Sensors;
 using WindowsInput.Events;
 using static HandheldCompanion.Devices.IDevice;
 using static HandheldCompanion.Utils.DeviceUtils;
+using AsusDevice = HandheldCompanion.Devices.ASUS.ASUS;
 
 namespace HandheldCompanion.Devices;
 
@@ -831,6 +833,9 @@ public abstract class IDevice
                             break;
                         case "RC73XA":
                             device = new XboxROGAllyX();
+                            break;
+                        default:
+                            device = new AsusDevice();
                             break;
                     }
                 }

--- a/HandheldCompanion/Devices/IDevice.cs
+++ b/HandheldCompanion/Devices/IDevice.cs
@@ -48,6 +48,7 @@ public enum DeviceCapabilities : ushort
     FanOverride = 512,
     OEMCPU = 1024,
     OEMGPU = 2048,
+    XGMobile = 4096,
 }
 
 public enum TDPMethod


### PR DESCRIPTION
## Summary

- make the XG Mobile command toggle the inverse ACPI state
- keep the QuickTools action enabled based on host capability rather than dock connection state
- add an explicit `XGMobile` device capability for the original ROG Ally
- probe the ASUS `GPUXG` ACPI endpoint for compatible Flow systems that currently use `DefaultDevice`
- exclude USB4-only ROG Ally X and Xbox Ally variants
- make the shared ASUS ACPI handle lifecycle safe for idempotent capability probing

## Root cause

`RogGPU.Execute` wrote the existing `IsToggled` value back to ACPI, so it never changed state. Its availability was also restricted to the `ROGAlly` runtime type and current XG Mobile connection state, excluding compatible Flow laptops and leaving the QuickTools control disabled when connection state was unavailable.

## Validation

- Installed test build confirmed on ROG Ally RC71L: QuickTools action is pressable and XG Mobile toggles successfully.
- `dotnet build HandheldCompanion.sln -c Release --no-restore --nologo -v:minimal`
- Result: 0 errors (existing repository warnings remain)

Fixes #1448

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added XG Mobile support for compatible ASUS handheld devices.
  * Improved device detection and capability reporting across ASUS hardware.
  * Added support validation for XG Mobile availability.

* **Bug Fixes**
  * Improved ASUS device communication and connection reliability.
  * Updated XG Mobile controls and status reporting to reflect actual hardware state.
  * Improved handling when supported hardware is unavailable or disconnected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->