### PR TITLE
Fix Intel MCHBAR address construction

### DIFF
--- a/HandheldCompanion/Processors/Intel/KX.cs
+++ b/HandheldCompanion/Processors/Intel/KX.cs
@@ -79,8 +79,13 @@ public class KX
                         if (returned == 0xFFFFFFFF)
                             continue;
 
-                        // store mchbar and leave loop
-                        mchbar = address + pnt_limit;
+                        // mchbar_addresses hold the full 32-bit MCHBAR base (low 16 bits = 0).
+                        // KX.exe forms its target address by concatenating hex strings, so the RAPL
+                        // register address is built as <base high 16 bits> + pnt_limit (0x59) + pointer
+                        // (0xa0/0xa4), e.g. "0xfedc" + "59" + "a0" => 0xFEDC59A0 (MCHBAR base + 0x59A0).
+                        // Concatenating the full "0xfedc0000" base instead would yield 0xFEDC000059A0,
+                        // an out-of-range physical address whose reads/writes are silently ignored.
+                        mchbar = address.Substring(0, 6) + pnt_limit;
                         return true;
                     }
                 }


### PR DESCRIPTION
## What changed

Correct the Intel KX MCHBAR address construction so the helper receives the intended 32-bit physical address instead of a malformed 48-bit value.

## Root cause

The existing string concatenation appends the register suffix to the full MCHBAR base, producing an out-of-range address whose reads and writes are ignored.

## Impact

Intel MMIO TDP reads and writes target the intended physical register address.

## Validation

- Verified the resulting address format against the configured MCHBAR base and register offset.
- Validated on Intel hardware through HWiNFO.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could generate invalid physical addresses when initializing Intel processor hardware registers.
  * Improved reliability of hardware configuration on supported handheld devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->