### PR TITLE
Hide RSR controls on non-AMD GPUs

### DIFF
--- a/HandheldCompanion/Views/QuickPages/QuickProfilesPage.xaml
+++ b/HandheldCompanion/Views/QuickPages/QuickProfilesPage.xaml
@@ -601,7 +601,8 @@
                             d:Visibility="Visible"
                             Description="{l:Static resx:Resources.ProfilesPage_RSRDesc}"
                             Header="{l:Static resx:Resources.ProfilesPage_RSR}"
-                            IsEnabled="{Binding HasRSRSupport, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
+                            IsEnabled="{Binding HasRSRSupport, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
+                            Visibility="{Binding IsAMDGPU, Mode=OneWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BooleanToVisibilityConverter}}">
 
                             <ui:ToggleSwitch Name="RSRToggle" IsOn="{Binding RSREnabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                         </ui:SettingsCard>


### PR DESCRIPTION
## What changed

Hide the Radeon Super Resolution settings card when the active GPU is not AMD, while retaining the existing capability-based enabled state.

## Root cause

RSR is AMD-only, but the settings card was visible on every GPU vendor.

## Impact

Intel and NVIDIA systems no longer display an irrelevant RSR control.

## Validation

- Uses the existing `IsAMDGPU` property and shared Boolean-to-visibility converter.
- Change is isolated to the RSR settings card.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the RSR settings card visibility so it appears only on supported AMD GPUs.
  * The card remains enabled when RSR support is detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->