### PR TITLE
Add configurable DualSense touchpad actions

### DIFF
--- a/HandheldCompanion/Actions/IActions.cs
+++ b/HandheldCompanion/Actions/IActions.cs
@@ -151,7 +151,7 @@ namespace HandheldCompanion.Actions
 
         public IActions() { }
 
-        public void CopyConfigurationFrom(IActions source)
+        internal void CopyConfigurationFrom(IActions source)
         {
             pressType = source.pressType;
             ActionTimer = source.ActionTimer;

--- a/HandheldCompanion/Actions/IActions.cs
+++ b/HandheldCompanion/Actions/IActions.cs
@@ -151,6 +151,23 @@ namespace HandheldCompanion.Actions
 
         public IActions() { }
 
+        public void CopyConfigurationFrom(IActions source)
+        {
+            pressType = source.pressType;
+            ActionTimer = source.ActionTimer;
+            HasTurbo = source.HasTurbo;
+            HasToggle = source.HasToggle;
+            HasInterruptable = source.HasInterruptable;
+            TurboDelay = source.TurboDelay;
+            StartDelay = source.StartDelay;
+            ShiftSlot = source.ShiftSlot;
+            ShiftMatchAny = source.ShiftMatchAny;
+            HapticMode = source.HapticMode;
+            HapticStrength = source.HapticStrength;
+            motionDirection = source.motionDirection;
+            motionThreshold = source.motionThreshold;
+        }
+
         /// <summary>
         /// Override to share toggle state across bindings targeting the same key/button,
         /// and to detect external releases. Default uses local toggle state.

--- a/HandheldCompanion/Actions/TouchpadActions.cs
+++ b/HandheldCompanion/Actions/TouchpadActions.cs
@@ -1,4 +1,5 @@
 using HandheldCompanion.Inputs;
+using HandheldCompanion.Misc;
 using System;
 
 namespace HandheldCompanion.Actions
@@ -6,11 +7,31 @@ namespace HandheldCompanion.Actions
     [Serializable]
     public sealed class TouchpadActions : ButtonActions
     {
-        public int X = 960;
-        public int Y = 471;
-        public int EndX = 1440;
-        public int EndY = 471;
-        public float SwipeDuration = 300.0f;
+        public const float MinimumSwipeDuration = 16.0f;
+        public const float MaximumSwipeDuration = 5000.0f;
+
+        internal static readonly ButtonFlags[] Targets =
+        [
+            ButtonFlags.TouchpadCoordinateClick,
+            ButtonFlags.TouchpadCoordinateTouch,
+            ButtonFlags.TouchpadSwipe,
+        ];
+
+        private int x = DS4Touch.TOUCHPAD_WIDTH / 2;
+        private int y = DS4Touch.TOUCHPAD_HEIGHT / 2;
+        private int endX = DS4Touch.TOUCHPAD_WIDTH * 3 / 4;
+        private int endY = DS4Touch.TOUCHPAD_HEIGHT / 2;
+        private float swipeDuration = 300.0f;
+
+        public int X { get => x; set => x = Math.Clamp(value, 0, DS4Touch.TOUCHPAD_WIDTH - 1); }
+        public int Y { get => y; set => y = Math.Clamp(value, 0, DS4Touch.TOUCHPAD_HEIGHT - 1); }
+        public int EndX { get => endX; set => endX = Math.Clamp(value, 0, DS4Touch.TOUCHPAD_WIDTH - 1); }
+        public int EndY { get => endY; set => endY = Math.Clamp(value, 0, DS4Touch.TOUCHPAD_HEIGHT - 1); }
+        public float SwipeDuration
+        {
+            get => swipeDuration;
+            set => swipeDuration = Math.Clamp(value, MinimumSwipeDuration, MaximumSwipeDuration);
+        }
 
         [NonSerialized] private bool wasPressed;
         [NonSerialized] private bool swipeActive;
@@ -38,9 +59,9 @@ namespace HandheldCompanion.Actions
             else if (swipeActive)
             {
                 swipeElapsed += delta;
-                if (swipeElapsed >= Math.Max(1.0f, SwipeDuration))
+                if (swipeElapsed >= SwipeDuration)
                 {
-                    swipeElapsed = Math.Max(1.0f, SwipeDuration);
+                    swipeElapsed = SwipeDuration;
                     swipeEndsAfterReport = true;
                 }
             }
@@ -48,26 +69,46 @@ namespace HandheldCompanion.Actions
             wasPressed = pressed;
         }
 
-        public bool ConsumeTouch(out int x, out int y)
+        internal bool TryGetTouch(out TouchpadSample sample)
         {
+            int x;
+            int y;
+            bool active;
+
             if (Button == ButtonFlags.TouchpadSwipe)
             {
-                float duration = Math.Max(1.0f, SwipeDuration);
-                float progress = Math.Clamp(swipeElapsed / duration, 0.0f, 1.0f);
+                float progress = Math.Clamp(swipeElapsed / SwipeDuration, 0.0f, 1.0f);
                 x = (int)MathF.Round(X + (EndX - X) * progress);
                 y = (int)MathF.Round(Y + (EndY - Y) * progress);
-                bool active = swipeActive;
+                active = swipeActive;
                 if (swipeEndsAfterReport)
                 {
                     swipeActive = false;
                     swipeEndsAfterReport = false;
                 }
-                return active;
+            }
+            else
+            {
+                x = X;
+                y = Y;
+                active = GetValue();
             }
 
-            x = X;
-            y = Y;
-            return GetValue();
+            sample = active
+                ? new TouchpadSample(Button, x, y)
+                : default;
+            return active;
         }
+    }
+
+    internal readonly record struct TouchpadSample(ButtonFlags Target, int X, int Y)
+    {
+        public int Priority => Target switch
+        {
+            ButtonFlags.TouchpadCoordinateClick => 3,
+            ButtonFlags.TouchpadSwipe => 2,
+            ButtonFlags.TouchpadCoordinateTouch => 1,
+            _ => 0,
+        };
     }
 }

--- a/HandheldCompanion/Actions/TouchpadActions.cs
+++ b/HandheldCompanion/Actions/TouchpadActions.cs
@@ -21,6 +21,9 @@ namespace HandheldCompanion.Actions
 
         public TouchpadActions(ButtonFlags button) : base(button) { }
 
+        public static bool IsTouchpadTarget(ButtonFlags button) => button is
+            ButtonFlags.TouchpadCoordinateClick or ButtonFlags.TouchpadCoordinateTouch or ButtonFlags.TouchpadSwipe;
+
         public override void Execute(ButtonFlags button, bool value, ShiftSlot shiftSlot, float delta)
         {
             base.Execute(button, value, shiftSlot, delta);
@@ -45,17 +48,14 @@ namespace HandheldCompanion.Actions
             wasPressed = pressed;
         }
 
-        public bool TryGetTouch(out int x, out int y, out bool click)
+        public bool ConsumeTouch(out int x, out int y)
         {
-            click = Button == ButtonFlags.TouchpadCoordinateClick;
-
             if (Button == ButtonFlags.TouchpadSwipe)
             {
                 float duration = Math.Max(1.0f, SwipeDuration);
                 float progress = Math.Clamp(swipeElapsed / duration, 0.0f, 1.0f);
                 x = (int)MathF.Round(X + (EndX - X) * progress);
                 y = (int)MathF.Round(Y + (EndY - Y) * progress);
-                click = false;
                 bool active = swipeActive;
                 if (swipeEndsAfterReport)
                 {

--- a/HandheldCompanion/Actions/TouchpadActions.cs
+++ b/HandheldCompanion/Actions/TouchpadActions.cs
@@ -9,6 +9,7 @@ namespace HandheldCompanion.Actions
     {
         public const float MinimumSwipeDuration = 16.0f;
         public const float MaximumSwipeDuration = 5000.0f;
+        public const float DefaultSwipeDuration = 300.0f;
 
         internal static readonly ButtonFlags[] Targets =
         [
@@ -21,7 +22,7 @@ namespace HandheldCompanion.Actions
         private int y = DS4Touch.TOUCHPAD_HEIGHT / 2;
         private int endX = DS4Touch.TOUCHPAD_WIDTH * 3 / 4;
         private int endY = DS4Touch.TOUCHPAD_HEIGHT / 2;
-        private float swipeDuration = 300.0f;
+        private float swipeDuration = DefaultSwipeDuration;
 
         public int X { get => x; set => x = Math.Clamp(value, 0, DS4Touch.TOUCHPAD_WIDTH - 1); }
         public int Y { get => y; set => y = Math.Clamp(value, 0, DS4Touch.TOUCHPAD_HEIGHT - 1); }
@@ -30,7 +31,9 @@ namespace HandheldCompanion.Actions
         public float SwipeDuration
         {
             get => swipeDuration;
-            set => swipeDuration = Math.Clamp(value, MinimumSwipeDuration, MaximumSwipeDuration);
+            set => swipeDuration = float.IsFinite(value)
+                ? Math.Clamp(value, MinimumSwipeDuration, MaximumSwipeDuration)
+                : DefaultSwipeDuration;
         }
 
         [NonSerialized] private bool wasPressed;

--- a/HandheldCompanion/Actions/TouchpadActions.cs
+++ b/HandheldCompanion/Actions/TouchpadActions.cs
@@ -1,0 +1,73 @@
+using HandheldCompanion.Inputs;
+using System;
+
+namespace HandheldCompanion.Actions
+{
+    [Serializable]
+    public sealed class TouchpadActions : ButtonActions
+    {
+        public int X = 960;
+        public int Y = 471;
+        public int EndX = 1440;
+        public int EndY = 471;
+        public float SwipeDuration = 300.0f;
+
+        [NonSerialized] private bool wasPressed;
+        [NonSerialized] private bool swipeActive;
+        [NonSerialized] private bool swipeEndsAfterReport;
+        [NonSerialized] private float swipeElapsed;
+
+        public TouchpadActions() { }
+
+        public TouchpadActions(ButtonFlags button) : base(button) { }
+
+        public override void Execute(ButtonFlags button, bool value, ShiftSlot shiftSlot, float delta)
+        {
+            base.Execute(button, value, shiftSlot, delta);
+
+            bool pressed = GetValue();
+            if (Button == ButtonFlags.TouchpadSwipe && pressed && !wasPressed)
+            {
+                swipeActive = true;
+                swipeEndsAfterReport = false;
+                swipeElapsed = 0.0f;
+            }
+            else if (swipeActive)
+            {
+                swipeElapsed += delta;
+                if (swipeElapsed >= Math.Max(1.0f, SwipeDuration))
+                {
+                    swipeElapsed = Math.Max(1.0f, SwipeDuration);
+                    swipeEndsAfterReport = true;
+                }
+            }
+
+            wasPressed = pressed;
+        }
+
+        public bool TryGetTouch(out int x, out int y, out bool click)
+        {
+            click = Button == ButtonFlags.TouchpadCoordinateClick;
+
+            if (Button == ButtonFlags.TouchpadSwipe)
+            {
+                float duration = Math.Max(1.0f, SwipeDuration);
+                float progress = Math.Clamp(swipeElapsed / duration, 0.0f, 1.0f);
+                x = (int)MathF.Round(X + (EndX - X) * progress);
+                y = (int)MathF.Round(Y + (EndY - Y) * progress);
+                click = false;
+                bool active = swipeActive;
+                if (swipeEndsAfterReport)
+                {
+                    swipeActive = false;
+                    swipeEndsAfterReport = false;
+                }
+                return active;
+            }
+
+            x = X;
+            y = Y;
+            return GetValue();
+        }
+    }
+}

--- a/HandheldCompanion/Controllers/Dummies/DummyDualSenseController.cs
+++ b/HandheldCompanion/Controllers/Dummies/DummyDualSenseController.cs
@@ -13,9 +13,6 @@ namespace HandheldCompanion.Controllers.Dummies
             TargetButtons.Add(ButtonFlags.RightPadClick);
             TargetButtons.Add(ButtonFlags.CenterPadClick);
             TargetButtons.Add(ButtonFlags.MicrophoneMute);
-            TargetButtons.Add(ButtonFlags.TouchpadCoordinateClick);
-            TargetButtons.Add(ButtonFlags.TouchpadCoordinateTouch);
-            TargetButtons.Add(ButtonFlags.TouchpadSwipe);
             TargetAxis.Add(AxisLayoutFlags.LeftPad);
             TargetAxis.Add(AxisLayoutFlags.RightPad);
         }

--- a/HandheldCompanion/Controllers/Dummies/DummyDualSenseController.cs
+++ b/HandheldCompanion/Controllers/Dummies/DummyDualSenseController.cs
@@ -5,10 +5,25 @@ namespace HandheldCompanion.Controllers.Dummies
 {
     public class DummyDualSenseController : DualSenseController
     {
+        public DummyDualSenseController()
+        {
+            // The dummy describes mapping destinations on the emulated DualSense;
+            // it is not an input device and must not advertise source touchpads.
+            TargetButtons.Add(ButtonFlags.LeftPadClick);
+            TargetButtons.Add(ButtonFlags.RightPadClick);
+            TargetButtons.Add(ButtonFlags.CenterPadClick);
+            TargetButtons.Add(ButtonFlags.MicrophoneMute);
+            TargetButtons.Add(ButtonFlags.TouchpadCoordinateClick);
+            TargetButtons.Add(ButtonFlags.TouchpadCoordinateTouch);
+            TargetButtons.Add(ButtonFlags.TouchpadSwipe);
+            TargetAxis.Add(AxisLayoutFlags.LeftPad);
+            TargetAxis.Add(AxisLayoutFlags.RightPad);
+        }
+
         public override bool IsVirtual() => true;
         public override bool IsDummy() => true;
-        protected override int GetTouchpads() => 1;
-        protected override int GetTouchpadFingers(int touchpad) => 2;
+        protected override int GetTouchpads() => 0;
+        protected override int GetTouchpadFingers(int touchpad) => 0;
 
         public override void Tick(long ticks, float delta, bool commit = false)
         {

--- a/HandheldCompanion/Controllers/SDL/DualSenseController.cs
+++ b/HandheldCompanion/Controllers/SDL/DualSenseController.cs
@@ -20,6 +20,7 @@ namespace HandheldCompanion.Controllers.SDL
                     return "\u2208";
                 case ButtonFlags.LeftPadClick:
                 case ButtonFlags.RightPadClick:
+                case ButtonFlags.CenterPadClick:
                 case ButtonFlags.LeftPadTouch:
                 case ButtonFlags.RightPadTouch:
                     return "\u2207";

--- a/HandheldCompanion/Inputs/ButtonFlags.cs
+++ b/HandheldCompanion/Inputs/ButtonFlags.cs
@@ -179,5 +179,13 @@ public enum ButtonFlags : byte
 
     HOTKEY_END = 150,
 
-    Max = 151
+    [Description("Center Pad Click")] CenterPadClick = 151,
+
+    [Description("Microphone Mute")] MicrophoneMute = 152,
+
+    [Description("Touchpad Click (Coordinate)")] TouchpadCoordinateClick = 153,
+    [Description("Touchpad Touch (Coordinate)")] TouchpadCoordinateTouch = 154,
+    [Description("Touchpad Swipe")] TouchpadSwipe = 155,
+
+    Max = 156
 }

--- a/HandheldCompanion/Managers/LayoutManager.cs
+++ b/HandheldCompanion/Managers/LayoutManager.cs
@@ -627,7 +627,19 @@ public class LayoutManager : IManager
                         {
                             var bA = (ButtonActions)action;
                             bA.Execute(button, pressed, shiftSlot, deltaMs);
-                            outputState.ButtonState[bA.Button] |= bA.GetValue();
+                            if (bA is TouchpadActions touchpadAction)
+                            {
+                                if (touchpadAction.TryGetTouch(out int x, out int y, out bool click))
+                                {
+                                    outputState.ButtonState[touchpadAction.Button] = true;
+                                    outputState.AxisState[AxisFlags.RightPadX] = CoordinateToAxis(x, DS4Touch.TOUCHPAD_WIDTH);
+                                    outputState.AxisState[AxisFlags.RightPadY] = CoordinateToAxis(DS4Touch.TOUCHPAD_HEIGHT - 1 - y, DS4Touch.TOUCHPAD_HEIGHT);
+                                }
+                            }
+                            else
+                            {
+                                outputState.ButtonState[bA.Button] |= bA.GetValue();
+                            }
                             break;
                         }
                     case ActionType.Keyboard:
@@ -660,6 +672,13 @@ public class LayoutManager : IManager
                 ApplyActionStateSideEffects(actions, i);
             }
         }
+    }
+
+    private static short CoordinateToAxis(int value, int extent)
+    {
+        int clamped = Math.Clamp(value, 0, extent - 1);
+        return (short)Math.Clamp((long)clamped * ushort.MaxValue / (extent - 1) + short.MinValue,
+            short.MinValue, short.MaxValue);
     }
 
     /// <summary>

--- a/HandheldCompanion/Managers/LayoutManager.cs
+++ b/HandheldCompanion/Managers/LayoutManager.cs
@@ -551,7 +551,7 @@ public class LayoutManager : IManager
             ShiftSlot shiftSlot = ComputeShiftSlot(controllerState, deltaMs);
 
             ProcessButtonActions(controllerState, shiftSlot, deltaMs, ref touchpadSample);
-            ProcessAxisActions(controllerState, shiftSlot, deltaMs);
+            ProcessAxisActions(controllerState, shiftSlot, deltaMs, ref touchpadSample);
             ApplyTouchpadCoordinates(touchpadSample);
             ProcessGyroActions(controllerState, shiftSlot, deltaMs);
         }
@@ -692,7 +692,8 @@ public class LayoutManager : IManager
     /// <summary>
     /// Third pass: process axis (stick / pad / trigger) actions and write to outputState.
     /// </summary>
-    private void ProcessAxisActions(ControllerState state, ShiftSlot shiftSlot, float deltaMs)
+    private void ProcessAxisActions(ControllerState state, ShiftSlot shiftSlot, float deltaMs,
+        ref TouchpadSample? selectedTouchpadSample)
     {
         for (int a = 0; a < _plannedAxes.Length; a++)
         {
@@ -718,7 +719,20 @@ public class LayoutManager : IManager
                         {
                             var bA = (ButtonActions)action;
                             bA.Execute(layout, shiftSlot, deltaMs);
-                            outputState.ButtonState[bA.Button] |= bA.GetValue();
+                            if (bA is TouchpadActions touchpadAction)
+                            {
+                                if (touchpadAction.TryGetTouch(out TouchpadSample sample))
+                                {
+                                    outputState.ButtonState[touchpadAction.Button] |= true;
+                                    if (selectedTouchpadSample is null ||
+                                        sample.Priority > selectedTouchpadSample.Value.Priority)
+                                        selectedTouchpadSample = sample;
+                                }
+                            }
+                            else
+                            {
+                                outputState.ButtonState[bA.Button] |= bA.GetValue();
+                            }
                             break;
                         }
                     case ActionType.Keyboard:

--- a/HandheldCompanion/Managers/LayoutManager.cs
+++ b/HandheldCompanion/Managers/LayoutManager.cs
@@ -50,9 +50,6 @@ public class LayoutManager : IManager
     private Dictionary<ButtonFlags, IActions[]> _buttonPlan = new();
     private Dictionary<AxisLayoutFlags, IActions[]> _axisPlan = new();
     private Dictionary<AxisLayoutFlags, IActions> _gyroPlan = new();  // one action per axis flag
-    private long touchpadAxisXSum;
-    private long touchpadAxisYSum;
-    private int touchpadCoordinateCount;
 
     // X/Y AxisFlags for each AxisLayoutFlags — cached to avoid per-tick lookups
     private readonly Dictionary<AxisLayoutFlags, (AxisFlags X, AxisFlags Y)> _axisXY = new();
@@ -546,18 +543,16 @@ public class LayoutManager : IManager
             outputState.ButtonState.Clear();
             outputState.AxisState.Clear();
             outputState.GyroState.CopyFrom(controllerState.GyroState);
-            touchpadAxisXSum = 0;
-            touchpadAxisYSum = 0;
-            touchpadCoordinateCount = 0;
+            TouchpadSample? touchpadSample = null;
 
             // delta arrives in seconds; all timer logic expects milliseconds
             float deltaMs = delta * 1000f;
 
             ShiftSlot shiftSlot = ComputeShiftSlot(controllerState, deltaMs);
 
-            ProcessButtonActions(controllerState, shiftSlot, deltaMs);
+            ProcessButtonActions(controllerState, shiftSlot, deltaMs, ref touchpadSample);
             ProcessAxisActions(controllerState, shiftSlot, deltaMs);
-            ApplyTouchpadCoordinates();
+            ApplyTouchpadCoordinates(touchpadSample);
             ProcessGyroActions(controllerState, shiftSlot, deltaMs);
         }
 
@@ -616,7 +611,8 @@ public class LayoutManager : IManager
     /// <summary>
     /// Second pass: process all non-Shift button actions and write to outputState.
     /// </summary>
-    private void ProcessButtonActions(ControllerState state, ShiftSlot shiftSlot, float deltaMs)
+    private void ProcessButtonActions(ControllerState state, ShiftSlot shiftSlot, float deltaMs,
+        ref TouchpadSample? selectedTouchpadSample)
     {
         for (int b = 0; b < _plannedButtons.Length; b++)
         {
@@ -636,12 +632,12 @@ public class LayoutManager : IManager
                             bA.Execute(button, pressed, shiftSlot, deltaMs);
                             if (bA is TouchpadActions touchpadAction)
                             {
-                                if (touchpadAction.ConsumeTouch(out int x, out int y))
+                                if (touchpadAction.TryGetTouch(out TouchpadSample sample))
                                 {
                                     outputState.ButtonState[touchpadAction.Button] |= true;
-                                    touchpadAxisXSum += DS4Touch.CoordinateToAxis(x, DS4Touch.TOUCHPAD_WIDTH);
-                                    touchpadAxisYSum += DS4Touch.CoordinateToAxis(DS4Touch.TOUCHPAD_HEIGHT - 1 - y, DS4Touch.TOUCHPAD_HEIGHT);
-                                    touchpadCoordinateCount++;
+                                    if (selectedTouchpadSample is null ||
+                                        sample.Priority > selectedTouchpadSample.Value.Priority)
+                                        selectedTouchpadSample = sample;
                                 }
                             }
                             else
@@ -682,15 +678,15 @@ public class LayoutManager : IManager
         }
     }
 
-    private void ApplyTouchpadCoordinates()
+    private void ApplyTouchpadCoordinates(TouchpadSample? sample)
     {
-        if (touchpadCoordinateCount == 0)
+        if (sample is null)
             return;
 
-        outputState.AxisState[AxisFlags.RightPadX] = (short)Math.Clamp(
-            Math.Round((double)touchpadAxisXSum / touchpadCoordinateCount), short.MinValue, short.MaxValue);
-        outputState.AxisState[AxisFlags.RightPadY] = (short)Math.Clamp(
-            Math.Round((double)touchpadAxisYSum / touchpadCoordinateCount), short.MinValue, short.MaxValue);
+        outputState.AxisState[AxisFlags.RightPadX] = DS4Touch.CoordinateToAxis(
+            sample.Value.X, DS4Touch.TOUCHPAD_WIDTH);
+        outputState.AxisState[AxisFlags.RightPadY] = DS4Touch.CoordinateToAxis(
+            DS4Touch.TOUCHPAD_HEIGHT - 1 - sample.Value.Y, DS4Touch.TOUCHPAD_HEIGHT);
     }
 
     /// <summary>

--- a/HandheldCompanion/Managers/LayoutManager.cs
+++ b/HandheldCompanion/Managers/LayoutManager.cs
@@ -50,6 +50,9 @@ public class LayoutManager : IManager
     private Dictionary<ButtonFlags, IActions[]> _buttonPlan = new();
     private Dictionary<AxisLayoutFlags, IActions[]> _axisPlan = new();
     private Dictionary<AxisLayoutFlags, IActions> _gyroPlan = new();  // one action per axis flag
+    private long touchpadAxisXSum;
+    private long touchpadAxisYSum;
+    private int touchpadCoordinateCount;
 
     // X/Y AxisFlags for each AxisLayoutFlags — cached to avoid per-tick lookups
     private readonly Dictionary<AxisLayoutFlags, (AxisFlags X, AxisFlags Y)> _axisXY = new();
@@ -543,6 +546,9 @@ public class LayoutManager : IManager
             outputState.ButtonState.Clear();
             outputState.AxisState.Clear();
             outputState.GyroState.CopyFrom(controllerState.GyroState);
+            touchpadAxisXSum = 0;
+            touchpadAxisYSum = 0;
+            touchpadCoordinateCount = 0;
 
             // delta arrives in seconds; all timer logic expects milliseconds
             float deltaMs = delta * 1000f;
@@ -551,6 +557,7 @@ public class LayoutManager : IManager
 
             ProcessButtonActions(controllerState, shiftSlot, deltaMs);
             ProcessAxisActions(controllerState, shiftSlot, deltaMs);
+            ApplyTouchpadCoordinates();
             ProcessGyroActions(controllerState, shiftSlot, deltaMs);
         }
 
@@ -629,11 +636,12 @@ public class LayoutManager : IManager
                             bA.Execute(button, pressed, shiftSlot, deltaMs);
                             if (bA is TouchpadActions touchpadAction)
                             {
-                                if (touchpadAction.TryGetTouch(out int x, out int y, out bool click))
+                                if (touchpadAction.ConsumeTouch(out int x, out int y))
                                 {
-                                    outputState.ButtonState[touchpadAction.Button] = true;
-                                    outputState.AxisState[AxisFlags.RightPadX] = CoordinateToAxis(x, DS4Touch.TOUCHPAD_WIDTH);
-                                    outputState.AxisState[AxisFlags.RightPadY] = CoordinateToAxis(DS4Touch.TOUCHPAD_HEIGHT - 1 - y, DS4Touch.TOUCHPAD_HEIGHT);
+                                    outputState.ButtonState[touchpadAction.Button] |= true;
+                                    touchpadAxisXSum += DS4Touch.CoordinateToAxis(x, DS4Touch.TOUCHPAD_WIDTH);
+                                    touchpadAxisYSum += DS4Touch.CoordinateToAxis(DS4Touch.TOUCHPAD_HEIGHT - 1 - y, DS4Touch.TOUCHPAD_HEIGHT);
+                                    touchpadCoordinateCount++;
                                 }
                             }
                             else
@@ -674,11 +682,15 @@ public class LayoutManager : IManager
         }
     }
 
-    private static short CoordinateToAxis(int value, int extent)
+    private void ApplyTouchpadCoordinates()
     {
-        int clamped = Math.Clamp(value, 0, extent - 1);
-        return (short)Math.Clamp((long)clamped * ushort.MaxValue / (extent - 1) + short.MinValue,
-            short.MinValue, short.MaxValue);
+        if (touchpadCoordinateCount == 0)
+            return;
+
+        outputState.AxisState[AxisFlags.RightPadX] = (short)Math.Clamp(
+            Math.Round((double)touchpadAxisXSum / touchpadCoordinateCount), short.MinValue, short.MaxValue);
+        outputState.AxisState[AxisFlags.RightPadY] = (short)Math.Clamp(
+            Math.Round((double)touchpadAxisYSum / touchpadCoordinateCount), short.MinValue, short.MaxValue);
     }
 
     /// <summary>

--- a/HandheldCompanion/Misc/DS4Touch.cs
+++ b/HandheldCompanion/Misc/DS4Touch.cs
@@ -168,6 +168,19 @@ public static class DS4Touch
         }
     }
 
+    public static short CoordinateToAxis(int value, int extent)
+    {
+        int clamped = Math.Clamp(value, 0, extent - 1);
+        long numerator = (long)clamped * ushort.MaxValue + (extent - 1) / 2;
+        return (short)Math.Clamp(numerator / (extent - 1) + short.MinValue, short.MinValue, short.MaxValue);
+    }
+
+    public static int AxisToCoordinate(short value, int extent)
+    {
+        long numerator = ((long)value - short.MinValue) * (extent - 1) + ushort.MaxValue / 2;
+        return (int)Math.Clamp(numerator / ushort.MaxValue, 0, extent - 1);
+    }
+
     public class TrackPadTouch
     {
         public byte Id;

--- a/HandheldCompanion/Targets/DualSenseTarget.cs
+++ b/HandheldCompanion/Targets/DualSenseTarget.cs
@@ -13,6 +13,10 @@ namespace HandheldCompanion.Targets
         protected override string DeviceType => "dualsenseedge";
         protected override int InputLength => 33;
 
+        private enum ClickRegion : byte { None, Left, Right }
+        private ClickRegion preparedClickRegion;
+        private bool preparedCoordinateClick;
+
         public DualSenseTarget(ushort vendorId, ushort productId) : base(vendorId, productId)
         {
             HID = HIDmode.DualSenseController;
@@ -36,6 +40,36 @@ namespace HandheldCompanion.Targets
             data[2] = (byte)(inputs.AxisState[AxisFlags.RightStickX] >> 8);
             data[3] = (byte)(InputUtils.NegateClampToShort((short)inputs.AxisState[AxisFlags.RightStickY]) >> 8);
 
+            bool leftPadClick = inputs.ButtonState[ButtonFlags.LeftPadClick];
+            bool rightPadClick = inputs.ButtonState[ButtonFlags.RightPadClick];
+            bool coordinateClick = inputs.ButtonState[ButtonFlags.TouchpadCoordinateClick];
+            bool centerPadClick = inputs.ButtonState[ButtonFlags.CenterPadClick] ||
+                (DS4Touch.OutputClickButton && !leftPadClick && !rightPadClick);
+
+            ClickRegion requestedRegion = leftPadClick ? ClickRegion.Left :
+                rightPadClick ? ClickRegion.Right : ClickRegion.None;
+
+            // Steam must see the regional touch before the shared click transitions
+            // down. Otherwise it first classifies the press as the center button.
+            bool emitPadClick = centerPadClick;
+            if (coordinateClick)
+            {
+                emitPadClick = preparedCoordinateClick;
+                preparedCoordinateClick = true;
+                preparedClickRegion = ClickRegion.None;
+            }
+            else if (requestedRegion != ClickRegion.None)
+            {
+                emitPadClick = preparedClickRegion == requestedRegion;
+                preparedClickRegion = requestedRegion;
+                preparedCoordinateClick = false;
+            }
+            else
+            {
+                preparedClickRegion = ClickRegion.None;
+                preparedCoordinateClick = false;
+            }
+
             uint buttons = 0;
             if (inputs.ButtonState[ButtonFlags.B1]) buttons |= 0x0020;
             if (inputs.ButtonState[ButtonFlags.B2]) buttons |= 0x0040;
@@ -48,7 +82,8 @@ namespace HandheldCompanion.Targets
             if (inputs.ButtonState[ButtonFlags.LeftStickClick]) buttons |= 0x4000;
             if (inputs.ButtonState[ButtonFlags.RightStickClick]) buttons |= 0x8000;
             if (inputs.ButtonState[ButtonFlags.Special]) buttons |= 0x00010000;
-            if (inputs.ButtonState[ButtonFlags.LeftPadClick] || inputs.ButtonState[ButtonFlags.RightPadClick] || DS4Touch.OutputClickButton) buttons |= 0x00020000;
+            if (emitPadClick) buttons |= 0x00020000;
+            if (inputs.ButtonState[ButtonFlags.MicrophoneMute]) buttons |= 0x00040000;
             data[4] = (byte)(buttons & 0xFF);
             data[5] = (byte)((buttons >> 8) & 0xFF);
             data[6] = (byte)((buttons >> 16) & 0xFF);
@@ -63,18 +98,24 @@ namespace HandheldCompanion.Targets
             data[9] = (byte)inputs.AxisState[AxisFlags.L2];
             data[10] = (byte)inputs.AxisState[AxisFlags.R2];
 
-            if (DS4Touch.RightPadTouch.IsActive)
-            {
-                ushort touchX = InputUtils.ClampToUShort((int)DS4Touch.RightPadTouch.X, 0, DS4Touch.TOUCHPAD_WIDTH - 1);
-                ushort touchYRaw = InputUtils.ClampToUShort((int)DS4Touch.RightPadTouch.Y, 0, DS4Touch.TOUCHPAD_HEIGHT - 1);
-                ushort touchXScaled = InputUtils.ClampToUShort(touchX * DS4Touch.TOUCHPAD_WIDTH / 1023, 0, DS4Touch.TOUCHPAD_WIDTH);
-                ushort touchYScaled = InputUtils.ClampToUShort(touchYRaw * 1080 / (DS4Touch.TOUCHPAD_HEIGHT - 1), 0, 1080);
-                data[11] = (byte)(touchXScaled & 0xFF);
-                data[12] = (byte)((touchXScaled >> 8) & 0xFF);
-                data[13] = (byte)(touchYScaled & 0xFF);
-                data[14] = (byte)((touchYScaled >> 8) & 0xFF);
-                data[15] = 1;
-            }
+            // A DualSense only has one physical touchpad-click button. Steam splits
+            // left and right from center using a touch which is already active when
+            // that button goes down. A center click is sent without an active touch.
+            bool coordinateTouch = coordinateClick || inputs.ButtonState[ButtonFlags.TouchpadCoordinateTouch] ||
+                inputs.ButtonState[ButtonFlags.TouchpadSwipe];
+
+            if (coordinateTouch)
+                WriteTouch(data,
+                    AxisToCoordinate(inputs.AxisState[AxisFlags.RightPadX], DS4Touch.TOUCHPAD_WIDTH),
+                    DS4Touch.TOUCHPAD_HEIGHT - 1 - AxisToCoordinate(inputs.AxisState[AxisFlags.RightPadY], DS4Touch.TOUCHPAD_HEIGHT));
+            else if (leftPadClick)
+                WriteTouch(data, DS4Touch.TOUCHPAD_WIDTH / 4, DS4Touch.TOUCHPAD_HEIGHT / 2);
+            else if (rightPadClick)
+                WriteTouch(data, DS4Touch.TOUCHPAD_WIDTH * 3 / 4, DS4Touch.TOUCHPAD_HEIGHT / 2);
+            else if (!centerPadClick && DS4Touch.LeftPadTouch.IsActive)
+                WriteTouch(data, DS4Touch.LeftPadTouch.X, DS4Touch.LeftPadTouch.Y);
+            else if (!centerPadClick && DS4Touch.RightPadTouch.IsActive)
+                WriteTouch(data, DS4Touch.RightPadTouch.X, DS4Touch.RightPadTouch.Y);
 
             if (gamepadMotion is not null)
             {
@@ -112,6 +153,23 @@ namespace HandheldCompanion.Targets
             }
 
             return data;
+        }
+
+        private static void WriteTouch(byte[] data, int x, int y)
+        {
+            ushort touchX = InputUtils.ClampToUShort(x, 0, DS4Touch.TOUCHPAD_WIDTH - 1);
+            ushort touchY = InputUtils.ClampToUShort(y, 0, DS4Touch.TOUCHPAD_HEIGHT - 1);
+            data[11] = (byte)(touchX & 0xFF);
+            data[12] = (byte)((touchX >> 8) & 0xFF);
+            data[13] = (byte)(touchY & 0xFF);
+            data[14] = (byte)((touchY >> 8) & 0xFF);
+            data[15] = 1;
+        }
+
+        private static int AxisToCoordinate(short value, int extent)
+        {
+            return (int)Math.Clamp(((long)value - short.MinValue) * (extent - 1) / ushort.MaxValue,
+                0, extent - 1);
         }
     }
 }

--- a/HandheldCompanion/Targets/DualSenseTarget.cs
+++ b/HandheldCompanion/Targets/DualSenseTarget.cs
@@ -13,9 +13,11 @@ namespace HandheldCompanion.Targets
         protected override string DeviceType => "dualsenseedge";
         protected override int InputLength => 33;
 
-        private enum ClickRegion : byte { None, Left, Right }
+        private enum ClickRegion : byte { None, Left, Right, Coordinate }
         private ClickRegion preparedClickRegion;
-        private bool preparedCoordinateClick;
+        private bool preparedClickEmitted;
+        private int preparedTouchX;
+        private int preparedTouchY;
 
         public DualSenseTarget(ushort vendorId, ushort productId) : base(vendorId, productId)
         {
@@ -43,31 +45,53 @@ namespace HandheldCompanion.Targets
             bool leftPadClick = inputs.ButtonState[ButtonFlags.LeftPadClick];
             bool rightPadClick = inputs.ButtonState[ButtonFlags.RightPadClick];
             bool coordinateClick = inputs.ButtonState[ButtonFlags.TouchpadCoordinateClick];
-            bool centerPadClick = inputs.ButtonState[ButtonFlags.CenterPadClick] ||
-                (DS4Touch.OutputClickButton && !leftPadClick && !rightPadClick);
+            bool centerPadClick = !coordinateClick && !leftPadClick && !rightPadClick &&
+                (inputs.ButtonState[ButtonFlags.CenterPadClick] ||
+                (DS4Touch.OutputClickButton && !leftPadClick && !rightPadClick));
 
-            ClickRegion requestedRegion = leftPadClick ? ClickRegion.Left :
+            int coordinateX = DS4Touch.AxisToCoordinate(inputs.AxisState[AxisFlags.RightPadX], DS4Touch.TOUCHPAD_WIDTH);
+            int coordinateY = DS4Touch.TOUCHPAD_HEIGHT - 1 -
+                DS4Touch.AxisToCoordinate(inputs.AxisState[AxisFlags.RightPadY], DS4Touch.TOUCHPAD_HEIGHT);
+
+            ClickRegion requestedRegion = coordinateClick ? ClickRegion.Coordinate :
+                leftPadClick ? ClickRegion.Left :
                 rightPadClick ? ClickRegion.Right : ClickRegion.None;
 
             // Steam must see the regional touch before the shared click transitions
             // down. Otherwise it first classifies the press as the center button.
             bool emitPadClick = centerPadClick;
-            if (coordinateClick)
+            ClickRegion touchClickRegion = requestedRegion;
+            bool consumePreparedClick = false;
+            if (requestedRegion != ClickRegion.None)
             {
-                emitPadClick = preparedCoordinateClick;
-                preparedCoordinateClick = true;
-                preparedClickRegion = ClickRegion.None;
+                if (requestedRegion == ClickRegion.Coordinate)
+                {
+                    preparedTouchX = coordinateX;
+                    preparedTouchY = coordinateY;
+                }
+
+                if (preparedClickRegion == requestedRegion)
+                {
+                    emitPadClick = true;
+                    preparedClickEmitted = true;
+                }
+                else
+                {
+                    preparedClickRegion = requestedRegion;
+                    preparedClickEmitted = false;
+                }
             }
-            else if (requestedRegion != ClickRegion.None)
+            else if (preparedClickRegion != ClickRegion.None && !preparedClickEmitted)
             {
-                emitPadClick = preparedClickRegion == requestedRegion;
-                preparedClickRegion = requestedRegion;
-                preparedCoordinateClick = false;
+                // Preserve a one-report tap long enough to emit the click after
+                // its preparatory touch report.
+                emitPadClick = true;
+                touchClickRegion = preparedClickRegion;
+                consumePreparedClick = true;
             }
             else
             {
-                preparedClickRegion = ClickRegion.None;
-                preparedCoordinateClick = false;
+                ClearPreparedClick();
             }
 
             uint buttons = 0;
@@ -104,18 +128,23 @@ namespace HandheldCompanion.Targets
             bool coordinateTouch = coordinateClick || inputs.ButtonState[ButtonFlags.TouchpadCoordinateTouch] ||
                 inputs.ButtonState[ButtonFlags.TouchpadSwipe];
 
-            if (coordinateTouch)
-                WriteTouch(data,
-                    AxisToCoordinate(inputs.AxisState[AxisFlags.RightPadX], DS4Touch.TOUCHPAD_WIDTH),
-                    DS4Touch.TOUCHPAD_HEIGHT - 1 - AxisToCoordinate(inputs.AxisState[AxisFlags.RightPadY], DS4Touch.TOUCHPAD_HEIGHT));
-            else if (leftPadClick)
+            data[15] = 0; // VIIPER Touch1Active validity flag
+            if (touchClickRegion == ClickRegion.Coordinate)
+                WriteTouch(data, coordinateClick ? coordinateX : preparedTouchX,
+                    coordinateClick ? coordinateY : preparedTouchY);
+            else if (touchClickRegion == ClickRegion.Left)
                 WriteTouch(data, DS4Touch.TOUCHPAD_WIDTH / 4, DS4Touch.TOUCHPAD_HEIGHT / 2);
-            else if (rightPadClick)
+            else if (touchClickRegion == ClickRegion.Right)
                 WriteTouch(data, DS4Touch.TOUCHPAD_WIDTH * 3 / 4, DS4Touch.TOUCHPAD_HEIGHT / 2);
+            else if (coordinateTouch)
+                WriteTouch(data, coordinateX, coordinateY);
             else if (!centerPadClick && DS4Touch.LeftPadTouch.IsActive)
                 WriteTouch(data, DS4Touch.LeftPadTouch.X, DS4Touch.LeftPadTouch.Y);
             else if (!centerPadClick && DS4Touch.RightPadTouch.IsActive)
                 WriteTouch(data, DS4Touch.RightPadTouch.X, DS4Touch.RightPadTouch.Y);
+
+            if (consumePreparedClick)
+                ClearPreparedClick();
 
             if (gamepadMotion is not null)
             {
@@ -166,10 +195,10 @@ namespace HandheldCompanion.Targets
             data[15] = 1;
         }
 
-        private static int AxisToCoordinate(short value, int extent)
+        private void ClearPreparedClick()
         {
-            return (int)Math.Clamp(((long)value - short.MinValue) * (extent - 1) / ushort.MaxValue,
-                0, extent - 1);
+            preparedClickRegion = ClickRegion.None;
+            preparedClickEmitted = false;
         }
     }
 }

--- a/HandheldCompanion/Targets/DualSenseTarget.cs
+++ b/HandheldCompanion/Targets/DualSenseTarget.cs
@@ -14,10 +14,7 @@ namespace HandheldCompanion.Targets
         protected override int InputLength => 33;
 
         private enum ClickRegion : byte { None, Left, Right, Coordinate }
-        private ClickRegion preparedClickRegion;
-        private bool preparedClickEmitted;
-        private int preparedTouchX;
-        private int preparedTouchY;
+        private readonly TouchpadClickSequencer touchpadClickSequencer = new();
 
         public DualSenseTarget(ushort vendorId, ushort productId) : base(vendorId, productId)
         {
@@ -57,42 +54,8 @@ namespace HandheldCompanion.Targets
                 leftPadClick ? ClickRegion.Left :
                 rightPadClick ? ClickRegion.Right : ClickRegion.None;
 
-            // Steam must see the regional touch before the shared click transitions
-            // down. Otherwise it first classifies the press as the center button.
-            bool emitPadClick = centerPadClick;
-            ClickRegion touchClickRegion = requestedRegion;
-            bool consumePreparedClick = false;
-            if (requestedRegion != ClickRegion.None)
-            {
-                if (requestedRegion == ClickRegion.Coordinate)
-                {
-                    preparedTouchX = coordinateX;
-                    preparedTouchY = coordinateY;
-                }
-
-                if (preparedClickRegion == requestedRegion)
-                {
-                    emitPadClick = true;
-                    preparedClickEmitted = true;
-                }
-                else
-                {
-                    preparedClickRegion = requestedRegion;
-                    preparedClickEmitted = false;
-                }
-            }
-            else if (preparedClickRegion != ClickRegion.None && !preparedClickEmitted)
-            {
-                // Preserve a one-report tap long enough to emit the click after
-                // its preparatory touch report.
-                emitPadClick = true;
-                touchClickRegion = preparedClickRegion;
-                consumePreparedClick = true;
-            }
-            else
-            {
-                ClearPreparedClick();
-            }
+            TouchpadClickFrame clickFrame = touchpadClickSequencer.Resolve(
+                requestedRegion, centerPadClick, coordinateX, coordinateY);
 
             uint buttons = 0;
             if (inputs.ButtonState[ButtonFlags.B1]) buttons |= 0x0020;
@@ -106,7 +69,7 @@ namespace HandheldCompanion.Targets
             if (inputs.ButtonState[ButtonFlags.LeftStickClick]) buttons |= 0x4000;
             if (inputs.ButtonState[ButtonFlags.RightStickClick]) buttons |= 0x8000;
             if (inputs.ButtonState[ButtonFlags.Special]) buttons |= 0x00010000;
-            if (emitPadClick) buttons |= 0x00020000;
+            if (clickFrame.EmitClick) buttons |= 0x00020000;
             if (inputs.ButtonState[ButtonFlags.MicrophoneMute]) buttons |= 0x00040000;
             data[4] = (byte)(buttons & 0xFF);
             data[5] = (byte)((buttons >> 8) & 0xFF);
@@ -129,12 +92,11 @@ namespace HandheldCompanion.Targets
                 inputs.ButtonState[ButtonFlags.TouchpadSwipe];
 
             data[15] = 0; // VIIPER Touch1Active validity flag
-            if (touchClickRegion == ClickRegion.Coordinate)
-                WriteTouch(data, coordinateClick ? coordinateX : preparedTouchX,
-                    coordinateClick ? coordinateY : preparedTouchY);
-            else if (touchClickRegion == ClickRegion.Left)
+            if (clickFrame.Region == ClickRegion.Coordinate)
+                WriteTouch(data, clickFrame.X, clickFrame.Y);
+            else if (clickFrame.Region == ClickRegion.Left)
                 WriteTouch(data, DS4Touch.TOUCHPAD_WIDTH / 4, DS4Touch.TOUCHPAD_HEIGHT / 2);
-            else if (touchClickRegion == ClickRegion.Right)
+            else if (clickFrame.Region == ClickRegion.Right)
                 WriteTouch(data, DS4Touch.TOUCHPAD_WIDTH * 3 / 4, DS4Touch.TOUCHPAD_HEIGHT / 2);
             else if (coordinateTouch)
                 WriteTouch(data, coordinateX, coordinateY);
@@ -142,9 +104,6 @@ namespace HandheldCompanion.Targets
                 WriteTouch(data, DS4Touch.LeftPadTouch.X, DS4Touch.LeftPadTouch.Y);
             else if (!centerPadClick && DS4Touch.RightPadTouch.IsActive)
                 WriteTouch(data, DS4Touch.RightPadTouch.X, DS4Touch.RightPadTouch.Y);
-
-            if (consumePreparedClick)
-                ClearPreparedClick();
 
             if (gamepadMotion is not null)
             {
@@ -195,10 +154,62 @@ namespace HandheldCompanion.Targets
             data[15] = 1;
         }
 
-        private void ClearPreparedClick()
+        private readonly record struct TouchpadClickFrame(bool EmitClick, ClickRegion Region, int X, int Y);
+
+        private sealed class TouchpadClickSequencer
         {
-            preparedClickRegion = ClickRegion.None;
-            preparedClickEmitted = false;
+            private ClickRegion preparedRegion;
+            private bool preparedClickEmitted;
+            private int preparedX;
+            private int preparedY;
+
+            public TouchpadClickFrame Resolve(ClickRegion requestedRegion, bool centerClick, int x, int y)
+            {
+                bool emitClick = centerClick;
+                ClickRegion touchRegion = requestedRegion;
+
+                if (requestedRegion != ClickRegion.None)
+                {
+                    if (requestedRegion == ClickRegion.Coordinate)
+                    {
+                        preparedX = x;
+                        preparedY = y;
+                    }
+
+                    if (preparedRegion == requestedRegion)
+                    {
+                        emitClick = true;
+                        preparedClickEmitted = true;
+                    }
+                    else
+                    {
+                        preparedRegion = requestedRegion;
+                        preparedClickEmitted = false;
+                    }
+                }
+                else if (preparedRegion != ClickRegion.None && !preparedClickEmitted)
+                {
+                    // Preserve a one-report tap long enough to emit the click after
+                    // its preparatory touch report.
+                    emitClick = true;
+                    touchRegion = preparedRegion;
+                    Clear();
+                }
+                else
+                {
+                    Clear();
+                }
+
+                return new TouchpadClickFrame(emitClick, touchRegion,
+                    touchRegion == ClickRegion.Coordinate ? preparedX : x,
+                    touchRegion == ClickRegion.Coordinate ? preparedY : y);
+            }
+
+            private void Clear()
+            {
+                preparedRegion = ClickRegion.None;
+                preparedClickEmitted = false;
+            }
         }
     }
 }

--- a/HandheldCompanion/ViewModels/HotkeyViewModel.cs
+++ b/HandheldCompanion/ViewModels/HotkeyViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using HandheldCompanion.Commands;
 using HandheldCompanion.Commands.Functions.HC;
+using HandheldCompanion.Actions;
 using HandheldCompanion.Commands.Functions.Windows;
 using HandheldCompanion.Controllers;
 using HandheldCompanion.Devices;
@@ -778,6 +779,9 @@ namespace HandheldCompanion.ViewModels
             {
                 foreach (var button in controller.GetTargetButtons())
                 {
+                    if (TouchpadActions.IsTouchpadTarget(button))
+                        continue;
+
                     newValues.Add(new MappingTargetViewModel
                     {
                         Tag = button,

--- a/HandheldCompanion/ViewModels/HotkeyViewModel.cs
+++ b/HandheldCompanion/ViewModels/HotkeyViewModel.cs
@@ -1,6 +1,5 @@
 ﻿using HandheldCompanion.Commands;
 using HandheldCompanion.Commands.Functions.HC;
-using HandheldCompanion.Actions;
 using HandheldCompanion.Commands.Functions.Windows;
 using HandheldCompanion.Controllers;
 using HandheldCompanion.Devices;
@@ -779,9 +778,6 @@ namespace HandheldCompanion.ViewModels
             {
                 foreach (var button in controller.GetTargetButtons())
                 {
-                    if (TouchpadActions.IsTouchpadTarget(button))
-                        continue;
-
                     newValues.Add(new MappingTargetViewModel
                     {
                         Tag = button,

--- a/HandheldCompanion/ViewModels/Layout/Mappings/AxisMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/AxisMappingViewModel.cs
@@ -751,9 +751,6 @@ namespace HandheldCompanion.ViewModels
                 MappingTargetViewModel? matchingTargetVm = null;
                 foreach (var button in controller.GetTargetButtons())
                 {
-                    if (TouchpadActions.IsTouchpadTarget(button))
-                        continue;
-
                     var mappingTargetVm = CreateTarget(button, controller.GetButtonName(button));
                     targets.Add(mappingTargetVm);
 

--- a/HandheldCompanion/ViewModels/Layout/Mappings/AxisMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/AxisMappingViewModel.cs
@@ -751,6 +751,9 @@ namespace HandheldCompanion.ViewModels
                 MappingTargetViewModel? matchingTargetVm = null;
                 foreach (var button in controller.GetTargetButtons())
                 {
+                    if (TouchpadActions.IsTouchpadTarget(button))
+                        continue;
+
                     var mappingTargetVm = CreateTarget(button, controller.GetButtonName(button));
                     targets.Add(mappingTargetVm);
 

--- a/HandheldCompanion/ViewModels/Layout/Mappings/AxisMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/AxisMappingViewModel.cs
@@ -377,6 +377,12 @@ namespace HandheldCompanion.ViewModels
         public override Visibility Axis2JoystickVisibility => Axis2MouseVisibility == Visibility.Visible && JoystickVisibility == Visibility.Visible ? Visibility.Visible : Visibility.Collapsed;
 
         public override bool IsAxisMapping => true;
+        public override Visibility TouchpadSettingsVisibility =>
+            ActionTypeIndex == (int)ActionType.Button && Action is TouchpadActions
+                ? Visibility.Visible : Visibility.Collapsed;
+        public override Visibility TouchpadSwipeSettingsVisibility =>
+            ActionTypeIndex == (int)ActionType.Button && Action is TouchpadActions { Button: ButtonFlags.TouchpadSwipe }
+                ? Visibility.Visible : Visibility.Collapsed;
 
         // Axis Direction and Threshold are only visible when converting Axis to Button
         public override Visibility AxisDirectionVisibility => Axis2ButtonVisibility;
@@ -749,7 +755,7 @@ namespace HandheldCompanion.ViewModels
                 }
 
                 MappingTargetViewModel? matchingTargetVm = null;
-                foreach (var button in controller.GetTargetButtons())
+                foreach (var button in GetButtonTargets(controller))
                 {
                     var mappingTargetVm = CreateTarget(button, controller.GetButtonName(button));
                     targets.Add(mappingTargetVm);
@@ -843,7 +849,10 @@ namespace HandheldCompanion.ViewModels
             {
                 case ActionType.Button:
                     if (SelectedTarget.Tag is ButtonFlags buttonFlags)
-                        ((ButtonActions)Action).Button = buttonFlags;
+                    {
+                        SetButtonTarget(buttonFlags);
+                        OnPropertyChanged(string.Empty);
+                    }
                     break;
 
                 case ActionType.Keyboard:

--- a/HandheldCompanion/ViewModels/Layout/Mappings/ButtonMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/ButtonMappingViewModel.cs
@@ -382,6 +382,10 @@ namespace HandheldCompanion.ViewModels
         public Visibility TouchpadSettingsVisibility => Action is TouchpadActions ? Visibility.Visible : Visibility.Collapsed;
         public Visibility TouchpadSwipeSettingsVisibility => Action is TouchpadActions touchpad && touchpad.Button == ButtonFlags.TouchpadSwipe
             ? Visibility.Visible : Visibility.Collapsed;
+        public int TouchpadMaxX => DS4Touch.TOUCHPAD_WIDTH - 1;
+        public int TouchpadMaxY => DS4Touch.TOUCHPAD_HEIGHT - 1;
+        public double TouchpadMaxDuration => 5000.0;
+        public string TouchpadCoordinateRangeDescription => $"DualSense coordinates: X 0–{TouchpadMaxX}, Y 0–{TouchpadMaxY}";
         public int TouchpadX { get => Action is TouchpadActions a ? a.X : 0; set { if (Action is TouchpadActions a) { a.X = Math.Clamp(value, 0, DS4Touch.TOUCHPAD_WIDTH - 1); OnPropertyChanged(nameof(TouchpadX)); } } }
         public int TouchpadY { get => Action is TouchpadActions a ? a.Y : 0; set { if (Action is TouchpadActions a) { a.Y = Math.Clamp(value, 0, DS4Touch.TOUCHPAD_HEIGHT - 1); OnPropertyChanged(nameof(TouchpadY)); } } }
         public int TouchpadEndX { get => Action is TouchpadActions a ? a.EndX : 0; set { if (Action is TouchpadActions a) { a.EndX = Math.Clamp(value, 0, DS4Touch.TOUCHPAD_WIDTH - 1); OnPropertyChanged(nameof(TouchpadEndX)); } } }
@@ -651,9 +655,17 @@ namespace HandheldCompanion.ViewModels
                             ButtonFlags.TouchpadCoordinateTouch or ButtonFlags.TouchpadSwipe;
 
                         if (isTouchpadAction && Action is not TouchpadActions)
-                            Action = new TouchpadActions(buttonFlags) { pressType = (PressType)_pressTypeFallbackIndex };
+                        {
+                            IActions previous = Action;
+                            Action = new TouchpadActions(buttonFlags);
+                            Action.CopyConfigurationFrom(previous);
+                        }
                         else if (!isTouchpadAction && Action is TouchpadActions)
-                            Action = new ButtonActions(buttonFlags) { pressType = (PressType)_pressTypeFallbackIndex };
+                        {
+                            IActions previous = Action;
+                            Action = new ButtonActions(buttonFlags);
+                            Action.CopyConfigurationFrom(previous);
+                        }
                         else
                             ((ButtonActions)Action).Button = buttonFlags;
 

--- a/HandheldCompanion/ViewModels/Layout/Mappings/ButtonMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/ButtonMappingViewModel.cs
@@ -380,9 +380,12 @@ namespace HandheldCompanion.ViewModels
             }
         }
 
-        public Visibility TouchpadSettingsVisibility => Action is TouchpadActions ? Visibility.Visible : Visibility.Collapsed;
-        public Visibility TouchpadSwipeSettingsVisibility => Action is TouchpadActions touchpad && touchpad.Button == ButtonFlags.TouchpadSwipe
-            ? Visibility.Visible : Visibility.Collapsed;
+        public override Visibility TouchpadSettingsVisibility =>
+            ActionTypeIndex == (int)ActionType.Button && Action is TouchpadActions
+                ? Visibility.Visible : Visibility.Collapsed;
+        public override Visibility TouchpadSwipeSettingsVisibility =>
+            ActionTypeIndex == (int)ActionType.Button && Action is TouchpadActions { Button: ButtonFlags.TouchpadSwipe }
+                ? Visibility.Visible : Visibility.Collapsed;
         public int TouchpadMaxX => DS4Touch.TOUCHPAD_WIDTH - 1;
         public int TouchpadMaxY => DS4Touch.TOUCHPAD_HEIGHT - 1;
         public double TouchpadMaxDuration => TouchpadActions.MaximumSwipeDuration;

--- a/HandheldCompanion/ViewModels/Layout/Mappings/ButtonMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/ButtonMappingViewModel.cs
@@ -1,7 +1,6 @@
 ﻿using GregsStack.InputSimulatorStandard.Native;
 using HandheldCompanion.Actions;
 using HandheldCompanion.Controllers;
-using HandheldCompanion.Controllers.Dummies;
 using HandheldCompanion.Inputs;
 using HandheldCompanion.Managers;
 using HandheldCompanion.Properties;
@@ -386,15 +385,6 @@ namespace HandheldCompanion.ViewModels
         public override Visibility TouchpadSwipeSettingsVisibility =>
             ActionTypeIndex == (int)ActionType.Button && Action is TouchpadActions { Button: ButtonFlags.TouchpadSwipe }
                 ? Visibility.Visible : Visibility.Collapsed;
-        public int TouchpadMaxX => DS4Touch.TOUCHPAD_WIDTH - 1;
-        public int TouchpadMaxY => DS4Touch.TOUCHPAD_HEIGHT - 1;
-        public double TouchpadMaxDuration => TouchpadActions.MaximumSwipeDuration;
-        public string TouchpadCoordinateRangeDescription => $"DualSense coordinates: X 0–{TouchpadMaxX}, Y 0–{TouchpadMaxY}";
-        public int TouchpadX { get => Action is TouchpadActions a ? a.X : 0; set { if (Action is TouchpadActions a) { a.X = value; OnPropertyChanged(nameof(TouchpadX)); } } }
-        public int TouchpadY { get => Action is TouchpadActions a ? a.Y : 0; set { if (Action is TouchpadActions a) { a.Y = value; OnPropertyChanged(nameof(TouchpadY)); } } }
-        public int TouchpadEndX { get => Action is TouchpadActions a ? a.EndX : 0; set { if (Action is TouchpadActions a) { a.EndX = value; OnPropertyChanged(nameof(TouchpadEndX)); } } }
-        public int TouchpadEndY { get => Action is TouchpadActions a ? a.EndY : 0; set { if (Action is TouchpadActions a) { a.EndY = value; OnPropertyChanged(nameof(TouchpadEndY)); } } }
-        public double TouchpadSwipeDuration { get => Action is TouchpadActions a ? a.SwipeDuration : TouchpadActions.DefaultSwipeDuration; set { if (Action is TouchpadActions a) { a.SwipeDuration = (float)value; OnPropertyChanged(nameof(TouchpadSwipeDuration)); } } }
 
         public override void OnPropertyChanged(string? propertyName)
         {
@@ -493,27 +483,13 @@ namespace HandheldCompanion.ViewModels
                 }
 
                 MappingTargetViewModel? matchingTargetVm = null;
-                foreach (var button in controller.GetTargetButtons())
+                foreach (var button in GetButtonTargets(controller))
                 {
                     var mappingTargetVm = CreateTarget(button, controller.GetButtonName(button));
                     targets.Add(mappingTargetVm);
 
                     if (button == ((ButtonActions)Action).Button)
                         matchingTargetVm = mappingTargetVm;
-                }
-
-                // Parameterized touchpad gestures are mapping actions rather than
-                // physical controller buttons. Expose them only in the button editor.
-                if (controller is DummyDualSenseController)
-                {
-                    foreach (var button in TouchpadActions.Targets)
-                    {
-                        var mappingTargetVm = CreateTarget(button, controller.GetButtonName(button));
-                        targets.Add(mappingTargetVm);
-
-                        if (button == ((ButtonActions)Action).Button)
-                            matchingTargetVm = mappingTargetVm;
-                    }
                 }
 
                 if (matchingTargetVm is null && preserveMissingTarget)
@@ -669,22 +645,7 @@ namespace HandheldCompanion.ViewModels
                 case ActionType.Button:
                     if (SelectedTarget.Tag is ButtonFlags buttonFlags)
                     {
-                        bool isTouchpadAction = TouchpadActions.IsTouchpadTarget(buttonFlags);
-
-                        if (isTouchpadAction && Action is not TouchpadActions)
-                        {
-                            IActions previous = Action;
-                            Action = new TouchpadActions(buttonFlags);
-                            Action.CopyConfigurationFrom(previous);
-                        }
-                        else if (!isTouchpadAction && Action is TouchpadActions)
-                        {
-                            IActions previous = Action;
-                            Action = new ButtonActions(buttonFlags);
-                            Action.CopyConfigurationFrom(previous);
-                        }
-                        else
-                            ((ButtonActions)Action).Button = buttonFlags;
+                        SetButtonTarget(buttonFlags);
 
                         OnPropertyChanged(string.Empty);
                     }

--- a/HandheldCompanion/ViewModels/Layout/Mappings/ButtonMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/ButtonMappingViewModel.cs
@@ -379,6 +379,15 @@ namespace HandheldCompanion.ViewModels
             }
         }
 
+        public Visibility TouchpadSettingsVisibility => Action is TouchpadActions ? Visibility.Visible : Visibility.Collapsed;
+        public Visibility TouchpadSwipeSettingsVisibility => Action is TouchpadActions touchpad && touchpad.Button == ButtonFlags.TouchpadSwipe
+            ? Visibility.Visible : Visibility.Collapsed;
+        public int TouchpadX { get => Action is TouchpadActions a ? a.X : 0; set { if (Action is TouchpadActions a) { a.X = Math.Clamp(value, 0, DS4Touch.TOUCHPAD_WIDTH - 1); OnPropertyChanged(nameof(TouchpadX)); } } }
+        public int TouchpadY { get => Action is TouchpadActions a ? a.Y : 0; set { if (Action is TouchpadActions a) { a.Y = Math.Clamp(value, 0, DS4Touch.TOUCHPAD_HEIGHT - 1); OnPropertyChanged(nameof(TouchpadY)); } } }
+        public int TouchpadEndX { get => Action is TouchpadActions a ? a.EndX : 0; set { if (Action is TouchpadActions a) { a.EndX = Math.Clamp(value, 0, DS4Touch.TOUCHPAD_WIDTH - 1); OnPropertyChanged(nameof(TouchpadEndX)); } } }
+        public int TouchpadEndY { get => Action is TouchpadActions a ? a.EndY : 0; set { if (Action is TouchpadActions a) { a.EndY = Math.Clamp(value, 0, DS4Touch.TOUCHPAD_HEIGHT - 1); OnPropertyChanged(nameof(TouchpadEndY)); } } }
+        public double TouchpadSwipeDuration { get => Action is TouchpadActions a ? a.SwipeDuration : 300.0; set { if (Action is TouchpadActions a) { a.SwipeDuration = (float)Math.Clamp(value, 16.0, 5000.0); OnPropertyChanged(nameof(TouchpadSwipeDuration)); } } }
+
         public override void OnPropertyChanged(string? propertyName)
         {
             switch (propertyName)
@@ -403,6 +412,8 @@ namespace HandheldCompanion.ViewModels
                     OnPropertyChanged(nameof(AxisVisualizerInnerDeadzoneSize));
                     OnPropertyChanged(nameof(AxisVisualizerOuterDeadzoneSize));
                     OnPropertyChanged(nameof(AxisVisualizerAntiDeadzoneSize));
+                    OnPropertyChanged(nameof(TouchpadSettingsVisibility));
+                    OnPropertyChanged(nameof(TouchpadSwipeSettingsVisibility));
                     break;
             }
 
@@ -635,7 +646,19 @@ namespace HandheldCompanion.ViewModels
             {
                 case ActionType.Button:
                     if (SelectedTarget.Tag is ButtonFlags buttonFlags)
-                        ((ButtonActions)Action).Button = buttonFlags;
+                    {
+                        bool isTouchpadAction = buttonFlags is ButtonFlags.TouchpadCoordinateClick or
+                            ButtonFlags.TouchpadCoordinateTouch or ButtonFlags.TouchpadSwipe;
+
+                        if (isTouchpadAction && Action is not TouchpadActions)
+                            Action = new TouchpadActions(buttonFlags) { pressType = (PressType)_pressTypeFallbackIndex };
+                        else if (!isTouchpadAction && Action is TouchpadActions)
+                            Action = new ButtonActions(buttonFlags) { pressType = (PressType)_pressTypeFallbackIndex };
+                        else
+                            ((ButtonActions)Action).Button = buttonFlags;
+
+                        OnPropertyChanged(string.Empty);
+                    }
                     break;
 
                 case ActionType.Keyboard:

--- a/HandheldCompanion/ViewModels/Layout/Mappings/ButtonMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/ButtonMappingViewModel.cs
@@ -391,7 +391,7 @@ namespace HandheldCompanion.ViewModels
         public int TouchpadY { get => Action is TouchpadActions a ? a.Y : 0; set { if (Action is TouchpadActions a) { a.Y = value; OnPropertyChanged(nameof(TouchpadY)); } } }
         public int TouchpadEndX { get => Action is TouchpadActions a ? a.EndX : 0; set { if (Action is TouchpadActions a) { a.EndX = value; OnPropertyChanged(nameof(TouchpadEndX)); } } }
         public int TouchpadEndY { get => Action is TouchpadActions a ? a.EndY : 0; set { if (Action is TouchpadActions a) { a.EndY = value; OnPropertyChanged(nameof(TouchpadEndY)); } } }
-        public double TouchpadSwipeDuration { get => Action is TouchpadActions a ? a.SwipeDuration : 300.0; set { if (Action is TouchpadActions a) { a.SwipeDuration = (float)value; OnPropertyChanged(nameof(TouchpadSwipeDuration)); } } }
+        public double TouchpadSwipeDuration { get => Action is TouchpadActions a ? a.SwipeDuration : TouchpadActions.DefaultSwipeDuration; set { if (Action is TouchpadActions a) { a.SwipeDuration = (float)value; OnPropertyChanged(nameof(TouchpadSwipeDuration)); } } }
 
         public override void OnPropertyChanged(string? propertyName)
         {

--- a/HandheldCompanion/ViewModels/Layout/Mappings/ButtonMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/ButtonMappingViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using GregsStack.InputSimulatorStandard.Native;
 using HandheldCompanion.Actions;
 using HandheldCompanion.Controllers;
+using HandheldCompanion.Controllers.Dummies;
 using HandheldCompanion.Inputs;
 using HandheldCompanion.Managers;
 using HandheldCompanion.Properties;
@@ -384,13 +385,13 @@ namespace HandheldCompanion.ViewModels
             ? Visibility.Visible : Visibility.Collapsed;
         public int TouchpadMaxX => DS4Touch.TOUCHPAD_WIDTH - 1;
         public int TouchpadMaxY => DS4Touch.TOUCHPAD_HEIGHT - 1;
-        public double TouchpadMaxDuration => 5000.0;
+        public double TouchpadMaxDuration => TouchpadActions.MaximumSwipeDuration;
         public string TouchpadCoordinateRangeDescription => $"DualSense coordinates: X 0–{TouchpadMaxX}, Y 0–{TouchpadMaxY}";
-        public int TouchpadX { get => Action is TouchpadActions a ? a.X : 0; set { if (Action is TouchpadActions a) { a.X = Math.Clamp(value, 0, DS4Touch.TOUCHPAD_WIDTH - 1); OnPropertyChanged(nameof(TouchpadX)); } } }
-        public int TouchpadY { get => Action is TouchpadActions a ? a.Y : 0; set { if (Action is TouchpadActions a) { a.Y = Math.Clamp(value, 0, DS4Touch.TOUCHPAD_HEIGHT - 1); OnPropertyChanged(nameof(TouchpadY)); } } }
-        public int TouchpadEndX { get => Action is TouchpadActions a ? a.EndX : 0; set { if (Action is TouchpadActions a) { a.EndX = Math.Clamp(value, 0, DS4Touch.TOUCHPAD_WIDTH - 1); OnPropertyChanged(nameof(TouchpadEndX)); } } }
-        public int TouchpadEndY { get => Action is TouchpadActions a ? a.EndY : 0; set { if (Action is TouchpadActions a) { a.EndY = Math.Clamp(value, 0, DS4Touch.TOUCHPAD_HEIGHT - 1); OnPropertyChanged(nameof(TouchpadEndY)); } } }
-        public double TouchpadSwipeDuration { get => Action is TouchpadActions a ? a.SwipeDuration : 300.0; set { if (Action is TouchpadActions a) { a.SwipeDuration = (float)Math.Clamp(value, 16.0, 5000.0); OnPropertyChanged(nameof(TouchpadSwipeDuration)); } } }
+        public int TouchpadX { get => Action is TouchpadActions a ? a.X : 0; set { if (Action is TouchpadActions a) { a.X = value; OnPropertyChanged(nameof(TouchpadX)); } } }
+        public int TouchpadY { get => Action is TouchpadActions a ? a.Y : 0; set { if (Action is TouchpadActions a) { a.Y = value; OnPropertyChanged(nameof(TouchpadY)); } } }
+        public int TouchpadEndX { get => Action is TouchpadActions a ? a.EndX : 0; set { if (Action is TouchpadActions a) { a.EndX = value; OnPropertyChanged(nameof(TouchpadEndX)); } } }
+        public int TouchpadEndY { get => Action is TouchpadActions a ? a.EndY : 0; set { if (Action is TouchpadActions a) { a.EndY = value; OnPropertyChanged(nameof(TouchpadEndY)); } } }
+        public double TouchpadSwipeDuration { get => Action is TouchpadActions a ? a.SwipeDuration : 300.0; set { if (Action is TouchpadActions a) { a.SwipeDuration = (float)value; OnPropertyChanged(nameof(TouchpadSwipeDuration)); } } }
 
         public override void OnPropertyChanged(string? propertyName)
         {
@@ -496,6 +497,20 @@ namespace HandheldCompanion.ViewModels
 
                     if (button == ((ButtonActions)Action).Button)
                         matchingTargetVm = mappingTargetVm;
+                }
+
+                // Parameterized touchpad gestures are mapping actions rather than
+                // physical controller buttons. Expose them only in the button editor.
+                if (controller is DummyDualSenseController)
+                {
+                    foreach (var button in TouchpadActions.Targets)
+                    {
+                        var mappingTargetVm = CreateTarget(button, controller.GetButtonName(button));
+                        targets.Add(mappingTargetVm);
+
+                        if (button == ((ButtonActions)Action).Button)
+                            matchingTargetVm = mappingTargetVm;
+                    }
                 }
 
                 if (matchingTargetVm is null && preserveMissingTarget)
@@ -651,8 +666,7 @@ namespace HandheldCompanion.ViewModels
                 case ActionType.Button:
                     if (SelectedTarget.Tag is ButtonFlags buttonFlags)
                     {
-                        bool isTouchpadAction = buttonFlags is ButtonFlags.TouchpadCoordinateClick or
-                            ButtonFlags.TouchpadCoordinateTouch or ButtonFlags.TouchpadSwipe;
+                        bool isTouchpadAction = TouchpadActions.IsTouchpadTarget(buttonFlags);
 
                         if (isTouchpadAction && Action is not TouchpadActions)
                         {

--- a/HandheldCompanion/ViewModels/Layout/Mappings/MappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/MappingViewModel.cs
@@ -330,6 +330,10 @@ namespace HandheldCompanion.ViewModels
         public virtual Visibility AxisDirectionVisibility => Visibility.Collapsed;
         public virtual Visibility AxisThresholdVisibility => Visibility.Collapsed;
 
+        // DualSense touchpad gesture settings are only supported by button mappings.
+        public virtual Visibility TouchpadSettingsVisibility => Visibility.Collapsed;
+        public virtual Visibility TouchpadSwipeSettingsVisibility => Visibility.Collapsed;
+
         // Combined visibility for settings that apply to both Button mappings and Axis2Button mappings
         // This avoids duplication - shows when ActionTypeIndex is Button/Keyboard/Mouse/Trigger/Shift
         // OR when it's an Axis mapping converting to Button

--- a/HandheldCompanion/ViewModels/Layout/Mappings/MappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/MappingViewModel.cs
@@ -1,7 +1,10 @@
 ﻿using GregsStack.InputSimulatorStandard.Native;
 using HandheldCompanion.Actions;
+using HandheldCompanion.Controllers;
+using HandheldCompanion.Controllers.Dummies;
 using HandheldCompanion.Inputs;
 using HandheldCompanion.Managers;
+using HandheldCompanion.Misc;
 using HandheldCompanion.Properties;
 using HandheldCompanion.Utils;
 using HandheldCompanion.Views;
@@ -333,6 +336,49 @@ namespace HandheldCompanion.ViewModels
         // DualSense touchpad gesture settings are only supported by button mappings.
         public virtual Visibility TouchpadSettingsVisibility => Visibility.Collapsed;
         public virtual Visibility TouchpadSwipeSettingsVisibility => Visibility.Collapsed;
+        public int TouchpadMaxX => DS4Touch.TOUCHPAD_WIDTH - 1;
+        public int TouchpadMaxY => DS4Touch.TOUCHPAD_HEIGHT - 1;
+        public double TouchpadMaxDuration => TouchpadActions.MaximumSwipeDuration;
+        public string TouchpadCoordinateRangeDescription => $"DualSense coordinates: X 0–{TouchpadMaxX}, Y 0–{TouchpadMaxY}";
+        public int TouchpadX { get => Action is TouchpadActions a ? a.X : 0; set { if (Action is TouchpadActions a) { a.X = value; OnPropertyChanged(nameof(TouchpadX)); } } }
+        public int TouchpadY { get => Action is TouchpadActions a ? a.Y : 0; set { if (Action is TouchpadActions a) { a.Y = value; OnPropertyChanged(nameof(TouchpadY)); } } }
+        public int TouchpadEndX { get => Action is TouchpadActions a ? a.EndX : 0; set { if (Action is TouchpadActions a) { a.EndX = value; OnPropertyChanged(nameof(TouchpadEndX)); } } }
+        public int TouchpadEndY { get => Action is TouchpadActions a ? a.EndY : 0; set { if (Action is TouchpadActions a) { a.EndY = value; OnPropertyChanged(nameof(TouchpadEndY)); } } }
+        public double TouchpadSwipeDuration { get => Action is TouchpadActions a ? a.SwipeDuration : TouchpadActions.DefaultSwipeDuration; set { if (Action is TouchpadActions a) { a.SwipeDuration = (float)value; OnPropertyChanged(nameof(TouchpadSwipeDuration)); } } }
+
+        protected static IEnumerable<ButtonFlags> GetButtonTargets(IController controller)
+        {
+            foreach (ButtonFlags button in controller.GetTargetButtons())
+                yield return button;
+
+            if (controller is DummyDualSenseController)
+            {
+                foreach (ButtonFlags button in TouchpadActions.Targets)
+                    yield return button;
+            }
+        }
+
+        protected void SetButtonTarget(ButtonFlags button)
+        {
+            bool isTouchpadAction = TouchpadActions.IsTouchpadTarget(button);
+            if (isTouchpadAction && Action is not TouchpadActions)
+            {
+                IActions? previous = Action;
+                Action = new TouchpadActions(button);
+                if (previous is not null)
+                    Action.CopyConfigurationFrom(previous);
+            }
+            else if (!isTouchpadAction && Action is TouchpadActions)
+            {
+                IActions previous = Action;
+                Action = new ButtonActions(button);
+                Action.CopyConfigurationFrom(previous);
+            }
+            else if (Action is ButtonActions buttonAction)
+            {
+                buttonAction.Button = button;
+            }
+        }
 
         // Combined visibility for settings that apply to both Button mappings and Axis2Button mappings
         // This avoids duplication - shows when ActionTypeIndex is Button/Keyboard/Mouse/Trigger/Shift

--- a/HandheldCompanion/ViewModels/Layout/Mappings/TriggerMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/TriggerMappingViewModel.cs
@@ -143,6 +143,9 @@ namespace HandheldCompanion.ViewModels
                 MappingTargetViewModel? matchingTargetVm = null;
                 foreach (var button in controller.GetTargetButtons())
                 {
+                    if (TouchpadActions.IsTouchpadTarget(button))
+                        continue;
+
                     var mappingTargetVm = CreateTarget(button, controller.GetButtonName(button));
                     targets.Add(mappingTargetVm);
 

--- a/HandheldCompanion/ViewModels/Layout/Mappings/TriggerMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/TriggerMappingViewModel.cs
@@ -143,9 +143,6 @@ namespace HandheldCompanion.ViewModels
                 MappingTargetViewModel? matchingTargetVm = null;
                 foreach (var button in controller.GetTargetButtons())
                 {
-                    if (TouchpadActions.IsTouchpadTarget(button))
-                        continue;
-
                     var mappingTargetVm = CreateTarget(button, controller.GetButtonName(button));
                     targets.Add(mappingTargetVm);
 

--- a/HandheldCompanion/ViewModels/Layout/Mappings/TriggerMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/TriggerMappingViewModel.cs
@@ -23,6 +23,12 @@ namespace HandheldCompanion.ViewModels
         ];
 
         public override bool IsTriggerMapping => true;
+        public override Visibility TouchpadSettingsVisibility =>
+            ActionTypeIndex == (int)ActionType.Button && Action is TouchpadActions
+                ? Visibility.Visible : Visibility.Collapsed;
+        public override Visibility TouchpadSwipeSettingsVisibility =>
+            ActionTypeIndex == (int)ActionType.Button && Action is TouchpadActions { Button: ButtonFlags.TouchpadSwipe }
+                ? Visibility.Visible : Visibility.Collapsed;
 
         public override int Trigger2TriggerInnerDeadzone
         {
@@ -141,7 +147,7 @@ namespace HandheldCompanion.ViewModels
                     Action = new ButtonActions() { motionThreshold = Gamepad.TriggerThreshold, motionDirection = DeflectionDirection.Up };
 
                 MappingTargetViewModel? matchingTargetVm = null;
-                foreach (var button in controller.GetTargetButtons())
+                foreach (var button in GetButtonTargets(controller))
                 {
                     var mappingTargetVm = CreateTarget(button, controller.GetButtonName(button));
                     targets.Add(mappingTargetVm);
@@ -288,7 +294,10 @@ namespace HandheldCompanion.ViewModels
             {
                 case ActionType.Button:
                     if (SelectedTarget.Tag is ButtonFlags buttonFlags)
-                        ((ButtonActions)Action).Button = buttonFlags;
+                    {
+                        SetButtonTarget(buttonFlags);
+                        OnPropertyChanged(string.Empty);
+                    }
                     break;
 
                 case ActionType.Keyboard:

--- a/HandheldCompanion/Views/Pages/ActionSettingsPage.xaml
+++ b/HandheldCompanion/Views/Pages/ActionSettingsPage.xaml
@@ -143,6 +143,43 @@
             </ikw:SimpleStackPanel>
         </ikw:SimpleStackPanel>
 
+        <!--  DualSense touchpad gesture settings  -->
+        <ikw:SimpleStackPanel Spacing="8" Visibility="{Binding TouchpadSettingsVisibility, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
+            <TextBlock Style="{StaticResource BaseTextBlockStyle}" Text="DualSense touchpad" />
+            <ikw:SimpleStackPanel Spacing="3">
+                <ui:SettingsCard Header="Start position" Description="DualSense coordinates: X 0–1919, Y 0–942">
+                    <StackPanel>
+                        <DockPanel>
+                            <TextBlock Width="72" VerticalAlignment="Center" Text="{Binding TouchpadX, Mode=OneWay, StringFormat={}X: {0}}" />
+                            <Slider Width="240" Minimum="0" Maximum="1919" TickFrequency="1" IsMoveToPointEnabled="True" Value="{Binding TouchpadX, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        </DockPanel>
+                        <DockPanel Margin="0,6,0,0">
+                            <TextBlock Width="72" VerticalAlignment="Center" Text="{Binding TouchpadY, Mode=OneWay, StringFormat={}Y: {0}}" />
+                            <Slider Width="240" Minimum="0" Maximum="942" TickFrequency="1" IsMoveToPointEnabled="True" Value="{Binding TouchpadY, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        </DockPanel>
+                    </StackPanel>
+                </ui:SettingsCard>
+                <ui:SettingsCard Header="End position" Visibility="{Binding TouchpadSwipeSettingsVisibility, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
+                    <StackPanel>
+                        <DockPanel>
+                            <TextBlock Width="72" VerticalAlignment="Center" Text="{Binding TouchpadEndX, Mode=OneWay, StringFormat={}X: {0}}" />
+                            <Slider Width="240" Minimum="0" Maximum="1919" TickFrequency="1" IsMoveToPointEnabled="True" Value="{Binding TouchpadEndX, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        </DockPanel>
+                        <DockPanel Margin="0,6,0,0">
+                            <TextBlock Width="72" VerticalAlignment="Center" Text="{Binding TouchpadEndY, Mode=OneWay, StringFormat={}Y: {0}}" />
+                            <Slider Width="240" Minimum="0" Maximum="942" TickFrequency="1" IsMoveToPointEnabled="True" Value="{Binding TouchpadEndY, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        </DockPanel>
+                    </StackPanel>
+                </ui:SettingsCard>
+                <ui:SettingsCard Header="Swipe duration" Visibility="{Binding TouchpadSwipeSettingsVisibility, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
+                    <DockPanel>
+                        <TextBox IsReadOnly="True" Text="{Binding TouchpadSwipeDuration, Mode=OneWay, StringFormat={}{0:N0} ms}" />
+                        <Slider Width="220" Margin="6,0,0,0" Minimum="16" Maximum="2000" TickFrequency="16" IsSnapToTickEnabled="True" Value="{Binding TouchpadSwipeDuration, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    </DockPanel>
+                </ui:SettingsCard>
+            </ikw:SimpleStackPanel>
+        </ikw:SimpleStackPanel>
+
         <!--  Trigger settings  -->
         <ikw:SimpleStackPanel Spacing="8" Visibility="{Binding TriggerSettingsSectionVisibility, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
             <TextBlock Style="{StaticResource BaseTextBlockStyle}" Text="Trigger settings" />

--- a/HandheldCompanion/Views/Pages/ActionSettingsPage.xaml
+++ b/HandheldCompanion/Views/Pages/ActionSettingsPage.xaml
@@ -147,15 +147,15 @@
         <ikw:SimpleStackPanel Spacing="8" Visibility="{Binding TouchpadSettingsVisibility, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
             <TextBlock Style="{StaticResource BaseTextBlockStyle}" Text="DualSense touchpad" />
             <ikw:SimpleStackPanel Spacing="3">
-                <ui:SettingsCard Header="Start position" Description="DualSense coordinates: X 0–1919, Y 0–942">
+                <ui:SettingsCard Header="Start position" Description="{Binding TouchpadCoordinateRangeDescription, Mode=OneWay}">
                     <StackPanel>
                         <DockPanel>
                             <TextBlock Width="72" VerticalAlignment="Center" Text="{Binding TouchpadX, Mode=OneWay, StringFormat={}X: {0}}" />
-                            <Slider Width="240" Minimum="0" Maximum="1919" TickFrequency="1" IsMoveToPointEnabled="True" Value="{Binding TouchpadX, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <Slider Width="240" Minimum="0" Maximum="{Binding TouchpadMaxX, Mode=OneWay}" TickFrequency="1" IsMoveToPointEnabled="True" Value="{Binding TouchpadX, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                         </DockPanel>
                         <DockPanel Margin="0,6,0,0">
                             <TextBlock Width="72" VerticalAlignment="Center" Text="{Binding TouchpadY, Mode=OneWay, StringFormat={}Y: {0}}" />
-                            <Slider Width="240" Minimum="0" Maximum="942" TickFrequency="1" IsMoveToPointEnabled="True" Value="{Binding TouchpadY, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <Slider Width="240" Minimum="0" Maximum="{Binding TouchpadMaxY, Mode=OneWay}" TickFrequency="1" IsMoveToPointEnabled="True" Value="{Binding TouchpadY, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                         </DockPanel>
                     </StackPanel>
                 </ui:SettingsCard>
@@ -163,18 +163,18 @@
                     <StackPanel>
                         <DockPanel>
                             <TextBlock Width="72" VerticalAlignment="Center" Text="{Binding TouchpadEndX, Mode=OneWay, StringFormat={}X: {0}}" />
-                            <Slider Width="240" Minimum="0" Maximum="1919" TickFrequency="1" IsMoveToPointEnabled="True" Value="{Binding TouchpadEndX, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <Slider Width="240" Minimum="0" Maximum="{Binding TouchpadMaxX, Mode=OneWay}" TickFrequency="1" IsMoveToPointEnabled="True" Value="{Binding TouchpadEndX, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                         </DockPanel>
                         <DockPanel Margin="0,6,0,0">
                             <TextBlock Width="72" VerticalAlignment="Center" Text="{Binding TouchpadEndY, Mode=OneWay, StringFormat={}Y: {0}}" />
-                            <Slider Width="240" Minimum="0" Maximum="942" TickFrequency="1" IsMoveToPointEnabled="True" Value="{Binding TouchpadEndY, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <Slider Width="240" Minimum="0" Maximum="{Binding TouchpadMaxY, Mode=OneWay}" TickFrequency="1" IsMoveToPointEnabled="True" Value="{Binding TouchpadEndY, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                         </DockPanel>
                     </StackPanel>
                 </ui:SettingsCard>
                 <ui:SettingsCard Header="Swipe duration" Visibility="{Binding TouchpadSwipeSettingsVisibility, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
                     <DockPanel>
                         <TextBox IsReadOnly="True" Text="{Binding TouchpadSwipeDuration, Mode=OneWay, StringFormat={}{0:N0} ms}" />
-                        <Slider Width="220" Margin="6,0,0,0" Minimum="16" Maximum="2000" TickFrequency="16" IsSnapToTickEnabled="True" Value="{Binding TouchpadSwipeDuration, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        <Slider Width="220" Margin="6,0,0,0" Minimum="16" Maximum="{Binding TouchpadMaxDuration, Mode=OneWay}" TickFrequency="16" IsSnapToTickEnabled="True" Value="{Binding TouchpadSwipeDuration, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                     </DockPanel>
                 </ui:SettingsCard>
             </ikw:SimpleStackPanel>


### PR DESCRIPTION
## Summary

- add configurable DualSense touchpad click and touch actions with native X/Y coordinates
- add a configurable touchpad swipe action with start/end coordinates and duration
- expose center touchpad click and microphone mute as DualSense mapping targets
- keep virtual DualSense touchpad capabilities target-only so physical controllers do not advertise touchpads
- improve DualSense touch/click report positioning and sequencing for Steam Input

## Why

Physical handheld buttons need to be able to drive the virtual DualSense controls that Steam exposes, including regional touchpad clicks, microphone mute, coordinate-specific touches, and swipe gestures.

The previous virtual report collapsed pad clicks into the shared center click and only forwarded one touch source. Parameterized gestures also had no layout action or settings UI.

## User impact

When the emulated DualSense target is selected, button mappings now include coordinate click, coordinate touch, swipe, center pad click, and microphone mute. Coordinate and swipe settings persist with layouts and profiles.

## Validation

- `dotnet build HandheldCompanion.sln --no-restore -c Debug -p:Platform=x64 -p:OutDir="$env:TEMP\\HandheldCompanion-build-verify\\"`
- build completed with 0 errors (existing warnings remain)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable DualSense touchpad gestures, including coordinate touches, clicks, and timed swipes.
  * Added touchpad settings for gesture positions and swipe duration.
  * Added support for microphone mute and center touchpad-click mappings.
* **Bug Fixes**
  * Improved touchpad event prioritization, coordinate handling, and click reporting.
  * Corrected DualSense center-pad glyph mapping.
* **Improvements**
  * Added coordinate conversion and range validation for more reliable touchpad input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->