### PR TITLE
Preserve dead-key keyboard labels

### DIFF
--- a/HandheldCompanion/Views/QuickPages/QuickKeyboardPage.xaml.cs
+++ b/HandheldCompanion/Views/QuickPages/QuickKeyboardPage.xaml.cs
@@ -292,9 +292,10 @@ namespace HandheldCompanion.Views.QuickPages
                         StringBuilder sb = new StringBuilder(2);
                         int cnt = ToUnicodeEx(vk, (uint)sc, st, sb, sb.Capacity, 0, _lastHkl);
 
-                        string content = sb[0].ToString();
-                        if (cnt > 0 && !string.IsNullOrEmpty(content))
-                            b.Content = content;
+                        // A negative result represents a dead key and still writes its spacing
+                        // character to the buffer. Zero is the only no-translation result.
+                        if (cnt != 0 && sb.Length > 0)
+                            b.Content = sb[0].ToString();
                     }
                 }
             }


### PR DESCRIPTION
## What changed

Accept negative `ToUnicodeEx` results when generating quick-keyboard labels, provided the output buffer contains the spacing character.

## Root cause

Windows returns a negative count for dead keys while still writing a valid spacing character. Treating only positive results as valid leaves dead-key buttons with stale or incorrect labels.

## Impact

Quick Keyboard displays valid labels for dead keys across applicable keyboard layouts.

## Validation

- Zero remains the no-translation case.
- The buffer-length guard prevents indexing an empty result.
- Change is isolated to keyboard label generation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard label updates for dead-key inputs.
  * Spacing characters now display correctly when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->