### PR TITLE
Add configurable trackpad haptic feedback

### DIFF
--- a/HandheldCompanion/Actions/IActions.cs
+++ b/HandheldCompanion/Actions/IActions.cs
@@ -151,7 +151,7 @@ namespace HandheldCompanion.Actions
 
         public IActions() { }
 
-        public void CopyConfigurationFrom(IActions source)
+        internal void CopyConfigurationFrom(IActions source)
         {
             pressType = source.pressType;
             ActionTimer = source.ActionTimer;

--- a/HandheldCompanion/Actions/IActions.cs
+++ b/HandheldCompanion/Actions/IActions.cs
@@ -138,7 +138,6 @@ namespace HandheldCompanion.Actions
         // --- Haptics ---
         public HapticMode HapticMode = HapticMode.Off;
         public HapticStrength HapticStrength = HapticStrength.Low;
-        public bool? HapticOverride = null;
 
         // --- Axis/motion ---
         public DeflectionDirection motionDirection = DeflectionDirection.None;
@@ -166,7 +165,6 @@ namespace HandheldCompanion.Actions
             ShiftMatchAny = source.ShiftMatchAny;
             HapticMode = source.HapticMode;
             HapticStrength = source.HapticStrength;
-            HapticOverride = source.HapticOverride;
             motionDirection = source.motionDirection;
             motionThreshold = source.motionThreshold;
         }

--- a/HandheldCompanion/Actions/IActions.cs
+++ b/HandheldCompanion/Actions/IActions.cs
@@ -151,6 +151,23 @@ namespace HandheldCompanion.Actions
 
         public IActions() { }
 
+        public void CopyConfigurationFrom(IActions source)
+        {
+            pressType = source.pressType;
+            ActionTimer = source.ActionTimer;
+            HasTurbo = source.HasTurbo;
+            HasToggle = source.HasToggle;
+            HasInterruptable = source.HasInterruptable;
+            TurboDelay = source.TurboDelay;
+            StartDelay = source.StartDelay;
+            ShiftSlot = source.ShiftSlot;
+            ShiftMatchAny = source.ShiftMatchAny;
+            HapticMode = source.HapticMode;
+            HapticStrength = source.HapticStrength;
+            motionDirection = source.motionDirection;
+            motionThreshold = source.motionThreshold;
+        }
+
         /// <summary>
         /// Override to share toggle state across bindings targeting the same key/button,
         /// and to detect external releases. Default uses local toggle state.

--- a/HandheldCompanion/Actions/IActions.cs
+++ b/HandheldCompanion/Actions/IActions.cs
@@ -212,7 +212,8 @@ namespace HandheldCompanion.Actions
         /// <summary>AxisLayout version: zeroes the vector when the slot is masked.</summary>
         public virtual void Execute(AxisLayout layout, ShiftSlot shiftSlot, float delta)
         {
-            if (!IsShiftAllowed(shiftSlot, ShiftSlot, ShiftMatchAny))
+            axisSlotDisabled = !IsShiftAllowed(shiftSlot, ShiftSlot, ShiftMatchAny);
+            if (axisSlotDisabled)
                 outVector = Vector2.Zero;
         }
 

--- a/HandheldCompanion/Actions/IActions.cs
+++ b/HandheldCompanion/Actions/IActions.cs
@@ -176,6 +176,26 @@ namespace HandheldCompanion.Actions
 
         public virtual void SetHaptic(ButtonFlags button, bool released)
         {
+            bool isTrackpadClick = button is
+                ButtonFlags.LeftPadClick or
+                ButtonFlags.LeftPadClickUp or
+                ButtonFlags.LeftPadClickDown or
+                ButtonFlags.LeftPadClickLeft or
+                ButtonFlags.LeftPadClickRight or
+                ButtonFlags.RightPadClick or
+                ButtonFlags.RightPadClickUp or
+                ButtonFlags.RightPadClickDown or
+                ButtonFlags.RightPadClickLeft or
+                ButtonFlags.RightPadClickRight;
+
+            if (isTrackpadClick &&
+                ControllerManager.GetTarget() is HandheldCompanion.Controllers.Steam.SteamController)
+            {
+                // Physical Steam trackpad clicks are handled once at controller level so the
+                // shared Controller-page setting applies regardless of the mapped action type.
+                return;
+            }
+
             if (HapticMode == HapticMode.Off) return;
             if (HapticMode == HapticMode.Down && released) return;
             if (HapticMode == HapticMode.Up && !released) return;

--- a/HandheldCompanion/Actions/IActions.cs
+++ b/HandheldCompanion/Actions/IActions.cs
@@ -179,12 +179,11 @@ namespace HandheldCompanion.Actions
 
         public virtual void SetHaptic(ButtonFlags button, bool released)
         {
-            if (TouchpadActions.IsPhysicalClick(button)) return;
             if (HapticMode == HapticMode.Off) return;
             if (HapticMode == HapticMode.Down && released) return;
             if (HapticMode == HapticMode.Up && !released) return;
 
-            ControllerManager.GetTarget()?.SetHaptic(HapticStrength, button);
+            ControllerManager.GetTarget()?.SetHaptic(HapticStrength, button, released);
         }
 
         /// <summary>AxisFlags version: computes shift-slot gating only.</summary>

--- a/HandheldCompanion/Actions/IActions.cs
+++ b/HandheldCompanion/Actions/IActions.cs
@@ -23,6 +23,7 @@ namespace HandheldCompanion.Actions
         Trigger = 5,
         Shift = 6,
         Inherit = 7,
+        Touchpad = 8,
     }
 
     [Serializable]
@@ -137,6 +138,7 @@ namespace HandheldCompanion.Actions
         // --- Haptics ---
         public HapticMode HapticMode = HapticMode.Off;
         public HapticStrength HapticStrength = HapticStrength.Low;
+        public bool? HapticOverride = null;
 
         // --- Axis/motion ---
         public DeflectionDirection motionDirection = DeflectionDirection.None;
@@ -164,6 +166,7 @@ namespace HandheldCompanion.Actions
             ShiftMatchAny = source.ShiftMatchAny;
             HapticMode = source.HapticMode;
             HapticStrength = source.HapticStrength;
+            HapticOverride = source.HapticOverride;
             motionDirection = source.motionDirection;
             motionThreshold = source.motionThreshold;
         }
@@ -176,26 +179,7 @@ namespace HandheldCompanion.Actions
 
         public virtual void SetHaptic(ButtonFlags button, bool released)
         {
-            bool isTrackpadClick = button is
-                ButtonFlags.LeftPadClick or
-                ButtonFlags.LeftPadClickUp or
-                ButtonFlags.LeftPadClickDown or
-                ButtonFlags.LeftPadClickLeft or
-                ButtonFlags.LeftPadClickRight or
-                ButtonFlags.RightPadClick or
-                ButtonFlags.RightPadClickUp or
-                ButtonFlags.RightPadClickDown or
-                ButtonFlags.RightPadClickLeft or
-                ButtonFlags.RightPadClickRight;
-
-            if (isTrackpadClick &&
-                ControllerManager.GetTarget() is HandheldCompanion.Controllers.Steam.SteamController)
-            {
-                // Physical Steam trackpad clicks are handled once at controller level so the
-                // shared Controller-page setting applies regardless of the mapped action type.
-                return;
-            }
-
+            if (TouchpadActions.IsPhysicalClick(button)) return;
             if (HapticMode == HapticMode.Off) return;
             if (HapticMode == HapticMode.Down && released) return;
             if (HapticMode == HapticMode.Up && !released) return;

--- a/HandheldCompanion/Actions/MouseActions.cs
+++ b/HandheldCompanion/Actions/MouseActions.cs
@@ -1,5 +1,4 @@
 using HandheldCompanion.Inputs;
-using HandheldCompanion.Managers;
 using HandheldCompanion.Simulators;
 using HandheldCompanion.Utils;
 using System;
@@ -30,8 +29,6 @@ namespace HandheldCompanion.Actions
 
         private const int ScrollAmountInClicks = 20;
         private const float FilterBeta = 0.5f;
-        private const float TrackpadHapticStep = (short.MaxValue - short.MinValue) / 10.0f;
-        private const float TrackpadHapticJitterThreshold = 128.0f;
 
         // Runtime
         private bool isCursorDown = false;
@@ -40,8 +37,6 @@ namespace HandheldCompanion.Actions
         private KeyCode[]? modifiersPressed;
         private OneEuroFilterPair mouseFilter;
         private float accelMemory = 0f;
-        private float trackpadHapticDistance = 0f;
-        private Vector2 trackpadHapticJitter = new();
 
         // Click settings
         public ModifierSet Modifiers = ModifierSet.None;
@@ -194,9 +189,6 @@ namespace HandheldCompanion.Actions
         {
             bool firstTouch = ConsumeNewTouch(touched);
 
-            if (!touched)
-                ResetTrackpadHaptics();
-
             Vector2 rawVector = layout.vector;
             outVector = rawVector;
             base.Execute(layout, shiftSlot, delta);
@@ -206,7 +198,6 @@ namespace HandheldCompanion.Actions
             {
                 rawVector.Y *= -1;
                 prevVector = rawVector;
-                ResetTrackpadHaptics();
                 return;
             }
 
@@ -216,7 +207,6 @@ namespace HandheldCompanion.Actions
             if (firstTouch && isTrackpad)
             {
                 prevVector = outVector;
-                ResetTrackpadHaptics();
                 return;
             }
 
@@ -240,7 +230,6 @@ namespace HandheldCompanion.Actions
                 case AxisLayoutFlags.RightPad:
                     Vector2 trackpadDelta = outVector - prevVector;
                     prevVector = outVector;
-                    UpdateTrackpadHaptics(layout.flags, touched, trackpadDelta);
 
                     deltaVector = trackpadDelta / short.MaxValue;
                     sensitivityScale = MouseType == MouseActionsType.Move ? 9.0f : 3.0f;
@@ -266,49 +255,6 @@ namespace HandheldCompanion.Actions
                 MouseSimulator.MoveBy((int)intDelta.X, (int)intDelta.Y);
             else
                 MouseSimulator.VerticalScroll((int)-intDelta.Y);
-        }
-
-        private void UpdateTrackpadHaptics(AxisLayoutFlags axis, bool touched, Vector2 delta)
-        {
-            if (!touched || HapticMode == HapticMode.Off)
-            {
-                ResetTrackpadHaptics();
-                return;
-            }
-
-            // Steam firmware provides its own feedback in lizard mode. Other controllers can use
-            // their normal haptic implementation when the mapped action enables feedback.
-            var targetController = ControllerManager.GetTarget();
-            if (targetController is null ||
-                targetController is HandheldCompanion.Controllers.Steam.SteamController steamController &&
-                steamController.IsLizardModeEnabled)
-            {
-                ResetTrackpadHaptics();
-                return;
-            }
-
-            trackpadHapticJitter += delta;
-            float distance = trackpadHapticJitter.Length();
-            if (distance < TrackpadHapticJitterThreshold)
-                return;
-
-            trackpadHapticJitter = Vector2.Zero;
-            trackpadHapticDistance += distance;
-            if (trackpadHapticDistance < TrackpadHapticStep)
-                return;
-
-            trackpadHapticDistance %= TrackpadHapticStep;
-
-            ButtonFlags button = axis == AxisLayoutFlags.LeftPad
-                ? ButtonFlags.LeftPadTouch
-                : ButtonFlags.RightPadTouch;
-            SetHaptic(button, released: false);
-        }
-
-        private void ResetTrackpadHaptics()
-        {
-            trackpadHapticDistance = 0f;
-            trackpadHapticJitter = Vector2.Zero;
         }
 
         private Vector2 ComputeStickDelta(Vector2 raw)

--- a/HandheldCompanion/Actions/MouseActions.cs
+++ b/HandheldCompanion/Actions/MouseActions.cs
@@ -1,4 +1,5 @@
 using HandheldCompanion.Inputs;
+using HandheldCompanion.Managers;
 using HandheldCompanion.Simulators;
 using HandheldCompanion.Utils;
 using System;
@@ -29,6 +30,8 @@ namespace HandheldCompanion.Actions
 
         private const int ScrollAmountInClicks = 20;
         private const float FilterBeta = 0.5f;
+        private const float TrackpadHapticStep = (short.MaxValue - short.MinValue) / 10.0f;
+        private const float TrackpadHapticJitterThreshold = 128.0f;
 
         // Runtime
         private bool isCursorDown = false;
@@ -37,6 +40,7 @@ namespace HandheldCompanion.Actions
         private KeyCode[]? modifiersPressed;
         private OneEuroFilterPair mouseFilter;
         private float accelMemory = 0f;
+        private float trackpadHapticDistance = 0f;
 
         // Click settings
         public ModifierSet Modifiers = ModifierSet.None;
@@ -152,6 +156,31 @@ namespace HandheldCompanion.Actions
             }
         }
 
+        public override void SetHaptic(ButtonFlags button, bool released)
+        {
+            bool isTrackpadClick = button is
+                ButtonFlags.LeftPadClick or
+                ButtonFlags.LeftPadClickUp or
+                ButtonFlags.LeftPadClickDown or
+                ButtonFlags.LeftPadClickLeft or
+                ButtonFlags.LeftPadClickRight or
+                ButtonFlags.RightPadClick or
+                ButtonFlags.RightPadClickUp or
+                ButtonFlags.RightPadClickDown or
+                ButtonFlags.RightPadClickLeft or
+                ButtonFlags.RightPadClickRight;
+
+            if (isTrackpadClick &&
+                ControllerManager.GetTarget() is HandheldCompanion.Controllers.Steam.SteamController)
+            {
+                // Physical Steam trackpad clicks are handled once at controller level so the
+                // shared Controller-page setting applies to both pads, regardless of mapping.
+                return;
+            }
+
+            base.SetHaptic(button, released);
+        }
+
         public void Execute(AxisLayout layout, bool touched, ShiftSlot shiftSlot, float delta)
         {
             switch (MouseType)
@@ -189,6 +218,9 @@ namespace HandheldCompanion.Actions
         {
             bool firstTouch = ConsumeNewTouch(touched);
 
+            if (!touched)
+                trackpadHapticDistance = 0f;
+
             outVector = layout.vector;
             base.Execute(layout, shiftSlot, delta);
 
@@ -215,10 +247,15 @@ namespace HandheldCompanion.Actions
                     if (firstTouch)
                     {
                         prevVector = outVector;
+                        trackpadHapticDistance = 0f;
                         return;
                     }
-                    deltaVector = (outVector - prevVector) / short.MaxValue;
+
+                    Vector2 trackpadDelta = outVector - prevVector;
                     prevVector = outVector;
+                    UpdateTrackpadHaptics(layout.flags, touched, trackpadDelta);
+
+                    deltaVector = trackpadDelta / short.MaxValue;
                     sensitivityScale = MouseType == MouseActionsType.Move ? 9.0f : 3.0f;
                     break;
             }
@@ -242,6 +279,33 @@ namespace HandheldCompanion.Actions
                 MouseSimulator.MoveBy((int)intDelta.X, (int)intDelta.Y);
             else
                 MouseSimulator.VerticalScroll((int)-intDelta.Y);
+        }
+
+        private void UpdateTrackpadHaptics(AxisLayoutFlags axis, bool touched, Vector2 delta)
+        {
+            if (!touched || HapticMode == HapticMode.Off)
+                return;
+
+            // Firmware-provided trackpad feedback is lost when Steam lizard mode is disabled.
+            // Only replace it for physical Steam controllers; other trackpads may provide their
+            // own feedback and should not receive controller-rumble pulses while moving.
+            if (ControllerManager.GetTarget() is not HandheldCompanion.Controllers.Steam.SteamController)
+                return;
+
+            float distance = delta.Length();
+            if (distance < TrackpadHapticJitterThreshold)
+                return;
+
+            trackpadHapticDistance += distance;
+            if (trackpadHapticDistance < TrackpadHapticStep)
+                return;
+
+            trackpadHapticDistance %= TrackpadHapticStep;
+
+            ButtonFlags button = axis == AxisLayoutFlags.LeftPad
+                ? ButtonFlags.LeftPadTouch
+                : ButtonFlags.RightPadTouch;
+            SetHaptic(button, released: false);
         }
 
         private Vector2 ComputeStickDelta(Vector2 raw)

--- a/HandheldCompanion/Actions/MouseActions.cs
+++ b/HandheldCompanion/Actions/MouseActions.cs
@@ -197,13 +197,22 @@ namespace HandheldCompanion.Actions
             if (!touched)
                 ResetTrackpadHaptics();
 
-            outVector = layout.vector;
+            Vector2 rawVector = layout.vector;
+            outVector = rawVector;
             base.Execute(layout, shiftSlot, delta);
+
+            bool isTrackpad = layout.flags is AxisLayoutFlags.LeftPad or AxisLayoutFlags.RightPad;
+            if (axisSlotDisabled && isTrackpad)
+            {
+                rawVector.Y *= -1;
+                prevVector = rawVector;
+                ResetTrackpadHaptics();
+                return;
+            }
 
             // Invert Y so that "up" on a stick or pad moves the cursor up
             outVector.Y *= -1;
 
-            bool isTrackpad = layout.flags is AxisLayoutFlags.LeftPad or AxisLayoutFlags.RightPad;
             if (firstTouch && isTrackpad)
             {
                 prevVector = outVector;
@@ -211,7 +220,8 @@ namespace HandheldCompanion.Actions
                 return;
             }
 
-            if (outVector == Vector2.Zero) return;
+            // Zero is the center of an absolute trackpad, not an absence of input.
+            if (outVector == Vector2.Zero && (!isTrackpad || !touched)) return;
 
             Vector2 deltaVector;
             float sensitivityScale;
@@ -266,10 +276,11 @@ namespace HandheldCompanion.Actions
                 return;
             }
 
-            // Firmware-provided trackpad feedback is lost when Steam lizard mode is disabled.
-            // Only replace it for physical Steam controllers; other trackpads may provide their
-            // own feedback and should not receive controller-rumble pulses while moving.
-            if (ControllerManager.GetTarget() is not HandheldCompanion.Controllers.Steam.SteamController steamController ||
+            // Steam firmware provides its own feedback in lizard mode. Other controllers can use
+            // their normal haptic implementation when the mapped action enables feedback.
+            var targetController = ControllerManager.GetTarget();
+            if (targetController is null ||
+                targetController is HandheldCompanion.Controllers.Steam.SteamController steamController &&
                 steamController.IsLizardModeEnabled)
             {
                 ResetTrackpadHaptics();

--- a/HandheldCompanion/Actions/MouseActions.cs
+++ b/HandheldCompanion/Actions/MouseActions.cs
@@ -41,6 +41,7 @@ namespace HandheldCompanion.Actions
         private OneEuroFilterPair mouseFilter;
         private float accelMemory = 0f;
         private float trackpadHapticDistance = 0f;
+        private Vector2 trackpadHapticJitter = new();
 
         // Click settings
         public ModifierSet Modifiers = ModifierSet.None;
@@ -156,31 +157,6 @@ namespace HandheldCompanion.Actions
             }
         }
 
-        public override void SetHaptic(ButtonFlags button, bool released)
-        {
-            bool isTrackpadClick = button is
-                ButtonFlags.LeftPadClick or
-                ButtonFlags.LeftPadClickUp or
-                ButtonFlags.LeftPadClickDown or
-                ButtonFlags.LeftPadClickLeft or
-                ButtonFlags.LeftPadClickRight or
-                ButtonFlags.RightPadClick or
-                ButtonFlags.RightPadClickUp or
-                ButtonFlags.RightPadClickDown or
-                ButtonFlags.RightPadClickLeft or
-                ButtonFlags.RightPadClickRight;
-
-            if (isTrackpadClick &&
-                ControllerManager.GetTarget() is HandheldCompanion.Controllers.Steam.SteamController)
-            {
-                // Physical Steam trackpad clicks are handled once at controller level so the
-                // shared Controller-page setting applies to both pads, regardless of mapping.
-                return;
-            }
-
-            base.SetHaptic(button, released);
-        }
-
         public void Execute(AxisLayout layout, bool touched, ShiftSlot shiftSlot, float delta)
         {
             switch (MouseType)
@@ -219,15 +195,23 @@ namespace HandheldCompanion.Actions
             bool firstTouch = ConsumeNewTouch(touched);
 
             if (!touched)
-                trackpadHapticDistance = 0f;
+                ResetTrackpadHaptics();
 
             outVector = layout.vector;
             base.Execute(layout, shiftSlot, delta);
 
-            if (outVector == Vector2.Zero) return;
-
             // Invert Y so that "up" on a stick or pad moves the cursor up
             outVector.Y *= -1;
+
+            bool isTrackpad = layout.flags is AxisLayoutFlags.LeftPad or AxisLayoutFlags.RightPad;
+            if (firstTouch && isTrackpad)
+            {
+                prevVector = outVector;
+                ResetTrackpadHaptics();
+                return;
+            }
+
+            if (outVector == Vector2.Zero) return;
 
             Vector2 deltaVector;
             float sensitivityScale;
@@ -244,13 +228,6 @@ namespace HandheldCompanion.Actions
 
                 case AxisLayoutFlags.LeftPad:
                 case AxisLayoutFlags.RightPad:
-                    if (firstTouch)
-                    {
-                        prevVector = outVector;
-                        trackpadHapticDistance = 0f;
-                        return;
-                    }
-
                     Vector2 trackpadDelta = outVector - prevVector;
                     prevVector = outVector;
                     UpdateTrackpadHaptics(layout.flags, touched, trackpadDelta);
@@ -284,18 +261,27 @@ namespace HandheldCompanion.Actions
         private void UpdateTrackpadHaptics(AxisLayoutFlags axis, bool touched, Vector2 delta)
         {
             if (!touched || HapticMode == HapticMode.Off)
+            {
+                ResetTrackpadHaptics();
                 return;
+            }
 
             // Firmware-provided trackpad feedback is lost when Steam lizard mode is disabled.
             // Only replace it for physical Steam controllers; other trackpads may provide their
             // own feedback and should not receive controller-rumble pulses while moving.
-            if (ControllerManager.GetTarget() is not HandheldCompanion.Controllers.Steam.SteamController)
+            if (ControllerManager.GetTarget() is not HandheldCompanion.Controllers.Steam.SteamController steamController ||
+                steamController.IsLizardModeEnabled)
+            {
+                ResetTrackpadHaptics();
                 return;
+            }
 
-            float distance = delta.Length();
+            trackpadHapticJitter += delta;
+            float distance = trackpadHapticJitter.Length();
             if (distance < TrackpadHapticJitterThreshold)
                 return;
 
+            trackpadHapticJitter = Vector2.Zero;
             trackpadHapticDistance += distance;
             if (trackpadHapticDistance < TrackpadHapticStep)
                 return;
@@ -306,6 +292,12 @@ namespace HandheldCompanion.Actions
                 ? ButtonFlags.LeftPadTouch
                 : ButtonFlags.RightPadTouch;
             SetHaptic(button, released: false);
+        }
+
+        private void ResetTrackpadHaptics()
+        {
+            trackpadHapticDistance = 0f;
+            trackpadHapticJitter = Vector2.Zero;
         }
 
         private Vector2 ComputeStickDelta(Vector2 raw)

--- a/HandheldCompanion/Actions/TouchpadActions.cs
+++ b/HandheldCompanion/Actions/TouchpadActions.cs
@@ -1,4 +1,5 @@
 using HandheldCompanion.Inputs;
+using HandheldCompanion.Misc;
 using System;
 
 namespace HandheldCompanion.Actions
@@ -6,11 +7,31 @@ namespace HandheldCompanion.Actions
     [Serializable]
     public sealed class TouchpadActions : ButtonActions
     {
-        public int X = 960;
-        public int Y = 471;
-        public int EndX = 1440;
-        public int EndY = 471;
-        public float SwipeDuration = 300.0f;
+        public const float MinimumSwipeDuration = 16.0f;
+        public const float MaximumSwipeDuration = 5000.0f;
+
+        internal static readonly ButtonFlags[] Targets =
+        [
+            ButtonFlags.TouchpadCoordinateClick,
+            ButtonFlags.TouchpadCoordinateTouch,
+            ButtonFlags.TouchpadSwipe,
+        ];
+
+        private int x = DS4Touch.TOUCHPAD_WIDTH / 2;
+        private int y = DS4Touch.TOUCHPAD_HEIGHT / 2;
+        private int endX = DS4Touch.TOUCHPAD_WIDTH * 3 / 4;
+        private int endY = DS4Touch.TOUCHPAD_HEIGHT / 2;
+        private float swipeDuration = 300.0f;
+
+        public int X { get => x; set => x = Math.Clamp(value, 0, DS4Touch.TOUCHPAD_WIDTH - 1); }
+        public int Y { get => y; set => y = Math.Clamp(value, 0, DS4Touch.TOUCHPAD_HEIGHT - 1); }
+        public int EndX { get => endX; set => endX = Math.Clamp(value, 0, DS4Touch.TOUCHPAD_WIDTH - 1); }
+        public int EndY { get => endY; set => endY = Math.Clamp(value, 0, DS4Touch.TOUCHPAD_HEIGHT - 1); }
+        public float SwipeDuration
+        {
+            get => swipeDuration;
+            set => swipeDuration = Math.Clamp(value, MinimumSwipeDuration, MaximumSwipeDuration);
+        }
 
         [NonSerialized] private bool wasPressed;
         [NonSerialized] private bool swipeActive;
@@ -38,9 +59,9 @@ namespace HandheldCompanion.Actions
             else if (swipeActive)
             {
                 swipeElapsed += delta;
-                if (swipeElapsed >= Math.Max(1.0f, SwipeDuration))
+                if (swipeElapsed >= SwipeDuration)
                 {
-                    swipeElapsed = Math.Max(1.0f, SwipeDuration);
+                    swipeElapsed = SwipeDuration;
                     swipeEndsAfterReport = true;
                 }
             }
@@ -48,26 +69,46 @@ namespace HandheldCompanion.Actions
             wasPressed = pressed;
         }
 
-        public bool ConsumeTouch(out int x, out int y)
+        internal bool TryGetTouch(out TouchpadSample sample)
         {
+            int x;
+            int y;
+            bool active;
+
             if (Button == ButtonFlags.TouchpadSwipe)
             {
-                float duration = Math.Max(1.0f, SwipeDuration);
-                float progress = Math.Clamp(swipeElapsed / duration, 0.0f, 1.0f);
+                float progress = Math.Clamp(swipeElapsed / SwipeDuration, 0.0f, 1.0f);
                 x = (int)MathF.Round(X + (EndX - X) * progress);
                 y = (int)MathF.Round(Y + (EndY - Y) * progress);
-                bool active = swipeActive;
+                active = swipeActive;
                 if (swipeEndsAfterReport)
                 {
                     swipeActive = false;
                     swipeEndsAfterReport = false;
                 }
-                return active;
+            }
+            else
+            {
+                x = X;
+                y = Y;
+                active = GetValue();
             }
 
-            x = X;
-            y = Y;
-            return GetValue();
+            sample = active
+                ? new TouchpadSample(Button, x, y)
+                : default;
+            return active;
         }
+    }
+
+    internal readonly record struct TouchpadSample(ButtonFlags Target, int X, int Y)
+    {
+        public int Priority => Target switch
+        {
+            ButtonFlags.TouchpadCoordinateClick => 3,
+            ButtonFlags.TouchpadSwipe => 2,
+            ButtonFlags.TouchpadCoordinateTouch => 1,
+            _ => 0,
+        };
     }
 }

--- a/HandheldCompanion/Actions/TouchpadActions.cs
+++ b/HandheldCompanion/Actions/TouchpadActions.cs
@@ -41,8 +41,7 @@ namespace HandheldCompanion.Actions
             ButtonFlags.RightPadClickRight,
         ];
 
-        private static readonly ButtonFlags[] AllClickSources =
-            [.. LeftClickSources, .. RightClickSources, ButtonFlags.CenterPadClick];
+        private static readonly ButtonFlags[] AllClickSources = [.. LeftClickSources, .. RightClickSources];
 
         public const float MinimumSwipeDuration = 16.0f;
         public const float MaximumSwipeDuration = 5000.0f;
@@ -51,10 +50,8 @@ namespace HandheldCompanion.Actions
         private const float HapticStep = (short.MaxValue - short.MinValue) / 10.0f;
         private const float HapticJitterThreshold = 128.0f;
 
-        internal static readonly ButtonFlags[] CoordinateTargets =
+        internal static readonly ButtonFlags[] GestureTargets =
         [
-            ButtonFlags.TouchpadCoordinateClick,
-            ButtonFlags.TouchpadCoordinateTouch,
             ButtonFlags.TouchpadSwipe,
         ];
 
@@ -63,6 +60,7 @@ namespace HandheldCompanion.Actions
         public AxisLayoutFlags Axis;
         public short ButtonX;
         public short ButtonY;
+        private byte finger = 1;
 
         private int x = DS4Touch.TOUCHPAD_WIDTH / 2;
         private int y = DS4Touch.TOUCHPAD_HEIGHT / 2;
@@ -74,6 +72,7 @@ namespace HandheldCompanion.Actions
         public int Y { get => y; set => y = Math.Clamp(value, 0, DS4Touch.TOUCHPAD_HEIGHT - 1); }
         public int EndX { get => endX; set => endX = Math.Clamp(value, 0, DS4Touch.TOUCHPAD_WIDTH - 1); }
         public int EndY { get => endY; set => endY = Math.Clamp(value, 0, DS4Touch.TOUCHPAD_HEIGHT - 1); }
+        public byte Finger { get => finger; set => finger = (byte)Math.Clamp((int)value, 1, 2); }
         public float SwipeDuration
         {
             get => swipeDuration;
@@ -137,17 +136,17 @@ namespace HandheldCompanion.Actions
             Button = ButtonFlags.None;
         }
 
-        public static bool IsCoordinateTarget(ButtonFlags button) => button is
-            ButtonFlags.TouchpadCoordinateClick or ButtonFlags.TouchpadCoordinateTouch or ButtonFlags.TouchpadSwipe;
+        public static bool IsGestureTarget(ButtonFlags button) => button is
+            ButtonFlags.TouchpadClick or ButtonFlags.TouchpadTouch or ButtonFlags.TouchpadSwipe;
 
         public static bool IsTouchpadButton(ButtonFlags button) => button is
             ButtonFlags.LeftPadTouch or ButtonFlags.RightPadTouch or
-            ButtonFlags.LeftPadClick or ButtonFlags.RightPadClick or ButtonFlags.CenterPadClick or
+            ButtonFlags.LeftPadClick or ButtonFlags.RightPadClick or
             ButtonFlags.LeftPadClickUp or ButtonFlags.LeftPadClickDown or
             ButtonFlags.LeftPadClickLeft or ButtonFlags.LeftPadClickRight or
             ButtonFlags.RightPadClickUp or ButtonFlags.RightPadClickDown or
             ButtonFlags.RightPadClickLeft or ButtonFlags.RightPadClickRight or
-            ButtonFlags.TouchpadCoordinateClick or ButtonFlags.TouchpadCoordinateTouch or ButtonFlags.TouchpadSwipe;
+            ButtonFlags.TouchpadClick or ButtonFlags.TouchpadTouch or ButtonFlags.TouchpadSwipe;
 
         public static bool IsLeftPadClick(ButtonFlags button) => button is
             ButtonFlags.LeftPadClick or ButtonFlags.LeftPadClickUp or ButtonFlags.LeftPadClickDown or
@@ -157,8 +156,7 @@ namespace HandheldCompanion.Actions
             ButtonFlags.RightPadClick or ButtonFlags.RightPadClickUp or ButtonFlags.RightPadClickDown or
             ButtonFlags.RightPadClickLeft or ButtonFlags.RightPadClickRight;
 
-        public static bool IsPhysicalClick(ButtonFlags button) =>
-            IsLeftPadClick(button) || IsRightPadClick(button) || button == ButtonFlags.CenterPadClick;
+        public static bool IsPhysicalClick(ButtonFlags button) => IsLeftPadClick(button) || IsRightPadClick(button);
 
         public static bool HasCustomHapticSettings(IActions action) =>
             action.HapticOverride == true;
@@ -166,22 +164,22 @@ namespace HandheldCompanion.Actions
         public static bool IsTouchpadAxis(AxisLayoutFlags axis) => axis is
             AxisLayoutFlags.LeftPad or AxisLayoutFlags.RightPad;
 
-        private static bool SupportsCoordinateTargets(IController controller) => controller is
+        private static bool SupportsGestureTargets(IController controller) => controller is
             DummyDualShock4Controller or DummyDualSenseController;
 
         public static bool HasTargets(IController controller) =>
             controller.GetTargetButtons().Any(IsTouchpadButton) ||
             controller.GetTargetAxis().Any(IsTouchpadAxis) ||
-            SupportsCoordinateTargets(controller);
+            SupportsGestureTargets(controller);
 
         public static IEnumerable<ButtonFlags> GetButtonTargets(IController controller)
         {
             foreach (ButtonFlags button in controller.GetTargetButtons().Where(IsTouchpadButton))
                 yield return button;
 
-            if (SupportsCoordinateTargets(controller))
+            if (SupportsGestureTargets(controller))
             {
-                foreach (ButtonFlags button in CoordinateTargets)
+                foreach (ButtonFlags button in GestureTargets)
                     yield return button;
             }
         }
@@ -275,7 +273,7 @@ namespace HandheldCompanion.Actions
 
         internal bool TryGetTouch(out TouchpadSample sample)
         {
-            if (TargetType != TouchpadTargetType.Button || !IsCoordinateTarget(Button))
+            if (TargetType != TouchpadTargetType.Button || !IsGestureTarget(Button))
             {
                 sample = default;
                 return false;
@@ -299,7 +297,9 @@ namespace HandheldCompanion.Actions
             }
             else
             {
-                x = X;
+                x = Button == ButtonFlags.TouchpadClick
+                    ? Finger == 1 ? DS4Touch.TOUCHPAD_WIDTH / 4 : DS4Touch.TOUCHPAD_WIDTH * 3 / 4
+                    : X;
                 y = Y;
                 active = outBool;
             }
@@ -324,8 +324,6 @@ namespace HandheldCompanion.Actions
                 state.ButtonState[ButtonFlags.RightPadClickDown] ||
                 state.ButtonState[ButtonFlags.RightPadClickLeft] ||
                 state.ButtonState[ButtonFlags.RightPadClickRight];
-            bool centerPressed = state.ButtonState[ButtonFlags.CenterPadClick];
-
             if (controller is null)
             {
                 clickController = null;
@@ -343,7 +341,7 @@ namespace HandheldCompanion.Actions
                 clickController = controller;
                 leftClickPressed = leftPressed;
                 rightClickPressed = rightPressed;
-                genericClickPressed = leftPressed || rightPressed || centerPressed;
+                genericClickPressed = leftPressed || rightPressed;
                 genericClickButton = GetPressedClickButton(leftPressed, rightPressed);
                 leftClickProfile = default;
                 rightClickProfile = default;
@@ -356,7 +354,7 @@ namespace HandheldCompanion.Actions
             {
                 leftClickPressed = leftPressed;
                 rightClickPressed = rightPressed;
-                genericClickPressed = leftPressed || rightPressed || centerPressed;
+                genericClickPressed = leftPressed || rightPressed;
                 leftClickProfile = default;
                 rightClickProfile = default;
                 genericClickProfile = default;
@@ -374,7 +372,7 @@ namespace HandheldCompanion.Actions
                 return;
             }
 
-            bool pressed = leftPressed || rightPressed || centerPressed;
+            bool pressed = leftPressed || rightPressed;
             if (pressed && !genericClickPressed)
                 genericClickButton = GetPressedClickButton(leftPressed, rightPressed);
 
@@ -388,7 +386,7 @@ namespace HandheldCompanion.Actions
                 ? ButtonFlags.LeftPadClick
                 : rightPressed
                     ? ButtonFlags.RightPadClick
-                    : ButtonFlags.CenterPadClick;
+                    : ButtonFlags.None;
 
         private static void UpdateClickHaptic(IController controller, ButtonFlags button, bool pressed,
             ref bool wasPressed, ref ClickHapticProfile profile, ControllerState state, ShiftSlot shiftSlot,
@@ -530,9 +528,9 @@ namespace HandheldCompanion.Actions
     {
         public int Priority => Target switch
         {
-            ButtonFlags.TouchpadCoordinateClick => 3,
+            ButtonFlags.TouchpadClick => 3,
             ButtonFlags.TouchpadSwipe => 2,
-            ButtonFlags.TouchpadCoordinateTouch => 1,
+            ButtonFlags.TouchpadTouch => 1,
             _ => 0,
         };
     }

--- a/HandheldCompanion/Actions/TouchpadActions.cs
+++ b/HandheldCompanion/Actions/TouchpadActions.cs
@@ -21,6 +21,9 @@ namespace HandheldCompanion.Actions
 
         public TouchpadActions(ButtonFlags button) : base(button) { }
 
+        public static bool IsTouchpadTarget(ButtonFlags button) => button is
+            ButtonFlags.TouchpadCoordinateClick or ButtonFlags.TouchpadCoordinateTouch or ButtonFlags.TouchpadSwipe;
+
         public override void Execute(ButtonFlags button, bool value, ShiftSlot shiftSlot, float delta)
         {
             base.Execute(button, value, shiftSlot, delta);
@@ -45,17 +48,14 @@ namespace HandheldCompanion.Actions
             wasPressed = pressed;
         }
 
-        public bool TryGetTouch(out int x, out int y, out bool click)
+        public bool ConsumeTouch(out int x, out int y)
         {
-            click = Button == ButtonFlags.TouchpadCoordinateClick;
-
             if (Button == ButtonFlags.TouchpadSwipe)
             {
                 float duration = Math.Max(1.0f, SwipeDuration);
                 float progress = Math.Clamp(swipeElapsed / duration, 0.0f, 1.0f);
                 x = (int)MathF.Round(X + (EndX - X) * progress);
                 y = (int)MathF.Round(Y + (EndY - Y) * progress);
-                click = false;
                 bool active = swipeActive;
                 if (swipeEndsAfterReport)
                 {

--- a/HandheldCompanion/Actions/TouchpadActions.cs
+++ b/HandheldCompanion/Actions/TouchpadActions.cs
@@ -9,6 +9,7 @@ namespace HandheldCompanion.Actions
     {
         public const float MinimumSwipeDuration = 16.0f;
         public const float MaximumSwipeDuration = 5000.0f;
+        public const float DefaultSwipeDuration = 300.0f;
 
         internal static readonly ButtonFlags[] Targets =
         [
@@ -21,7 +22,7 @@ namespace HandheldCompanion.Actions
         private int y = DS4Touch.TOUCHPAD_HEIGHT / 2;
         private int endX = DS4Touch.TOUCHPAD_WIDTH * 3 / 4;
         private int endY = DS4Touch.TOUCHPAD_HEIGHT / 2;
-        private float swipeDuration = 300.0f;
+        private float swipeDuration = DefaultSwipeDuration;
 
         public int X { get => x; set => x = Math.Clamp(value, 0, DS4Touch.TOUCHPAD_WIDTH - 1); }
         public int Y { get => y; set => y = Math.Clamp(value, 0, DS4Touch.TOUCHPAD_HEIGHT - 1); }
@@ -30,7 +31,9 @@ namespace HandheldCompanion.Actions
         public float SwipeDuration
         {
             get => swipeDuration;
-            set => swipeDuration = Math.Clamp(value, MinimumSwipeDuration, MaximumSwipeDuration);
+            set => swipeDuration = float.IsFinite(value)
+                ? Math.Clamp(value, MinimumSwipeDuration, MaximumSwipeDuration)
+                : DefaultSwipeDuration;
         }
 
         [NonSerialized] private bool wasPressed;

--- a/HandheldCompanion/Actions/TouchpadActions.cs
+++ b/HandheldCompanion/Actions/TouchpadActions.cs
@@ -166,17 +166,20 @@ namespace HandheldCompanion.Actions
         public static bool IsTouchpadAxis(AxisLayoutFlags axis) => axis is
             AxisLayoutFlags.LeftPad or AxisLayoutFlags.RightPad;
 
+        private static bool SupportsCoordinateTargets(IController controller) => controller is
+            DummyDualShock4Controller or DummyDualSenseController;
+
         public static bool HasTargets(IController controller) =>
             controller.GetTargetButtons().Any(IsTouchpadButton) ||
             controller.GetTargetAxis().Any(IsTouchpadAxis) ||
-            controller is DummyDualSenseController;
+            SupportsCoordinateTargets(controller);
 
         public static IEnumerable<ButtonFlags> GetButtonTargets(IController controller)
         {
             foreach (ButtonFlags button in controller.GetTargetButtons().Where(IsTouchpadButton))
                 yield return button;
 
-            if (controller is DummyDualSenseController)
+            if (SupportsCoordinateTargets(controller))
             {
                 foreach (ButtonFlags button in CoordinateTargets)
                     yield return button;

--- a/HandheldCompanion/Actions/TouchpadActions.cs
+++ b/HandheldCompanion/Actions/TouchpadActions.cs
@@ -23,26 +23,6 @@ namespace HandheldCompanion.Actions
     [Serializable]
     public sealed class TouchpadActions : GyroActions
     {
-        private static readonly ButtonFlags[] LeftClickSources =
-        [
-            ButtonFlags.LeftPadClick,
-            ButtonFlags.LeftPadClickUp,
-            ButtonFlags.LeftPadClickDown,
-            ButtonFlags.LeftPadClickLeft,
-            ButtonFlags.LeftPadClickRight,
-        ];
-
-        private static readonly ButtonFlags[] RightClickSources =
-        [
-            ButtonFlags.RightPadClick,
-            ButtonFlags.RightPadClickUp,
-            ButtonFlags.RightPadClickDown,
-            ButtonFlags.RightPadClickLeft,
-            ButtonFlags.RightPadClickRight,
-        ];
-
-        private static readonly ButtonFlags[] AllClickSources = [.. LeftClickSources, .. RightClickSources];
-
         public const float MinimumSwipeDuration = 16.0f;
         public const float MaximumSwipeDuration = 5000.0f;
         public const float DefaultSwipeDuration = 300.0f;
@@ -60,6 +40,9 @@ namespace HandheldCompanion.Actions
         public AxisLayoutFlags Axis;
         public short ButtonX;
         public short ButtonY;
+        public int AxisAntiDeadZone = 0;
+        public int AxisDeadZoneInner = 0;
+        public int AxisDeadZoneOuter = 0;
         private byte finger = 1;
 
         private int x = DS4Touch.TOUCHPAD_WIDTH / 2;
@@ -87,18 +70,8 @@ namespace HandheldCompanion.Actions
         [NonSerialized] private float swipeElapsed;
         [NonSerialized] private bool isKeyDown;
         [NonSerialized] private bool isTouched;
-        private static MovementHapticState leftHaptics = new();
-        private static MovementHapticState rightHaptics = new();
-        private static IController? movementController;
-        private static bool leftClickPressed;
-        private static bool rightClickPressed;
-        private static bool genericClickPressed;
-        private static ButtonFlags genericClickButton = ButtonFlags.RightPadClick;
-        private static IController? clickController;
-        private static ClickHapticProfile leftClickProfile;
-        private static ClickHapticProfile rightClickProfile;
-        private static ClickHapticProfile genericClickProfile;
-        private static TouchpadSample?[] outputSamples = new TouchpadSample?[2];
+        [NonSerialized] private bool clickPressed;
+        [NonSerialized] private MovementHapticState movementHaptics = new();
 
         public TouchpadActions()
         {
@@ -119,8 +92,7 @@ namespace HandheldCompanion.Actions
         private void OnDeserialized(StreamingContext context)
         {
             actionType = ActionType.Touchpad;
-            leftHaptics ??= new();
-            rightHaptics ??= new();
+            movementHaptics ??= new();
         }
 
         public void SetTarget(ButtonFlags button)
@@ -201,11 +173,18 @@ namespace HandheldCompanion.Actions
 
             isTouched = outBool;
 
-            if (outBool != isKeyDown)
+            if (outBool)
             {
-                isKeyDown = outBool;
-                if (button != ButtonFlags.None)
-                    SetHaptic(button, released: !outBool);
+                if (!isKeyDown)
+                {
+                    isKeyDown = true;
+                    SetHaptic(button, released: false);
+                }
+            }
+            else if (isKeyDown)
+            {
+                isKeyDown = false;
+                SetHaptic(button, released: true);
             }
 
             UpdateGestureState(delta);
@@ -217,9 +196,12 @@ namespace HandheldCompanion.Actions
             {
                 outVector = layout.vector;
                 base.Execute(layout, shiftSlot, delta);
+                ApplyAxisDeadzones();
                 bool sourceReportsTouch = ControllerState.AxisTouchButtons.ContainsKey(layout.flags);
                 isTouched = !axisSlotDisabled &&
-                    (sourceReportsTouch ? touched : outVector != Vector2.Zero);
+                    outVector != Vector2.Zero &&
+                    (!sourceReportsTouch || touched);
+                UpdateMovementHaptics(isTouched, outVector);
                 return;
             }
 
@@ -239,6 +221,15 @@ namespace HandheldCompanion.Actions
                 _ => ButtonFlags.None,
             };
             Execute(sourceButton, pressed, shiftSlot, delta);
+        }
+
+        private void ApplyAxisDeadzones()
+        {
+            if (outVector == Vector2.Zero)
+                return;
+
+            outVector = InputUtils.ThumbScaledRadialInnerOuterDeadzone(outVector, AxisDeadZoneInner, AxisDeadZoneOuter);
+            outVector = InputUtils.ApplyAntiDeadzone(outVector, AxisAntiDeadZone);
         }
 
         public bool GetButtonValue() => outBool;
@@ -309,18 +300,14 @@ namespace HandheldCompanion.Actions
             return active;
         }
 
-        internal static void BeginOutputFrame()
-        {
-            Array.Clear(outputSamples);
-            DS4Touch.ClearOutputTouches();
-        }
-
-        internal void ApplyOutput(ControllerState outputState,
-            AxisFlags outputAxisX = AxisFlags.None, AxisFlags outputAxisY = AxisFlags.None)
+        internal void ApplyOutput(ControllerState outputState)
         {
             if (TargetType == TouchpadTargetType.Axis)
             {
                 Vector2 value = GetAxisValue();
+                var layout = AxisLayout.Layouts[Axis];
+                AxisFlags outputAxisX = layout.GetAxisFlags('X');
+                AxisFlags outputAxisY = layout.GetAxisFlags('Y');
                 outputState.AxisState[outputAxisX] = ClampShort(outputState.AxisState[outputAxisX] + value.X);
                 outputState.AxisState[outputAxisY] = ClampShort(outputState.AxisState[outputAxisY] + value.Y);
 
@@ -335,216 +322,63 @@ namespace HandheldCompanion.Actions
                     return;
 
                 outputState.ButtonState[Button] |= true;
-                int fingerIndex = sample.Finger - 1;
-                if (outputSamples[fingerIndex] is null || sample.Priority > outputSamples[fingerIndex]!.Value.Priority)
-                    outputSamples[fingerIndex] = sample;
+                DS4Touch.SetOutputTouch(sample.Finger, sample.X, sample.Y);
                 return;
             }
 
             outputState.ButtonState[Button] |= GetButtonValue();
         }
 
-        internal static void CommitOutputFrame()
+        internal void ApplyGyroOutput(ControllerState outputState)
         {
-            foreach (TouchpadSample? sample in outputSamples)
-            {
-                if (sample is TouchpadSample value)
-                    DS4Touch.SetOutputTouch(value.Finger, value.X, value.Y);
-            }
+            var layout = AxisLayout.Layouts[Axis];
+            var outputAxisX = layout.GetAxisFlags('X');
+            var outputAxisY = layout.GetAxisFlags('Y');
+            var current = new Vector2(outputState.AxisState[outputAxisX], outputState.AxisState[outputAxisY]);
+            float padNorm = Math.Clamp(current.Length() / short.MaxValue, 0f, 1f);
+            float weightFactor = gyroWeight - padNorm;
+            var blended = current + GetAxisValue() * weightFactor;
+
+            outputState.AxisState[outputAxisX] = ClampShort(blended.X);
+            outputState.AxisState[outputAxisY] = ClampShort(blended.Y);
+
+            if (ControllerState.AxisTouchButtons.TryGetValue(Axis, out ButtonFlags touchButton))
+                outputState.ButtonState[touchButton] |= GetTouchValue();
         }
 
-        internal static void UpdateClickHaptics(ControllerState state, ShiftSlot shiftSlot,
-            IReadOnlyDictionary<ButtonFlags, IActions[]> buttonPlan)
+        private void UpdateMovementHaptics(bool touched, Vector2 position)
         {
-            IController? controller = ControllerManager.GetTarget();
-            bool leftPressed = state.ButtonState[ButtonFlags.LeftPadClick] ||
-                state.ButtonState[ButtonFlags.LeftPadClickUp] ||
-                state.ButtonState[ButtonFlags.LeftPadClickDown] ||
-                state.ButtonState[ButtonFlags.LeftPadClickLeft] ||
-                state.ButtonState[ButtonFlags.LeftPadClickRight];
-            bool rightPressed = state.ButtonState[ButtonFlags.RightPadClick] ||
-                state.ButtonState[ButtonFlags.RightPadClickUp] ||
-                state.ButtonState[ButtonFlags.RightPadClickDown] ||
-                state.ButtonState[ButtonFlags.RightPadClickLeft] ||
-                state.ButtonState[ButtonFlags.RightPadClickRight];
-            if (controller is null)
+            if (!touched || HapticMode is not (HapticMode.Down or HapticMode.Both) ||
+                ControllerManager.GetTarget() is not IController controller ||
+                controller is SteamController { IsLizardModeEnabled: true })
             {
-                clickController = null;
-                leftClickPressed = false;
-                rightClickPressed = false;
-                genericClickPressed = false;
-                leftClickProfile = default;
-                rightClickProfile = default;
-                genericClickProfile = default;
+                movementHaptics.Reset(touched, position);
                 return;
             }
 
-            if (!ReferenceEquals(clickController, controller))
+            if (!movementHaptics.WasTouched)
             {
-                clickController = controller;
-                leftClickPressed = leftPressed;
-                rightClickPressed = rightPressed;
-                genericClickPressed = leftPressed || rightPressed;
-                genericClickButton = GetPressedClickButton(leftPressed, rightPressed);
-                leftClickProfile = default;
-                rightClickProfile = default;
-                genericClickProfile = default;
+                movementHaptics.Reset(touched: true, position);
                 return;
             }
 
-            bool disabledByFirmware = controller is SteamController steamController && steamController.IsLizardModeEnabled;
-            if (disabledByFirmware)
-            {
-                leftClickPressed = leftPressed;
-                rightClickPressed = rightPressed;
-                genericClickPressed = leftPressed || rightPressed;
-                leftClickProfile = default;
-                rightClickProfile = default;
-                genericClickProfile = default;
-                return;
-            }
+            Vector2 delta = position - movementHaptics.PreviousPosition;
+            movementHaptics.PreviousPosition = position;
+            movementHaptics.Jitter += delta;
 
-            if (controller is SteamController)
-            {
-                UpdateClickHaptic(controller, ButtonFlags.LeftPadClick,
-                    leftPressed, ref leftClickPressed, ref leftClickProfile,
-                    state, shiftSlot, buttonPlan, LeftClickSources);
-                UpdateClickHaptic(controller, ButtonFlags.RightPadClick,
-                    rightPressed, ref rightClickPressed, ref rightClickProfile,
-                    state, shiftSlot, buttonPlan, RightClickSources);
-                return;
-            }
-
-            bool pressed = leftPressed || rightPressed;
-            if (pressed && !genericClickPressed)
-                genericClickButton = GetPressedClickButton(leftPressed, rightPressed);
-
-            UpdateClickHaptic(controller, genericClickButton, pressed, ref genericClickPressed,
-                ref genericClickProfile, state, shiftSlot,
-                buttonPlan, AllClickSources);
-        }
-
-        private static ButtonFlags GetPressedClickButton(bool leftPressed, bool rightPressed) =>
-            leftPressed
-                ? ButtonFlags.LeftPadClick
-                : rightPressed
-                    ? ButtonFlags.RightPadClick
-                    : ButtonFlags.None;
-
-        private static void UpdateClickHaptic(IController controller, ButtonFlags button, bool pressed,
-            ref bool wasPressed, ref ClickHapticProfile profile, ControllerState state, ShiftSlot shiftSlot,
-            IReadOnlyDictionary<ButtonFlags, IActions[]> buttonPlan, ButtonFlags[] sources)
-        {
-            if (pressed == wasPressed)
-                return;
-
-            wasPressed = pressed;
-            if (pressed)
-                profile = ResolveClickHapticProfile(state, shiftSlot, buttonPlan, sources);
-
-            bool released = !pressed;
-            if (profile.Mode == HapticMode.Off ||
-                profile.Mode == HapticMode.Down && released ||
-                profile.Mode == HapticMode.Up && !released)
-                return;
-
-            controller.SetTrackpadClickHaptic(profile.Strength, button, released: !pressed);
-        }
-
-        private static ClickHapticProfile ResolveClickHapticProfile(ControllerState state,
-            ShiftSlot shiftSlot, IReadOnlyDictionary<ButtonFlags, IActions[]> buttonPlan,
-            ButtonFlags[] sources)
-        {
-            bool hasOverride = false;
-            int combinedMode = (int)HapticMode.Off;
-            HapticStrength strength = HapticStrength.Low;
-
-            foreach (ButtonFlags source in sources)
-            {
-                if (!state.ButtonState[source] || !buttonPlan.TryGetValue(source, out IActions[]? actions))
-                    continue;
-
-                foreach (IActions action in actions)
-                {
-                    if (!HasCustomHapticSettings(action) ||
-                        !IsShiftAllowed(shiftSlot, action.ShiftSlot, action.ShiftMatchAny))
-                        continue;
-
-                    hasOverride = true;
-                    combinedMode |= (int)action.HapticMode;
-                    if (action.HapticMode != HapticMode.Off &&
-                        (int)action.HapticStrength > (int)strength)
-                        strength = action.HapticStrength;
-                }
-            }
-
-            if (hasOverride)
-                return new ClickHapticProfile((HapticMode)combinedMode, strength);
-
-            int globalStrength = ManagerFactory.settingsManager.GetInt("TrackpadClickHaptics");
-            return globalStrength <= 0
-                ? default
-                : new ClickHapticProfile(HapticMode.Both,
-                    (HapticStrength)Math.Clamp(globalStrength - 1, 0, 2));
-        }
-
-        internal static void UpdateMovementHaptics(AxisLayoutFlags axis, Vector2 position, bool touched,
-            ShiftSlot shiftSlot, IActions[] actions)
-        {
-            MovementHapticState state = axis == AxisLayoutFlags.LeftPad ? leftHaptics : rightHaptics;
-            IActions? hapticAction = null;
-            for (int i = 0; i < actions.Length; i++)
-            {
-                IActions action = actions[i];
-                if (action.HapticMode is HapticMode.Down or HapticMode.Both &&
-                    IsShiftAllowed(shiftSlot, action.ShiftSlot, action.ShiftMatchAny) &&
-                    (action is MouseActions { MouseType: MouseActionsType.Move or MouseActionsType.Scroll } ||
-                     action is TouchpadActions { TargetType: TouchpadTargetType.Axis }))
-                {
-                    hapticAction = action;
-                    break;
-                }
-            }
-
-            IController? controller = ControllerManager.GetTarget();
-            if (!ReferenceEquals(movementController, controller))
-            {
-                movementController = controller;
-                leftHaptics.Reset(touched: false, Vector2.Zero);
-                rightHaptics.Reset(touched: false, Vector2.Zero);
-            }
-
-            if (!touched || hapticAction is null || controller is null ||
-                controller is SteamController steamController && steamController.IsLizardModeEnabled)
-            {
-                state.Reset(touched, position);
-                return;
-            }
-
-            if (!state.WasTouched)
-            {
-                state.Reset(touched: true, position);
-                return;
-            }
-
-            Vector2 delta = position - state.PreviousPosition;
-            state.PreviousPosition = position;
-            state.Jitter += delta;
-
-            float distance = state.Jitter.Length();
+            float distance = movementHaptics.Jitter.Length();
             if (distance < HapticJitterThreshold)
                 return;
 
-            state.Jitter = Vector2.Zero;
-            state.Distance += distance;
-            if (state.Distance < HapticStep)
+            movementHaptics.Jitter = Vector2.Zero;
+            movementHaptics.Distance += distance;
+            if (movementHaptics.Distance < HapticStep)
                 return;
 
-            state.Distance %= HapticStep;
-            ButtonFlags button = axis == AxisLayoutFlags.LeftPad
-                ? ButtonFlags.LeftPadTouch
-                : ButtonFlags.RightPadTouch;
-            hapticAction.SetHaptic(button, released: false);
+            movementHaptics.Distance %= HapticStep;
+            ButtonFlags button = Axis == AxisLayoutFlags.LeftPad ? ButtonFlags.LeftPadTouch : ButtonFlags.RightPadTouch;
+
+            controller.SetHaptic(HapticStrength, button, released: false);
         }
 
         [Serializable]
@@ -570,13 +404,5 @@ namespace HandheldCompanion.Actions
     }
 
     internal readonly record struct TouchpadSample(ButtonFlags Target, byte Finger, int X, int Y)
-    {
-        public int Priority => Target switch
-        {
-            ButtonFlags.TouchpadClick => 3,
-            ButtonFlags.TouchpadSwipe => 2,
-            ButtonFlags.TouchpadTouch => 1,
-            _ => 0,
-        };
-    }
+    { }
 }

--- a/HandheldCompanion/Actions/TouchpadActions.cs
+++ b/HandheldCompanion/Actions/TouchpadActions.cs
@@ -131,14 +131,11 @@ namespace HandheldCompanion.Actions
 
         public static bool IsPhysicalClick(ButtonFlags button) => IsLeftPadClick(button) || IsRightPadClick(button);
 
-        public static bool HasCustomHapticSettings(IActions action) =>
-            action.HapticOverride == true;
-
         public static bool IsTouchpadAxis(AxisLayoutFlags axis) => axis is
             AxisLayoutFlags.LeftPad or AxisLayoutFlags.RightPad;
 
         private static bool SupportsGestureTargets(IController controller) => controller is
-            DummyDualShock4Controller or DummyDualSenseController;
+            DummyDualShock4Controller or DummyDualSenseController or SteamController;
 
         public static bool HasTargets(IController controller) =>
             controller.GetTargetButtons().Any(IsTouchpadButton) ||

--- a/HandheldCompanion/Actions/TouchpadActions.cs
+++ b/HandheldCompanion/Actions/TouchpadActions.cs
@@ -1,22 +1,68 @@
+using HandheldCompanion.Controllers;
+using HandheldCompanion.Controllers.Dummies;
+using HandheldCompanion.Controllers.Steam;
 using HandheldCompanion.Inputs;
+using HandheldCompanion.Managers;
 using HandheldCompanion.Misc;
+using HandheldCompanion.Utils;
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Runtime.Serialization;
 
 namespace HandheldCompanion.Actions
 {
     [Serializable]
-    public sealed class TouchpadActions : ButtonActions
+    public enum TouchpadTargetType
     {
+        Button = 0,
+        Axis = 1,
+    }
+
+    [Serializable]
+    public sealed class TouchpadActions : GyroActions
+    {
+        private static readonly ButtonFlags[] LeftClickSources =
+        [
+            ButtonFlags.LeftPadClick,
+            ButtonFlags.LeftPadClickUp,
+            ButtonFlags.LeftPadClickDown,
+            ButtonFlags.LeftPadClickLeft,
+            ButtonFlags.LeftPadClickRight,
+        ];
+
+        private static readonly ButtonFlags[] RightClickSources =
+        [
+            ButtonFlags.RightPadClick,
+            ButtonFlags.RightPadClickUp,
+            ButtonFlags.RightPadClickDown,
+            ButtonFlags.RightPadClickLeft,
+            ButtonFlags.RightPadClickRight,
+        ];
+
+        private static readonly ButtonFlags[] AllClickSources =
+            [.. LeftClickSources, .. RightClickSources, ButtonFlags.CenterPadClick];
+
         public const float MinimumSwipeDuration = 16.0f;
         public const float MaximumSwipeDuration = 5000.0f;
         public const float DefaultSwipeDuration = 300.0f;
 
-        internal static readonly ButtonFlags[] Targets =
+        private const float HapticStep = (short.MaxValue - short.MinValue) / 10.0f;
+        private const float HapticJitterThreshold = 128.0f;
+
+        internal static readonly ButtonFlags[] CoordinateTargets =
         [
             ButtonFlags.TouchpadCoordinateClick,
             ButtonFlags.TouchpadCoordinateTouch,
             ButtonFlags.TouchpadSwipe,
         ];
+
+        public TouchpadTargetType TargetType = TouchpadTargetType.Button;
+        public ButtonFlags Button;
+        public AxisLayoutFlags Axis;
+        public short ButtonX;
+        public short ButtonY;
 
         private int x = DS4Touch.TOUCHPAD_WIDTH / 2;
         private int y = DS4Touch.TOUCHPAD_HEIGHT / 2;
@@ -40,19 +86,171 @@ namespace HandheldCompanion.Actions
         [NonSerialized] private bool swipeActive;
         [NonSerialized] private bool swipeEndsAfterReport;
         [NonSerialized] private float swipeElapsed;
+        [NonSerialized] private bool isKeyDown;
+        [NonSerialized] private bool isTouched;
+        [NonSerialized] private MovementHapticState leftHaptics = new();
+        [NonSerialized] private MovementHapticState rightHaptics = new();
+        [NonSerialized] private IController? movementController;
+        [NonSerialized] private bool leftClickPressed;
+        [NonSerialized] private bool rightClickPressed;
+        [NonSerialized] private bool genericClickPressed;
+        [NonSerialized] private ButtonFlags genericClickButton = ButtonFlags.RightPadClick;
+        [NonSerialized] private IController? clickController;
+        [NonSerialized] private ClickHapticProfile leftClickProfile;
+        [NonSerialized] private ClickHapticProfile rightClickProfile;
+        [NonSerialized] private ClickHapticProfile genericClickProfile;
 
-        public TouchpadActions() { }
+        public TouchpadActions()
+        {
+            actionType = ActionType.Touchpad;
+        }
 
-        public TouchpadActions(ButtonFlags button) : base(button) { }
+        public TouchpadActions(ButtonFlags button) : this()
+        {
+            SetTarget(button);
+        }
 
-        public static bool IsTouchpadTarget(ButtonFlags button) => button is
+        public TouchpadActions(AxisLayoutFlags axis) : this()
+        {
+            SetTarget(axis);
+        }
+
+        [OnDeserialized]
+        private void OnDeserialized(StreamingContext context)
+        {
+            actionType = ActionType.Touchpad;
+            leftHaptics ??= new();
+            rightHaptics ??= new();
+        }
+
+        public void SetTarget(ButtonFlags button)
+        {
+            TargetType = TouchpadTargetType.Button;
+            Button = button;
+            Axis = AxisLayoutFlags.None;
+        }
+
+        public void SetTarget(AxisLayoutFlags axis)
+        {
+            TargetType = TouchpadTargetType.Axis;
+            Axis = axis;
+            Button = ButtonFlags.None;
+        }
+
+        public static bool IsCoordinateTarget(ButtonFlags button) => button is
             ButtonFlags.TouchpadCoordinateClick or ButtonFlags.TouchpadCoordinateTouch or ButtonFlags.TouchpadSwipe;
+
+        public static bool IsTouchpadButton(ButtonFlags button) => button is
+            ButtonFlags.LeftPadTouch or ButtonFlags.RightPadTouch or
+            ButtonFlags.LeftPadClick or ButtonFlags.RightPadClick or ButtonFlags.CenterPadClick or
+            ButtonFlags.LeftPadClickUp or ButtonFlags.LeftPadClickDown or
+            ButtonFlags.LeftPadClickLeft or ButtonFlags.LeftPadClickRight or
+            ButtonFlags.RightPadClickUp or ButtonFlags.RightPadClickDown or
+            ButtonFlags.RightPadClickLeft or ButtonFlags.RightPadClickRight or
+            ButtonFlags.TouchpadCoordinateClick or ButtonFlags.TouchpadCoordinateTouch or ButtonFlags.TouchpadSwipe;
+
+        public static bool IsLeftPadClick(ButtonFlags button) => button is
+            ButtonFlags.LeftPadClick or ButtonFlags.LeftPadClickUp or ButtonFlags.LeftPadClickDown or
+            ButtonFlags.LeftPadClickLeft or ButtonFlags.LeftPadClickRight;
+
+        public static bool IsRightPadClick(ButtonFlags button) => button is
+            ButtonFlags.RightPadClick or ButtonFlags.RightPadClickUp or ButtonFlags.RightPadClickDown or
+            ButtonFlags.RightPadClickLeft or ButtonFlags.RightPadClickRight;
+
+        public static bool IsPhysicalClick(ButtonFlags button) =>
+            IsLeftPadClick(button) || IsRightPadClick(button) || button == ButtonFlags.CenterPadClick;
+
+        public static bool HasCustomHapticSettings(IActions action) =>
+            action.HapticOverride == true;
+
+        public static bool IsTouchpadAxis(AxisLayoutFlags axis) => axis is
+            AxisLayoutFlags.LeftPad or AxisLayoutFlags.RightPad;
+
+        public static bool HasTargets(IController controller) =>
+            controller.GetTargetButtons().Any(IsTouchpadButton) ||
+            controller.GetTargetAxis().Any(IsTouchpadAxis) ||
+            controller is DummyDualSenseController;
+
+        public static IEnumerable<ButtonFlags> GetButtonTargets(IController controller)
+        {
+            foreach (ButtonFlags button in controller.GetTargetButtons().Where(IsTouchpadButton))
+                yield return button;
+
+            if (controller is DummyDualSenseController)
+            {
+                foreach (ButtonFlags button in CoordinateTargets)
+                    yield return button;
+            }
+        }
+
+        public static IEnumerable<AxisLayoutFlags> GetAxisTargets(IController controller) =>
+            controller.GetTargetAxis().Where(IsTouchpadAxis);
 
         public override void Execute(ButtonFlags button, bool value, ShiftSlot shiftSlot, float delta)
         {
             base.Execute(button, value, shiftSlot, delta);
 
-            bool pressed = GetValue();
+            if (TargetType == TouchpadTargetType.Axis)
+            {
+                outVector = outBool ? new Vector2(ButtonX, ButtonY) : Vector2.Zero;
+                isTouched = outBool;
+                return;
+            }
+
+            isTouched = outBool;
+
+            if (outBool != isKeyDown)
+            {
+                isKeyDown = outBool;
+                if (button != ButtonFlags.None)
+                    SetHaptic(button, released: !outBool);
+            }
+
+            UpdateGestureState(delta);
+        }
+
+        public void Execute(AxisLayout layout, bool touched, ShiftSlot shiftSlot, float delta)
+        {
+            if (TargetType == TouchpadTargetType.Axis)
+            {
+                outVector = layout.vector;
+                base.Execute(layout, shiftSlot, delta);
+                bool sourceReportsTouch = ControllerState.AxisTouchButtons.ContainsKey(layout.flags);
+                isTouched = !axisSlotDisabled &&
+                    (sourceReportsTouch ? touched : outVector != Vector2.Zero);
+                return;
+            }
+
+            outVector = layout.vector;
+            base.Execute(layout, shiftSlot, delta);
+
+            DeflectionDirection direction = InputUtils.GetDeflectionDirection(outVector, motionThreshold);
+            bool pressed = DirectionMatches(direction, motionDirection);
+            ButtonFlags sourceButton = layout.flags switch
+            {
+                AxisLayoutFlags.LeftStick => ButtonFlags.LeftStickTouch,
+                AxisLayoutFlags.RightStick => ButtonFlags.RightStickTouch,
+                AxisLayoutFlags.LeftPad => ButtonFlags.LeftPadTouch,
+                AxisLayoutFlags.RightPad => ButtonFlags.RightPadTouch,
+                AxisLayoutFlags.L2 => ButtonFlags.L2Soft,
+                AxisLayoutFlags.R2 => ButtonFlags.R2Soft,
+                _ => ButtonFlags.None,
+            };
+            Execute(sourceButton, pressed, shiftSlot, delta);
+        }
+
+        public bool GetButtonValue() => outBool;
+
+        public Vector2 GetAxisValue() => outVector;
+
+        public bool GetTouchValue() => isTouched;
+
+        private void UpdateGestureState(float delta)
+        {
+            if (TargetType != TouchpadTargetType.Button)
+                return;
+
+            bool pressed = outBool;
             if (Button == ButtonFlags.TouchpadSwipe && pressed && !wasPressed)
             {
                 swipeActive = true;
@@ -74,6 +272,12 @@ namespace HandheldCompanion.Actions
 
         internal bool TryGetTouch(out TouchpadSample sample)
         {
+            if (TargetType != TouchpadTargetType.Button || !IsCoordinateTarget(Button))
+            {
+                sample = default;
+                return false;
+            }
+
             int x;
             int y;
             bool active;
@@ -94,7 +298,7 @@ namespace HandheldCompanion.Actions
             {
                 x = X;
                 y = Y;
-                active = GetValue();
+                active = outBool;
             }
 
             sample = active
@@ -102,6 +306,221 @@ namespace HandheldCompanion.Actions
                 : default;
             return active;
         }
+
+        internal void UpdateClickHaptics(ControllerState state, ShiftSlot shiftSlot,
+            IReadOnlyDictionary<ButtonFlags, IActions[]> buttonPlan)
+        {
+            IController? controller = ControllerManager.GetTarget();
+            bool leftPressed = state.ButtonState[ButtonFlags.LeftPadClick] ||
+                state.ButtonState[ButtonFlags.LeftPadClickUp] ||
+                state.ButtonState[ButtonFlags.LeftPadClickDown] ||
+                state.ButtonState[ButtonFlags.LeftPadClickLeft] ||
+                state.ButtonState[ButtonFlags.LeftPadClickRight];
+            bool rightPressed = state.ButtonState[ButtonFlags.RightPadClick] ||
+                state.ButtonState[ButtonFlags.RightPadClickUp] ||
+                state.ButtonState[ButtonFlags.RightPadClickDown] ||
+                state.ButtonState[ButtonFlags.RightPadClickLeft] ||
+                state.ButtonState[ButtonFlags.RightPadClickRight];
+            bool centerPressed = state.ButtonState[ButtonFlags.CenterPadClick];
+
+            if (controller is null)
+            {
+                clickController = null;
+                leftClickPressed = false;
+                rightClickPressed = false;
+                genericClickPressed = false;
+                leftClickProfile = default;
+                rightClickProfile = default;
+                genericClickProfile = default;
+                return;
+            }
+
+            if (!ReferenceEquals(clickController, controller))
+            {
+                clickController = controller;
+                leftClickPressed = leftPressed;
+                rightClickPressed = rightPressed;
+                genericClickPressed = leftPressed || rightPressed || centerPressed;
+                genericClickButton = GetPressedClickButton(leftPressed, rightPressed);
+                leftClickProfile = default;
+                rightClickProfile = default;
+                genericClickProfile = default;
+                return;
+            }
+
+            bool disabledByFirmware = controller is SteamController steamController && steamController.IsLizardModeEnabled;
+            if (disabledByFirmware)
+            {
+                leftClickPressed = leftPressed;
+                rightClickPressed = rightPressed;
+                genericClickPressed = leftPressed || rightPressed || centerPressed;
+                leftClickProfile = default;
+                rightClickProfile = default;
+                genericClickProfile = default;
+                return;
+            }
+
+            if (controller is SteamController)
+            {
+                UpdateClickHaptic(controller, ButtonFlags.LeftPadClick,
+                    leftPressed, ref leftClickPressed, ref leftClickProfile,
+                    state, shiftSlot, buttonPlan, LeftClickSources);
+                UpdateClickHaptic(controller, ButtonFlags.RightPadClick,
+                    rightPressed, ref rightClickPressed, ref rightClickProfile,
+                    state, shiftSlot, buttonPlan, RightClickSources);
+                return;
+            }
+
+            bool pressed = leftPressed || rightPressed || centerPressed;
+            if (pressed && !genericClickPressed)
+                genericClickButton = GetPressedClickButton(leftPressed, rightPressed);
+
+            UpdateClickHaptic(controller, genericClickButton, pressed, ref genericClickPressed,
+                ref genericClickProfile, state, shiftSlot,
+                buttonPlan, AllClickSources);
+        }
+
+        private static ButtonFlags GetPressedClickButton(bool leftPressed, bool rightPressed) =>
+            leftPressed
+                ? ButtonFlags.LeftPadClick
+                : rightPressed
+                    ? ButtonFlags.RightPadClick
+                    : ButtonFlags.CenterPadClick;
+
+        private static void UpdateClickHaptic(IController controller, ButtonFlags button, bool pressed,
+            ref bool wasPressed, ref ClickHapticProfile profile, ControllerState state, ShiftSlot shiftSlot,
+            IReadOnlyDictionary<ButtonFlags, IActions[]> buttonPlan, ButtonFlags[] sources)
+        {
+            if (pressed == wasPressed)
+                return;
+
+            wasPressed = pressed;
+            if (pressed)
+                profile = ResolveClickHapticProfile(state, shiftSlot, buttonPlan, sources);
+
+            bool released = !pressed;
+            if (profile.Mode == HapticMode.Off ||
+                profile.Mode == HapticMode.Down && released ||
+                profile.Mode == HapticMode.Up && !released)
+                return;
+
+            controller.SetTrackpadClickHaptic(profile.Strength, button, released: !pressed);
+        }
+
+        private static ClickHapticProfile ResolveClickHapticProfile(ControllerState state,
+            ShiftSlot shiftSlot, IReadOnlyDictionary<ButtonFlags, IActions[]> buttonPlan,
+            ButtonFlags[] sources)
+        {
+            bool hasOverride = false;
+            int combinedMode = (int)HapticMode.Off;
+            HapticStrength strength = HapticStrength.Low;
+
+            foreach (ButtonFlags source in sources)
+            {
+                if (!state.ButtonState[source] || !buttonPlan.TryGetValue(source, out IActions[]? actions))
+                    continue;
+
+                foreach (IActions action in actions)
+                {
+                    if (!HasCustomHapticSettings(action) ||
+                        !IsShiftAllowed(shiftSlot, action.ShiftSlot, action.ShiftMatchAny))
+                        continue;
+
+                    hasOverride = true;
+                    combinedMode |= (int)action.HapticMode;
+                    if (action.HapticMode != HapticMode.Off &&
+                        (int)action.HapticStrength > (int)strength)
+                        strength = action.HapticStrength;
+                }
+            }
+
+            if (hasOverride)
+                return new ClickHapticProfile((HapticMode)combinedMode, strength);
+
+            int globalStrength = ManagerFactory.settingsManager.GetInt("TrackpadClickHaptics");
+            return globalStrength <= 0
+                ? default
+                : new ClickHapticProfile(HapticMode.Both,
+                    (HapticStrength)Math.Clamp(globalStrength - 1, 0, 2));
+        }
+
+        internal void UpdateMovementHaptics(AxisLayoutFlags axis, Vector2 position, bool touched,
+            ShiftSlot shiftSlot, IActions[] actions)
+        {
+            MovementHapticState state = axis == AxisLayoutFlags.LeftPad ? leftHaptics : rightHaptics;
+            IActions? hapticAction = null;
+            for (int i = 0; i < actions.Length; i++)
+            {
+                IActions action = actions[i];
+                if (action.HapticMode is HapticMode.Down or HapticMode.Both &&
+                    IsShiftAllowed(shiftSlot, action.ShiftSlot, action.ShiftMatchAny) &&
+                    (action is MouseActions { MouseType: MouseActionsType.Move or MouseActionsType.Scroll } ||
+                     action is TouchpadActions { TargetType: TouchpadTargetType.Axis }))
+                {
+                    hapticAction = action;
+                    break;
+                }
+            }
+
+            IController? controller = ControllerManager.GetTarget();
+            if (!ReferenceEquals(movementController, controller))
+            {
+                movementController = controller;
+                leftHaptics.Reset(touched: false, Vector2.Zero);
+                rightHaptics.Reset(touched: false, Vector2.Zero);
+            }
+
+            if (!touched || hapticAction is null || controller is null ||
+                controller is SteamController steamController && steamController.IsLizardModeEnabled)
+            {
+                state.Reset(touched, position);
+                return;
+            }
+
+            if (!state.WasTouched)
+            {
+                state.Reset(touched: true, position);
+                return;
+            }
+
+            Vector2 delta = position - state.PreviousPosition;
+            state.PreviousPosition = position;
+            state.Jitter += delta;
+
+            float distance = state.Jitter.Length();
+            if (distance < HapticJitterThreshold)
+                return;
+
+            state.Jitter = Vector2.Zero;
+            state.Distance += distance;
+            if (state.Distance < HapticStep)
+                return;
+
+            state.Distance %= HapticStep;
+            ButtonFlags button = axis == AxisLayoutFlags.LeftPad
+                ? ButtonFlags.LeftPadTouch
+                : ButtonFlags.RightPadTouch;
+            hapticAction.SetHaptic(button, released: false);
+        }
+
+        [Serializable]
+        private sealed class MovementHapticState
+        {
+            public bool WasTouched;
+            public Vector2 PreviousPosition;
+            public Vector2 Jitter;
+            public float Distance;
+
+            public void Reset(bool touched, Vector2 position)
+            {
+                WasTouched = touched;
+                PreviousPosition = position;
+                Jitter = Vector2.Zero;
+                Distance = 0.0f;
+            }
+        }
+
+        private readonly record struct ClickHapticProfile(HapticMode Mode, HapticStrength Strength);
     }
 
     internal readonly record struct TouchpadSample(ButtonFlags Target, int X, int Y)

--- a/HandheldCompanion/Actions/TouchpadActions.cs
+++ b/HandheldCompanion/Actions/TouchpadActions.cs
@@ -297,9 +297,7 @@ namespace HandheldCompanion.Actions
             }
             else
             {
-                x = Button == ButtonFlags.TouchpadClick
-                    ? Finger == 1 ? DS4Touch.TOUCHPAD_WIDTH / 4 : DS4Touch.TOUCHPAD_WIDTH * 3 / 4
-                    : X;
+                x = X;
                 y = Y;
                 active = outBool;
             }

--- a/HandheldCompanion/Actions/TouchpadActions.cs
+++ b/HandheldCompanion/Actions/TouchpadActions.cs
@@ -305,7 +305,7 @@ namespace HandheldCompanion.Actions
             }
 
             sample = active
-                ? new TouchpadSample(Button, x, y)
+                ? new TouchpadSample(Button, Finger, x, y)
                 : default;
             return active;
         }
@@ -524,7 +524,7 @@ namespace HandheldCompanion.Actions
         private readonly record struct ClickHapticProfile(HapticMode Mode, HapticStrength Strength);
     }
 
-    internal readonly record struct TouchpadSample(ButtonFlags Target, int X, int Y)
+    internal readonly record struct TouchpadSample(ButtonFlags Target, byte Finger, int X, int Y)
     {
         public int Priority => Target switch
         {

--- a/HandheldCompanion/Actions/TouchpadActions.cs
+++ b/HandheldCompanion/Actions/TouchpadActions.cs
@@ -87,17 +87,18 @@ namespace HandheldCompanion.Actions
         [NonSerialized] private float swipeElapsed;
         [NonSerialized] private bool isKeyDown;
         [NonSerialized] private bool isTouched;
-        [NonSerialized] private MovementHapticState leftHaptics = new();
-        [NonSerialized] private MovementHapticState rightHaptics = new();
-        [NonSerialized] private IController? movementController;
-        [NonSerialized] private bool leftClickPressed;
-        [NonSerialized] private bool rightClickPressed;
-        [NonSerialized] private bool genericClickPressed;
-        [NonSerialized] private ButtonFlags genericClickButton = ButtonFlags.RightPadClick;
-        [NonSerialized] private IController? clickController;
-        [NonSerialized] private ClickHapticProfile leftClickProfile;
-        [NonSerialized] private ClickHapticProfile rightClickProfile;
-        [NonSerialized] private ClickHapticProfile genericClickProfile;
+        private static MovementHapticState leftHaptics = new();
+        private static MovementHapticState rightHaptics = new();
+        private static IController? movementController;
+        private static bool leftClickPressed;
+        private static bool rightClickPressed;
+        private static bool genericClickPressed;
+        private static ButtonFlags genericClickButton = ButtonFlags.RightPadClick;
+        private static IController? clickController;
+        private static ClickHapticProfile leftClickProfile;
+        private static ClickHapticProfile rightClickProfile;
+        private static ClickHapticProfile genericClickProfile;
+        private static TouchpadSample?[] outputSamples = new TouchpadSample?[2];
 
         public TouchpadActions()
         {
@@ -308,7 +309,51 @@ namespace HandheldCompanion.Actions
             return active;
         }
 
-        internal void UpdateClickHaptics(ControllerState state, ShiftSlot shiftSlot,
+        internal static void BeginOutputFrame()
+        {
+            Array.Clear(outputSamples);
+            DS4Touch.ClearOutputTouches();
+        }
+
+        internal void ApplyOutput(ControllerState outputState,
+            AxisFlags outputAxisX = AxisFlags.None, AxisFlags outputAxisY = AxisFlags.None)
+        {
+            if (TargetType == TouchpadTargetType.Axis)
+            {
+                Vector2 value = GetAxisValue();
+                outputState.AxisState[outputAxisX] = ClampShort(outputState.AxisState[outputAxisX] + value.X);
+                outputState.AxisState[outputAxisY] = ClampShort(outputState.AxisState[outputAxisY] + value.Y);
+
+                if (ControllerState.AxisTouchButtons.TryGetValue(Axis, out ButtonFlags touchButton))
+                    outputState.ButtonState[touchButton] |= GetTouchValue();
+                return;
+            }
+
+            if (IsGestureTarget(Button))
+            {
+                if (!TryGetTouch(out TouchpadSample sample))
+                    return;
+
+                outputState.ButtonState[Button] |= true;
+                int fingerIndex = sample.Finger - 1;
+                if (outputSamples[fingerIndex] is null || sample.Priority > outputSamples[fingerIndex]!.Value.Priority)
+                    outputSamples[fingerIndex] = sample;
+                return;
+            }
+
+            outputState.ButtonState[Button] |= GetButtonValue();
+        }
+
+        internal static void CommitOutputFrame()
+        {
+            foreach (TouchpadSample? sample in outputSamples)
+            {
+                if (sample is TouchpadSample value)
+                    DS4Touch.SetOutputTouch(value.Finger, value.X, value.Y);
+            }
+        }
+
+        internal static void UpdateClickHaptics(ControllerState state, ShiftSlot shiftSlot,
             IReadOnlyDictionary<ButtonFlags, IActions[]> buttonPlan)
         {
             IController? controller = ControllerManager.GetTarget();
@@ -443,7 +488,7 @@ namespace HandheldCompanion.Actions
                     (HapticStrength)Math.Clamp(globalStrength - 1, 0, 2));
         }
 
-        internal void UpdateMovementHaptics(AxisLayoutFlags axis, Vector2 position, bool touched,
+        internal static void UpdateMovementHaptics(AxisLayoutFlags axis, Vector2 position, bool touched,
             ShiftSlot shiftSlot, IActions[] actions)
         {
             MovementHapticState state = axis == AxisLayoutFlags.LeftPad ? leftHaptics : rightHaptics;
@@ -520,6 +565,8 @@ namespace HandheldCompanion.Actions
         }
 
         private readonly record struct ClickHapticProfile(HapticMode Mode, HapticStrength Strength);
+
+        private static short ClampShort(float value) => (short)Math.Clamp(value, short.MinValue, short.MaxValue);
     }
 
     internal readonly record struct TouchpadSample(ButtonFlags Target, byte Finger, int X, int Y)

--- a/HandheldCompanion/Actions/TouchpadActions.cs
+++ b/HandheldCompanion/Actions/TouchpadActions.cs
@@ -1,0 +1,73 @@
+using HandheldCompanion.Inputs;
+using System;
+
+namespace HandheldCompanion.Actions
+{
+    [Serializable]
+    public sealed class TouchpadActions : ButtonActions
+    {
+        public int X = 960;
+        public int Y = 471;
+        public int EndX = 1440;
+        public int EndY = 471;
+        public float SwipeDuration = 300.0f;
+
+        [NonSerialized] private bool wasPressed;
+        [NonSerialized] private bool swipeActive;
+        [NonSerialized] private bool swipeEndsAfterReport;
+        [NonSerialized] private float swipeElapsed;
+
+        public TouchpadActions() { }
+
+        public TouchpadActions(ButtonFlags button) : base(button) { }
+
+        public override void Execute(ButtonFlags button, bool value, ShiftSlot shiftSlot, float delta)
+        {
+            base.Execute(button, value, shiftSlot, delta);
+
+            bool pressed = GetValue();
+            if (Button == ButtonFlags.TouchpadSwipe && pressed && !wasPressed)
+            {
+                swipeActive = true;
+                swipeEndsAfterReport = false;
+                swipeElapsed = 0.0f;
+            }
+            else if (swipeActive)
+            {
+                swipeElapsed += delta;
+                if (swipeElapsed >= Math.Max(1.0f, SwipeDuration))
+                {
+                    swipeElapsed = Math.Max(1.0f, SwipeDuration);
+                    swipeEndsAfterReport = true;
+                }
+            }
+
+            wasPressed = pressed;
+        }
+
+        public bool TryGetTouch(out int x, out int y, out bool click)
+        {
+            click = Button == ButtonFlags.TouchpadCoordinateClick;
+
+            if (Button == ButtonFlags.TouchpadSwipe)
+            {
+                float duration = Math.Max(1.0f, SwipeDuration);
+                float progress = Math.Clamp(swipeElapsed / duration, 0.0f, 1.0f);
+                x = (int)MathF.Round(X + (EndX - X) * progress);
+                y = (int)MathF.Round(Y + (EndY - Y) * progress);
+                click = false;
+                bool active = swipeActive;
+                if (swipeEndsAfterReport)
+                {
+                    swipeActive = false;
+                    swipeEndsAfterReport = false;
+                }
+                return active;
+            }
+
+            x = X;
+            y = Y;
+            return GetValue();
+        }
+    }
+}

--- a/HandheldCompanion/Actions/TouchpadActions.cs
+++ b/HandheldCompanion/Actions/TouchpadActions.cs
@@ -43,6 +43,7 @@ namespace HandheldCompanion.Actions
         public int AxisAntiDeadZone = 0;
         public int AxisDeadZoneInner = 0;
         public int AxisDeadZoneOuter = 0;
+        public bool UseCoordinates;
         private byte finger = 1;
 
         private int x = DS4Touch.TOUCHPAD_WIDTH / 2;
@@ -88,18 +89,14 @@ namespace HandheldCompanion.Actions
             SetTarget(axis);
         }
 
-        [OnDeserialized]
-        private void OnDeserialized(StreamingContext context)
-        {
-            actionType = ActionType.Touchpad;
-            movementHaptics ??= new();
-        }
-
         public void SetTarget(ButtonFlags button)
         {
             TargetType = TouchpadTargetType.Button;
             Button = button;
             Axis = AxisLayoutFlags.None;
+
+            if (button == ButtonFlags.TouchpadSwipe)
+                UseCoordinates = true;
         }
 
         public void SetTarget(AxisLayoutFlags axis)
@@ -268,8 +265,8 @@ namespace HandheldCompanion.Actions
                 return false;
             }
 
-            int x;
-            int y;
+            int? x;
+            int? y;
             bool active;
 
             if (Button == ButtonFlags.TouchpadSwipe)
@@ -286,8 +283,8 @@ namespace HandheldCompanion.Actions
             }
             else
             {
-                x = X;
-                y = Y;
+                x = UseCoordinates ? X : null;
+                y = UseCoordinates ? Y : null;
                 active = outBool;
             }
 
@@ -319,7 +316,8 @@ namespace HandheldCompanion.Actions
                     return;
 
                 outputState.ButtonState[Button] |= true;
-                DS4Touch.SetOutputTouch(sample.Finger, sample.X, sample.Y);
+                if (sample.X is int x && sample.Y is int y)
+                    DS4Touch.SetOutputTouch(sample.Finger, x, y);
                 return;
             }
 
@@ -400,6 +398,6 @@ namespace HandheldCompanion.Actions
         private static short ClampShort(float value) => (short)Math.Clamp(value, short.MinValue, short.MaxValue);
     }
 
-    internal readonly record struct TouchpadSample(ButtonFlags Target, byte Finger, int X, int Y)
+    internal readonly record struct TouchpadSample(ButtonFlags Target, byte Finger, int? X, int? Y)
     { }
 }

--- a/HandheldCompanion/App.config
+++ b/HandheldCompanion/App.config
@@ -134,9 +134,6 @@
    <setting name="SteamControllerMode" serializeAs="String">
     <value>0</value>
    </setting>
-   <setting name="TrackpadClickHaptics" serializeAs="String">
-    <value>3</value>
-   </setting>
    <setting name="HIDcloakonconnect" serializeAs="String">
     <value>True</value>
    </setting>

--- a/HandheldCompanion/App.config
+++ b/HandheldCompanion/App.config
@@ -134,7 +134,7 @@
    <setting name="SteamControllerMode" serializeAs="String">
     <value>0</value>
    </setting>
-   <setting name="SteamTrackpadClickHaptics" serializeAs="String">
+   <setting name="TrackpadClickHaptics" serializeAs="String">
     <value>3</value>
    </setting>
    <setting name="HIDcloakonconnect" serializeAs="String">

--- a/HandheldCompanion/App.config
+++ b/HandheldCompanion/App.config
@@ -134,6 +134,9 @@
    <setting name="SteamControllerMode" serializeAs="String">
     <value>0</value>
    </setting>
+   <setting name="SteamTrackpadClickHaptics" serializeAs="String">
+    <value>3</value>
+   </setting>
    <setting name="HIDcloakonconnect" serializeAs="String">
     <value>True</value>
    </setting>

--- a/HandheldCompanion/App.xaml
+++ b/HandheldCompanion/App.xaml
@@ -71,6 +71,7 @@
             <converters:InverseBooleanToVisibilityConverter x:Key="InverseBooleanToVisibilityConverter" />
             <converters:IndexToVisibilityConverter x:Key="IndexToVisibilityConverter" />
             <converters:IsEnabledConverter x:Key="IsEnabledConverter" />
+            <converters:ActionTypeSupportedConverter x:Key="ActionTypeSupportedConverter" />
             <converters:PercentageConverter x:Key="PercentageConverter" />
             <converters:InvertBooleanConverter x:Key="InvertBooleanConverter" />
             <converters:InvertPercentageConverter x:Key="InvertPercentageConverter" />

--- a/HandheldCompanion/Controllers/Dummies/DummyDualSenseController.cs
+++ b/HandheldCompanion/Controllers/Dummies/DummyDualSenseController.cs
@@ -9,9 +9,8 @@ namespace HandheldCompanion.Controllers.Dummies
         {
             // The dummy describes mapping destinations on the emulated DualSense;
             // it is not an input device and must not advertise source touchpads.
-            TargetButtons.Add(ButtonFlags.LeftPadClick);
-            TargetButtons.Add(ButtonFlags.RightPadClick);
-            TargetButtons.Add(ButtonFlags.CenterPadClick);
+            TargetButtons.Add(ButtonFlags.TouchpadClick);
+            TargetButtons.Add(ButtonFlags.TouchpadTouch);
             TargetButtons.Add(ButtonFlags.MicrophoneMute);
             TargetAxis.Add(AxisLayoutFlags.LeftPad);
             TargetAxis.Add(AxisLayoutFlags.RightPad);

--- a/HandheldCompanion/Controllers/Dummies/DummyDualSenseController.cs
+++ b/HandheldCompanion/Controllers/Dummies/DummyDualSenseController.cs
@@ -13,9 +13,6 @@ namespace HandheldCompanion.Controllers.Dummies
             TargetButtons.Add(ButtonFlags.RightPadClick);
             TargetButtons.Add(ButtonFlags.CenterPadClick);
             TargetButtons.Add(ButtonFlags.MicrophoneMute);
-            TargetButtons.Add(ButtonFlags.TouchpadCoordinateClick);
-            TargetButtons.Add(ButtonFlags.TouchpadCoordinateTouch);
-            TargetButtons.Add(ButtonFlags.TouchpadSwipe);
             TargetAxis.Add(AxisLayoutFlags.LeftPad);
             TargetAxis.Add(AxisLayoutFlags.RightPad);
         }

--- a/HandheldCompanion/Controllers/Dummies/DummyDualSenseController.cs
+++ b/HandheldCompanion/Controllers/Dummies/DummyDualSenseController.cs
@@ -5,10 +5,25 @@ namespace HandheldCompanion.Controllers.Dummies
 {
     public class DummyDualSenseController : DualSenseController
     {
+        public DummyDualSenseController()
+        {
+            // The dummy describes mapping destinations on the emulated DualSense;
+            // it is not an input device and must not advertise source touchpads.
+            TargetButtons.Add(ButtonFlags.LeftPadClick);
+            TargetButtons.Add(ButtonFlags.RightPadClick);
+            TargetButtons.Add(ButtonFlags.CenterPadClick);
+            TargetButtons.Add(ButtonFlags.MicrophoneMute);
+            TargetButtons.Add(ButtonFlags.TouchpadCoordinateClick);
+            TargetButtons.Add(ButtonFlags.TouchpadCoordinateTouch);
+            TargetButtons.Add(ButtonFlags.TouchpadSwipe);
+            TargetAxis.Add(AxisLayoutFlags.LeftPad);
+            TargetAxis.Add(AxisLayoutFlags.RightPad);
+        }
+
         public override bool IsVirtual() => true;
         public override bool IsDummy() => true;
-        protected override int GetTouchpads() => 1;
-        protected override int GetTouchpadFingers(int touchpad) => 2;
+        protected override int GetTouchpads() => 0;
+        protected override int GetTouchpadFingers(int touchpad) => 0;
 
         public override void Tick(long ticks, float delta, bool commit = false)
         {

--- a/HandheldCompanion/Controllers/Dummies/DummyDualSenseController.cs
+++ b/HandheldCompanion/Controllers/Dummies/DummyDualSenseController.cs
@@ -11,7 +11,7 @@ namespace HandheldCompanion.Controllers.Dummies
             // it is not an input device and must not advertise source touchpads.
             TargetButtons.Add(ButtonFlags.TouchpadClick);
             TargetButtons.Add(ButtonFlags.TouchpadTouch);
-            TargetButtons.Add(ButtonFlags.MicrophoneMute);
+            TargetButtons.Add(ButtonFlags.B5);
             TargetAxis.Add(AxisLayoutFlags.LeftPad);
             TargetAxis.Add(AxisLayoutFlags.RightPad);
         }

--- a/HandheldCompanion/Controllers/IController.cs
+++ b/HandheldCompanion/Controllers/IController.cs
@@ -372,6 +372,11 @@ namespace HandheldCompanion.Controllers
         // let the controller decide itself what motor to use for a specific button
         public virtual void SetHaptic(HapticStrength strength, ButtonFlags button)
         {
+            SetHapticCore(strength, button);
+        }
+
+        private void SetHapticCore(HapticStrength strength, ButtonFlags button)
+        {
             int delay;
             switch (strength)
             {
@@ -389,23 +394,36 @@ namespace HandheldCompanion.Controllers
                     break;
             }
 
-            switch (button)
+            RumbleHaptic(delay, byte.MaxValue, button);
+        }
+
+        public virtual void SetTrackpadClickHaptic(HapticStrength strength, ButtonFlags button, bool released)
+        {
+            (int delay, byte amplitude) = strength switch
             {
-                case ButtonFlags.B1:
-                case ButtonFlags.B2:
-                case ButtonFlags.B3:
-                case ButtonFlags.B4:
-                case ButtonFlags.L1:
-                case ButtonFlags.L2Soft:
-                case ButtonFlags.Start:
-                case ButtonFlags.RightStickClick:
-                case ButtonFlags.RightPadClick:
-                    Rumble(delay, 0, byte.MaxValue);
-                    break;
-                default:
-                    Rumble(delay, byte.MaxValue, 0);
-                    break;
+                HapticStrength.Low => (85, (byte)96),
+                HapticStrength.Medium => (105, (byte)176),
+                _ => (125, byte.MaxValue),
+            };
+
+            RumbleHaptic(delay, amplitude, button);
+        }
+
+        private void RumbleHaptic(int delay, byte amplitude, ButtonFlags button)
+        {
+            if (button is
+                ButtonFlags.B1 or ButtonFlags.B2 or ButtonFlags.B3 or ButtonFlags.B4 or
+                ButtonFlags.L1 or ButtonFlags.L2Soft or ButtonFlags.Start or
+                ButtonFlags.RightStickTouch or ButtonFlags.RightStickClick or
+                ButtonFlags.RightPadTouch or ButtonFlags.RightPadClick or
+                ButtonFlags.RightPadClickUp or ButtonFlags.RightPadClickDown or
+                ButtonFlags.RightPadClickLeft or ButtonFlags.RightPadClickRight)
+            {
+                Rumble(delay, 0, amplitude);
+                return;
             }
+
+            Rumble(delay, amplitude, 0);
         }
 
         public virtual bool IsConnected()
@@ -427,7 +445,8 @@ namespace HandheldCompanion.Controllers
                 rumbleCts?.Cancel();
                 rumbleCts = new CancellationTokenSource();
 
-                var token = rumbleCts.Token;
+                CancellationTokenSource currentCts = rumbleCts;
+                var token = currentCts.Token;
                 rumbleTask = Task.Run(async () =>
                 {
                     try
@@ -438,10 +457,19 @@ namespace HandheldCompanion.Controllers
                     catch (OperationCanceledException) { }
                     finally
                     {
-                        try { SetVibration(0, 0); }
-                        catch { }
+                        lock (rumbleLock)
+                        {
+                            if (ReferenceEquals(rumbleCts, currentCts))
+                            {
+                                try { SetVibration(0, 0); }
+                                catch { }
+                                rumbleCts = null;
+                            }
+
+                            currentCts.Dispose();
+                        }
                     }
-                }, token);
+                });
             }
         }
 

--- a/HandheldCompanion/Controllers/IController.cs
+++ b/HandheldCompanion/Controllers/IController.cs
@@ -370,60 +370,66 @@ namespace HandheldCompanion.Controllers
         { }
 
         // let the controller decide itself what motor to use for a specific button
-        public virtual void SetHaptic(HapticStrength strength, ButtonFlags button)
-        {
-            SetHapticCore(strength, button);
-        }
-
-        private void SetHapticCore(HapticStrength strength, ButtonFlags button)
+        public virtual void SetHaptic(HapticStrength strength, ButtonFlags button, bool released)
         {
             int delay;
+            byte amplitude = byte.MaxValue;
+
             switch (strength)
             {
                 default:
                 case HapticStrength.Low:
-                    delay = 85;
+                    delay = 40;
                     break;
 
                 case HapticStrength.Medium:
-                    delay = 105;
+                    delay = 80;
                     break;
 
                 case HapticStrength.High:
-                    delay = 125;
+                    delay = 120;
                     break;
             }
 
-            RumbleHaptic(delay, byte.MaxValue, button);
+            RumbleHaptic(delay, amplitude, button, released);
         }
 
-        public virtual void SetTrackpadClickHaptic(HapticStrength strength, ButtonFlags button, bool released)
+        // Select the physical rumble motor associated with the button.
+        // Rumble arguments are ordered as delay, large motor, small motor.
+        private void RumbleHaptic(int delay, byte amplitude, ButtonFlags button, bool released)
         {
-            (int delay, byte amplitude) = strength switch
+            switch (button)
             {
-                HapticStrength.Low => (85, (byte)96),
-                HapticStrength.Medium => (105, (byte)176),
-                _ => (125, byte.MaxValue),
-            };
+                // right motor
+                case ButtonFlags.B1:
+                case ButtonFlags.B2:
+                case ButtonFlags.B3:
+                case ButtonFlags.B4:
+                case ButtonFlags.R1:
+                case ButtonFlags.R2Soft:
+                case ButtonFlags.Start:
+                case ButtonFlags.RightStickClick:
+                case ButtonFlags.RightStickTouch:
+                case ButtonFlags.RightPadClick:
+                case ButtonFlags.RightPadClickUp:
+                case ButtonFlags.RightPadClickDown:
+                case ButtonFlags.RightPadClickLeft:
+                case ButtonFlags.RightPadClickRight:
+                    Rumble(delay, 0, amplitude);
+                    return;
 
-            RumbleHaptic(delay, amplitude, button);
-        }
+                // both motors
+                case ButtonFlags.TouchpadTouch:
+                case ButtonFlags.LeftPadTouch:
+                case ButtonFlags.RightPadTouch:
+                    Rumble(delay / 4, amplitude, amplitude);
+                    break;
 
-        private void RumbleHaptic(int delay, byte amplitude, ButtonFlags button)
-        {
-            if (button is
-                ButtonFlags.B1 or ButtonFlags.B2 or ButtonFlags.B3 or ButtonFlags.B4 or
-                ButtonFlags.L1 or ButtonFlags.L2Soft or ButtonFlags.Start or
-                ButtonFlags.RightStickTouch or ButtonFlags.RightStickClick or
-                ButtonFlags.RightPadTouch or ButtonFlags.RightPadClick or
-                ButtonFlags.RightPadClickUp or ButtonFlags.RightPadClickDown or
-                ButtonFlags.RightPadClickLeft or ButtonFlags.RightPadClickRight)
-            {
-                Rumble(delay, 0, amplitude);
-                return;
+                // left motor
+                default:
+                    Rumble(delay, amplitude, 0);
+                    return;
             }
-
-            Rumble(delay, amplitude, 0);
         }
 
         public virtual bool IsConnected()

--- a/HandheldCompanion/Controllers/SDL/DualSenseController.cs
+++ b/HandheldCompanion/Controllers/SDL/DualSenseController.cs
@@ -20,6 +20,7 @@ namespace HandheldCompanion.Controllers.SDL
                     return "\u2208";
                 case ButtonFlags.LeftPadClick:
                 case ButtonFlags.RightPadClick:
+                case ButtonFlags.CenterPadClick:
                 case ButtonFlags.LeftPadTouch:
                 case ButtonFlags.RightPadTouch:
                     return "\u2207";

--- a/HandheldCompanion/Controllers/SDL/DualSenseController.cs
+++ b/HandheldCompanion/Controllers/SDL/DualSenseController.cs
@@ -20,9 +20,10 @@ namespace HandheldCompanion.Controllers.SDL
                     return "\u2208";
                 case ButtonFlags.LeftPadClick:
                 case ButtonFlags.RightPadClick:
-                case ButtonFlags.CenterPadClick:
                 case ButtonFlags.LeftPadTouch:
                 case ButtonFlags.RightPadTouch:
+                case ButtonFlags.TouchpadClick:
+                case ButtonFlags.TouchpadTouch:
                     return "\u2207";
             }
 

--- a/HandheldCompanion/Controllers/SDLController.cs
+++ b/HandheldCompanion/Controllers/SDLController.cs
@@ -150,7 +150,8 @@ namespace HandheldCompanion.Controllers
 
                     if (IsVirtual())
                     {
-                        TargetButtons.Add(ButtonFlags.LeftPadClick);
+                        TargetButtons.Add(ButtonFlags.TouchpadClick);
+                        TargetButtons.Add(ButtonFlags.TouchpadTouch);
                         TargetAxis.Add(AxisLayoutFlags.LeftPad);
                     }
                 }
@@ -163,7 +164,6 @@ namespace HandheldCompanion.Controllers
 
                     if (IsVirtual())
                     {
-                        TargetButtons.Add(ButtonFlags.RightPadClick);
                         TargetAxis.Add(AxisLayoutFlags.RightPad);
                     }
                 }

--- a/HandheldCompanion/Controllers/Steam/GordonController.cs
+++ b/HandheldCompanion/Controllers/Steam/GordonController.cs
@@ -185,9 +185,6 @@ namespace HandheldCompanion.Controllers.Steam
             // Right Pad
             Inputs.ButtonState[ButtonFlags.RightPadTouch] = input.State.ButtonState[GordonControllerButton.BtnRPadTouch];
             Inputs.ButtonState[ButtonFlags.RightPadClick] = input.State.ButtonState[GordonControllerButton.BtnRPadPress];
-            UpdateTrackpadClickHaptics(
-                Inputs.ButtonState[ButtonFlags.LeftPadClick],
-                Inputs.ButtonState[ButtonFlags.RightPadClick]);
 
             Inputs.AxisState[AxisFlags.RightPadX] = input.State.AxesState[GordonControllerAxis.RightPadX];
             Inputs.AxisState[AxisFlags.RightPadY] = input.State.AxesState[GordonControllerAxis.RightPadY];

--- a/HandheldCompanion/Controllers/Steam/GordonController.cs
+++ b/HandheldCompanion/Controllers/Steam/GordonController.cs
@@ -19,6 +19,8 @@ namespace HandheldCompanion.Controllers.Steam
         private const short TrackPadInner = short.MaxValue / 2;
         public const ushort MaxRumbleIntensity = 2048;
 
+        public override bool IsLizardModeEnabled => Controller?.LizardModeEnabled ?? true;
+
         public override bool IsWireless()
         {
             return GetProductID() != 0x1102;

--- a/HandheldCompanion/Controllers/Steam/GordonController.cs
+++ b/HandheldCompanion/Controllers/Steam/GordonController.cs
@@ -54,8 +54,8 @@ namespace HandheldCompanion.Controllers.Steam
             TargetButtons.Add(ButtonFlags.L4);
             TargetButtons.Add(ButtonFlags.R4);
 
-            TargetButtons.Add(ButtonFlags.LeftPadClick);
-            TargetButtons.Add(ButtonFlags.RightPadClick);
+            TargetButtons.Add(ButtonFlags.TouchpadClick);
+            TargetButtons.Add(ButtonFlags.TouchpadTouch);
 
             TargetAxis.Add(AxisLayoutFlags.LeftPad);
             TargetAxis.Add(AxisLayoutFlags.RightPad);

--- a/HandheldCompanion/Controllers/Steam/GordonController.cs
+++ b/HandheldCompanion/Controllers/Steam/GordonController.cs
@@ -183,6 +183,9 @@ namespace HandheldCompanion.Controllers.Steam
             // Right Pad
             Inputs.ButtonState[ButtonFlags.RightPadTouch] = input.State.ButtonState[GordonControllerButton.BtnRPadTouch];
             Inputs.ButtonState[ButtonFlags.RightPadClick] = input.State.ButtonState[GordonControllerButton.BtnRPadPress];
+            UpdateTrackpadClickHaptics(
+                Inputs.ButtonState[ButtonFlags.LeftPadClick],
+                Inputs.ButtonState[ButtonFlags.RightPadClick]);
 
             Inputs.AxisState[AxisFlags.RightPadX] = input.State.AxesState[GordonControllerAxis.RightPadX];
             Inputs.AxisState[AxisFlags.RightPadY] = input.State.AxesState[GordonControllerAxis.RightPadY];
@@ -326,6 +329,20 @@ namespace HandheldCompanion.Controllers.Steam
                 _ => 0,
             };
             Controller?.SetHaptic((byte)GetMotorForButton(button), value, 0, 1);
+        }
+
+        protected override void SendTrackpadClickHaptic(SCHapticMotor motor, int strength, bool released)
+        {
+            ushort duration = released ? (ushort)5000 : (ushort)10000;
+            sbyte gain = strength switch
+            {
+                1 => 0,
+                2 => 3,
+                3 => 6,
+                _ => 3,
+            };
+
+            Controller?.SetHaptic((byte)motor, duration, 0, 1, gain);
         }
     }
 }

--- a/HandheldCompanion/Controllers/Steam/GordonController.cs
+++ b/HandheldCompanion/Controllers/Steam/GordonController.cs
@@ -318,30 +318,18 @@ namespace HandheldCompanion.Controllers.Steam
             Controller?.SetHaptic((byte)SCHapticMotor.Right, rightAmplitude, 0, 1);
         }
 
-        public override void SetHaptic(HapticStrength strength, ButtonFlags button)
-        {
-            ushort value = strength switch
-            {
-                HapticStrength.Low => 512,
-                HapticStrength.Medium => 1024,
-                HapticStrength.High => 2048,
-                _ => 0,
-            };
-            Controller?.SetHaptic((byte)GetMotorForButton(button), value, 0, 1);
-        }
-
-        protected override void SendTrackpadClickHaptic(SCHapticMotor motor, int strength, bool released)
+        public override void SetHaptic(HapticStrength strength, ButtonFlags button, bool released)
         {
             ushort duration = released ? (ushort)5000 : (ushort)10000;
             sbyte gain = strength switch
             {
-                1 => 0,
-                2 => 3,
-                3 => 6,
+                HapticStrength.Low => 0,
+                HapticStrength.Medium => 3,
+                HapticStrength.High => 6,
                 _ => 3,
             };
 
-            Controller?.SetHaptic((byte)motor, duration, 0, 1, gain);
+            Controller?.SetHaptic((byte)GetMotorForButton(button), duration, 0, 1, gain);
         }
     }
 }

--- a/HandheldCompanion/Controllers/Steam/NeptuneController.cs
+++ b/HandheldCompanion/Controllers/Steam/NeptuneController.cs
@@ -215,6 +215,10 @@ public class NeptuneController : SteamController
         }
 
         Inputs.ButtonState[ButtonFlags.RightPadClick] = input.State.ButtonState[NeptuneControllerButton.BtnRPadPress];
+        UpdateTrackpadClickHaptics(
+            Inputs.ButtonState[ButtonFlags.LeftPadClick],
+            Inputs.ButtonState[ButtonFlags.RightPadClick]);
+
         if (Inputs.ButtonState[ButtonFlags.RightPadClick])
         {
             Inputs.ButtonState[ButtonFlags.RightPadClickUp] = Inputs.AxisState[AxisFlags.RightPadY] >= TrackPadInner;
@@ -466,5 +470,27 @@ public class NeptuneController : SteamController
             _ => 0,
         };
         Controller?.SetHaptic((byte)GetMotorForButton(button), value, 0, 1);
+    }
+
+    protected override void SendTrackpadClickHaptic(SCHapticMotor motor, int strength, bool released)
+    {
+        // Steam Deck's newer haptic command exposes real waveform style and calibrated
+        // intensity. Keep the levels intentionally far apart so each setting is distinct.
+        // Its motor numbering is opposite to the legacy pulse command used by SCHapticMotor.
+        motor = motor == SCHapticMotor.Left ? SCHapticMotor.Right : SCHapticMotor.Left;
+
+        NCHapticStyle style = strength == 1 ? NCHapticStyle.Weak : NCHapticStyle.Strong;
+        sbyte intensity = strength switch
+        {
+            1 => -7,
+            2 => -1,
+            3 => 5,
+            _ => -1,
+        };
+
+        if (released)
+            intensity = (sbyte)Math.Max(-7, intensity - 3);
+
+        Controller?.SetHaptic2(motor, style, intensity);
     }
 }

--- a/HandheldCompanion/Controllers/Steam/NeptuneController.cs
+++ b/HandheldCompanion/Controllers/Steam/NeptuneController.cs
@@ -458,31 +458,17 @@ public class NeptuneController : SteamController
         }
     }
 
-    public override void SetHaptic(HapticStrength strength, ButtonFlags button)
+    public override void SetHaptic(HapticStrength strength, ButtonFlags button, bool released)
     {
-        ushort value = strength switch
-        {
-            HapticStrength.Low => 512,
-            HapticStrength.Medium => 1024,
-            HapticStrength.High => 2048,
-            _ => 0,
-        };
-        Controller?.SetHaptic((byte)GetMotorForButton(button), value, 0, 1);
-    }
-
-    protected override void SendTrackpadClickHaptic(SCHapticMotor motor, int strength, bool released)
-    {
-        // Steam Deck's newer haptic command exposes real waveform style and calibrated
-        // intensity. Keep the levels intentionally far apart so each setting is distinct.
-        // Its motor numbering is opposite to the legacy pulse command used by SCHapticMotor.
+        SCHapticMotor motor = GetMotorForButton(button);
         motor = motor == SCHapticMotor.Left ? SCHapticMotor.Right : SCHapticMotor.Left;
 
-        NCHapticStyle style = strength == 1 ? NCHapticStyle.Weak : NCHapticStyle.Strong;
+        NCHapticStyle style = strength == HapticStrength.Low ? NCHapticStyle.Weak : NCHapticStyle.Strong;
         sbyte intensity = strength switch
         {
-            1 => -7,
-            2 => -1,
-            3 => 5,
+            HapticStrength.Low => -7,
+            HapticStrength.Medium => -1,
+            HapticStrength.High => 5,
             _ => -1,
         };
 

--- a/HandheldCompanion/Controllers/Steam/NeptuneController.cs
+++ b/HandheldCompanion/Controllers/Steam/NeptuneController.cs
@@ -57,8 +57,8 @@ public class NeptuneController : SteamController
         TargetButtons.Add(ButtonFlags.R5);
         TargetButtons.Add(ButtonFlags.Special2);
 
-        TargetButtons.Add(ButtonFlags.LeftPadClick);
-        TargetButtons.Add(ButtonFlags.RightPadClick);
+        TargetButtons.Add(ButtonFlags.TouchpadClick);
+        TargetButtons.Add(ButtonFlags.TouchpadTouch);
 
         TargetAxis.Add(AxisLayoutFlags.LeftPad);
         TargetAxis.Add(AxisLayoutFlags.RightPad);

--- a/HandheldCompanion/Controllers/Steam/NeptuneController.cs
+++ b/HandheldCompanion/Controllers/Steam/NeptuneController.cs
@@ -217,10 +217,6 @@ public class NeptuneController : SteamController
         }
 
         Inputs.ButtonState[ButtonFlags.RightPadClick] = input.State.ButtonState[NeptuneControllerButton.BtnRPadPress];
-        UpdateTrackpadClickHaptics(
-            Inputs.ButtonState[ButtonFlags.LeftPadClick],
-            Inputs.ButtonState[ButtonFlags.RightPadClick]);
-
         if (Inputs.ButtonState[ButtonFlags.RightPadClick])
         {
             Inputs.ButtonState[ButtonFlags.RightPadClickUp] = Inputs.AxisState[AxisFlags.RightPadY] >= TrackPadInner;

--- a/HandheldCompanion/Controllers/Steam/NeptuneController.cs
+++ b/HandheldCompanion/Controllers/Steam/NeptuneController.cs
@@ -24,6 +24,8 @@ public class NeptuneController : SteamController
     public const sbyte MinIntensity = -2;
     public const sbyte MaxIntensity = 10;
 
+    public override bool IsLizardModeEnabled => Controller?.LizardModeEnabled ?? true;
+
     // TODO: why not use TimerManager.Tick?
     private Thread? rumbleThread;
     private bool rumbleThreadRunning;

--- a/HandheldCompanion/Controllers/Steam/SteamController.cs
+++ b/HandheldCompanion/Controllers/Steam/SteamController.cs
@@ -1,10 +1,14 @@
 ﻿using HandheldCompanion.Inputs;
+using HandheldCompanion.Managers;
 using steam_hidapi.net.Hid;
 
 namespace HandheldCompanion.Controllers.Steam
 {
     public abstract class SteamController : IController
     {
+        private bool leftPadClickPressed;
+        private bool rightPadClickPressed;
+
         protected bool isVirtualMuted = false;
 
         public SteamController() : base()
@@ -195,5 +199,27 @@ namespace HandheldCompanion.Controllers.Steam
 
             }
         }
+
+        protected void UpdateTrackpadClickHaptics(bool leftPressed, bool rightPressed)
+        {
+            UpdateTrackpadClickHaptic(SCHapticMotor.Left, leftPressed, ref leftPadClickPressed);
+            UpdateTrackpadClickHaptic(SCHapticMotor.Right, rightPressed, ref rightPadClickPressed);
+        }
+
+        private void UpdateTrackpadClickHaptic(SCHapticMotor motor, bool pressed, ref bool wasPressed)
+        {
+            if (pressed == wasPressed)
+                return;
+
+            wasPressed = pressed;
+
+            int strength = ManagerFactory.settingsManager.GetInt("SteamTrackpadClickHaptics");
+            if (strength <= 0)
+                return;
+
+            SendTrackpadClickHaptic(motor, System.Math.Clamp(strength, 1, 3), released: !pressed);
+        }
+
+        protected abstract void SendTrackpadClickHaptic(SCHapticMotor motor, int strength, bool released);
     }
 }

--- a/HandheldCompanion/Controllers/Steam/SteamController.cs
+++ b/HandheldCompanion/Controllers/Steam/SteamController.cs
@@ -198,12 +198,5 @@ namespace HandheldCompanion.Controllers.Steam
 
             }
         }
-
-        public override void SetTrackpadClickHaptic(HapticStrength strength, ButtonFlags button, bool released)
-        {
-            SendTrackpadClickHaptic(GetMotorForButton(button), (int)strength + 1, released);
-        }
-
-        protected abstract void SendTrackpadClickHaptic(SCHapticMotor motor, int strength, bool released);
     }
 }

--- a/HandheldCompanion/Controllers/Steam/SteamController.cs
+++ b/HandheldCompanion/Controllers/Steam/SteamController.cs
@@ -9,6 +9,8 @@ namespace HandheldCompanion.Controllers.Steam
         private bool leftPadClickPressed;
         private bool rightPadClickPressed;
 
+        public abstract bool IsLizardModeEnabled { get; }
+
         protected bool isVirtualMuted = false;
 
         public SteamController() : base()

--- a/HandheldCompanion/Controllers/Steam/SteamController.cs
+++ b/HandheldCompanion/Controllers/Steam/SteamController.cs
@@ -1,14 +1,11 @@
 ﻿using HandheldCompanion.Inputs;
-using HandheldCompanion.Managers;
+using HandheldCompanion.Actions;
 using steam_hidapi.net.Hid;
 
 namespace HandheldCompanion.Controllers.Steam
 {
     public abstract class SteamController : IController
     {
-        private bool leftPadClickPressed;
-        private bool rightPadClickPressed;
-
         public abstract bool IsLizardModeEnabled { get; }
 
         protected bool isVirtualMuted = false;
@@ -202,24 +199,9 @@ namespace HandheldCompanion.Controllers.Steam
             }
         }
 
-        protected void UpdateTrackpadClickHaptics(bool leftPressed, bool rightPressed)
+        public override void SetTrackpadClickHaptic(HapticStrength strength, ButtonFlags button, bool released)
         {
-            UpdateTrackpadClickHaptic(SCHapticMotor.Left, leftPressed, ref leftPadClickPressed);
-            UpdateTrackpadClickHaptic(SCHapticMotor.Right, rightPressed, ref rightPadClickPressed);
-        }
-
-        private void UpdateTrackpadClickHaptic(SCHapticMotor motor, bool pressed, ref bool wasPressed)
-        {
-            if (pressed == wasPressed)
-                return;
-
-            wasPressed = pressed;
-
-            int strength = ManagerFactory.settingsManager.GetInt("SteamTrackpadClickHaptics");
-            if (strength <= 0)
-                return;
-
-            SendTrackpadClickHaptic(motor, System.Math.Clamp(strength, 1, 3), released: !pressed);
+            SendTrackpadClickHaptic(GetMotorForButton(button), (int)strength + 1, released);
         }
 
         protected abstract void SendTrackpadClickHaptic(SCHapticMotor motor, int strength, bool released);

--- a/HandheldCompanion/Converters/ActionTypeIndexToNameConverter.cs
+++ b/HandheldCompanion/Converters/ActionTypeIndexToNameConverter.cs
@@ -21,6 +21,7 @@ public class ActionTypeIndexToNameConverter : IValueConverter
                 5 => Resources.LayoutPage_ActionType_Trigger,
                 6 => Resources.LayoutPage_ActionType_Shift,
                 7 => Resources.LayoutPage_ActionType_Inherit,
+                8 => Resources.LayoutPage_ActionType_Touchpad,
                 _ => "Unknown"
             };
         }

--- a/HandheldCompanion/Converters/ActionTypeSupportedConverter.cs
+++ b/HandheldCompanion/Converters/ActionTypeSupportedConverter.cs
@@ -1,0 +1,19 @@
+using HandheldCompanion.Actions;
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Windows.Data;
+
+namespace HandheldCompanion.Converters;
+
+public sealed class ActionTypeSupportedConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return value is ActionType[] supportedActionTypes
+            && parameter is ActionType actionType
+            && supportedActionTypes.Contains(actionType);
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotSupportedException();
+}

--- a/HandheldCompanion/Converters/MotionOutputToNameConverter.cs
+++ b/HandheldCompanion/Converters/MotionOutputToNameConverter.cs
@@ -17,6 +17,8 @@ public class MotionOutputToNameConverter : IValueConverter
                 2 => "Right Stick",
                 3 => "Move Cursor",
                 4 => "Scroll Wheel",
+                5 => "Left Pad",
+                6 => "Right Pad",
                 _ => "Unknown"
             };
         }

--- a/HandheldCompanion/Extensions/GlyphExtensions.cs
+++ b/HandheldCompanion/Extensions/GlyphExtensions.cs
@@ -39,6 +39,10 @@ namespace HandheldCompanion.Extensions
                     return "\uE962";
                 case MotionOutput.ScrollWheel:
                     return "\uEC8F";
+                case MotionOutput.LeftPad:
+                    return "\u2264";
+                case MotionOutput.RightPad:
+                    return "\u2265";
             }
         }
     }

--- a/HandheldCompanion/Inputs/ButtonFlags.cs
+++ b/HandheldCompanion/Inputs/ButtonFlags.cs
@@ -61,10 +61,10 @@ public enum ButtonFlags : byte
     OEM8 = 37,
     OEM9 = 38,
     OEM10 = 39,
-
+    
+    // UI only
     [Description("Left Pad Touch")] LeftPadTouch = 40,
     [Description("Right Pad Touch")] RightPadTouch = 41,
-
     [Description("Left Pad Click")] LeftPadClick = 42,
     [Description("Right Pad Click")] RightPadClick = 43,
 

--- a/HandheldCompanion/Inputs/ButtonFlags.cs
+++ b/HandheldCompanion/Inputs/ButtonFlags.cs
@@ -179,12 +179,10 @@ public enum ButtonFlags : byte
 
     HOTKEY_END = 150,
 
-    [Description("Center Pad Click")] CenterPadClick = 151,
-
     [Description("Microphone Mute")] MicrophoneMute = 152,
 
-    [Description("Touchpad Click (Coordinate)")] TouchpadCoordinateClick = 153,
-    [Description("Touchpad Touch (Coordinate)")] TouchpadCoordinateTouch = 154,
+    [Description("Touchpad Click")] TouchpadClick = 153,
+    [Description("Touchpad Touch")] TouchpadTouch = 154,
     [Description("Touchpad Swipe")] TouchpadSwipe = 155,
 
     Max = 156

--- a/HandheldCompanion/Inputs/ButtonFlags.cs
+++ b/HandheldCompanion/Inputs/ButtonFlags.cs
@@ -179,5 +179,13 @@ public enum ButtonFlags : byte
 
     HOTKEY_END = 150,
 
-    Max = 151
+    [Description("Center Pad Click")] CenterPadClick = 151,
+
+    [Description("Microphone Mute")] MicrophoneMute = 152,
+
+    [Description("Touchpad Click (Coordinate)")] TouchpadCoordinateClick = 153,
+    [Description("Touchpad Touch (Coordinate)")] TouchpadCoordinateTouch = 154,
+    [Description("Touchpad Swipe")] TouchpadSwipe = 155,
+
+    Max = 156
 }

--- a/HandheldCompanion/Inputs/ButtonFlags.cs
+++ b/HandheldCompanion/Inputs/ButtonFlags.cs
@@ -179,8 +179,6 @@ public enum ButtonFlags : byte
 
     HOTKEY_END = 150,
 
-    [Description("Microphone Mute")] MicrophoneMute = 152,
-
     [Description("Touchpad Click")] TouchpadClick = 153,
     [Description("Touchpad Touch")] TouchpadTouch = 154,
     [Description("Touchpad Swipe")] TouchpadSwipe = 155,

--- a/HandheldCompanion/Managers/LayoutManager.cs
+++ b/HandheldCompanion/Managers/LayoutManager.cs
@@ -715,7 +715,6 @@ public class LayoutManager : IManager
 
     private void ApplyTouchpadCoordinates(TouchpadSample?[] samples)
     {
-        TouchpadSample? primarySample = null;
         foreach (TouchpadSample? sample in samples)
         {
             if (sample is null)
@@ -723,17 +722,7 @@ public class LayoutManager : IManager
 
             TouchpadSample value = sample.Value;
             DS4Touch.SetOutputTouch(value.Finger, value.X, value.Y);
-            if (primarySample is null || value.Priority > primarySample.Value.Priority)
-                primarySample = value;
         }
-
-        if (primarySample is null)
-            return;
-
-        outputState.AxisState[AxisFlags.RightPadX] = DS4Touch.CoordinateToAxis(
-            primarySample.Value.X, DS4Touch.TOUCHPAD_WIDTH);
-        outputState.AxisState[AxisFlags.RightPadY] = DS4Touch.CoordinateToAxis(
-            DS4Touch.TOUCHPAD_HEIGHT - 1 - primarySample.Value.Y, DS4Touch.TOUCHPAD_HEIGHT);
     }
 
     /// <summary>

--- a/HandheldCompanion/Managers/LayoutManager.cs
+++ b/HandheldCompanion/Managers/LayoutManager.cs
@@ -3,8 +3,10 @@ using HandheldCompanion.Controllers;
 using HandheldCompanion.Helpers;
 using HandheldCompanion.Inputs;
 using HandheldCompanion.Misc;
+using HandheldCompanion.Notifications;
 using HandheldCompanion.Shared;
 using HandheldCompanion.Utils;
+using iNKORE.UI.WPF.Modern.Controls;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -38,6 +40,13 @@ public class LayoutManager : IManager
     private Layout? desktopLayout = null;
 
     private readonly ControllerState outputState = new();
+    private readonly TouchpadActions touchpadHaptics = new();
+    private readonly Notification trackpadClickHapticOverrideNotification = new(
+        Properties.Resources.ControllerPage_TrackpadClickHapticsOverride,
+        Properties.Resources.ControllerPage_TrackpadClickHapticsOverrideDesc,
+        string.Empty,
+        InfoBarSeverity.Warning);
+    private bool hasTrackpadClickHapticOverrides;
 
     private const string desktopLayoutFile = "desktop";
 
@@ -515,6 +524,8 @@ public class LayoutManager : IManager
             {
                 if (action is AxisActions aa) EnsureAxisXY(aa.Axis);
                 if (action is TriggerActions ta) EnsureAxisXY(ta.Axis);
+                if (action is TouchpadActions { TargetType: TouchpadTargetType.Axis } touchpadAction)
+                    EnsureAxisXY(touchpadAction.Axis);
             }
 
         foreach (var actions in _buttonPlan.Values)
@@ -522,7 +533,35 @@ public class LayoutManager : IManager
             {
                 if (action is AxisActions aa) EnsureAxisXY(aa.Axis);
                 if (action is TriggerActions ta) EnsureAxisXY(ta.Axis);
+                if (action is TouchpadActions { TargetType: TouchpadTargetType.Axis } touchpadAction)
+                    EnsureAxisXY(touchpadAction.Axis);
             }
+
+        foreach (var action in _gyroPlan.Values)
+        {
+            if (action is AxisActions axisAction)
+                EnsureAxisXY(axisAction.Axis);
+            if (action is TouchpadActions { TargetType: TouchpadTargetType.Axis } touchpadAction)
+                EnsureAxisXY(touchpadAction.Axis);
+        }
+
+        UpdateTrackpadClickHapticOverrideNotification();
+    }
+
+    private void UpdateTrackpadClickHapticOverrideNotification()
+    {
+        bool hasOverrides = _buttonPlan.Any(pair =>
+            TouchpadActions.IsPhysicalClick(pair.Key) &&
+            pair.Value.Any(TouchpadActions.HasCustomHapticSettings));
+
+        if (hasOverrides == hasTrackpadClickHapticOverrides)
+            return;
+
+        hasTrackpadClickHapticOverrides = hasOverrides;
+        if (hasOverrides)
+            ManagerFactory.notificationManager.Add(trackpadClickHapticOverrideNotification);
+        else
+            ManagerFactory.notificationManager.Discard(trackpadClickHapticOverrideNotification);
     }
 
     private void EnsureAxisXY(AxisLayoutFlags flag)
@@ -549,11 +588,12 @@ public class LayoutManager : IManager
             float deltaMs = delta * 1000f;
 
             ShiftSlot shiftSlot = ComputeShiftSlot(controllerState, deltaMs);
+            touchpadHaptics.UpdateClickHaptics(controllerState, shiftSlot, _buttonPlan);
 
             ProcessButtonActions(controllerState, shiftSlot, deltaMs, ref touchpadSample);
             ProcessAxisActions(controllerState, shiftSlot, deltaMs, ref touchpadSample);
-            ApplyTouchpadCoordinates(touchpadSample);
             ProcessGyroActions(controllerState, shiftSlot, deltaMs);
+            ApplyTouchpadCoordinates(touchpadSample);
         }
 
         return outputState;
@@ -630,20 +670,14 @@ public class LayoutManager : IManager
                         {
                             var bA = (ButtonActions)action;
                             bA.Execute(button, pressed, shiftSlot, deltaMs);
-                            if (bA is TouchpadActions touchpadAction)
-                            {
-                                if (touchpadAction.TryGetTouch(out TouchpadSample sample))
-                                {
-                                    outputState.ButtonState[touchpadAction.Button] |= true;
-                                    if (selectedTouchpadSample is null ||
-                                        sample.Priority > selectedTouchpadSample.Value.Priority)
-                                        selectedTouchpadSample = sample;
-                                }
-                            }
-                            else
-                            {
-                                outputState.ButtonState[bA.Button] |= bA.GetValue();
-                            }
+                            outputState.ButtonState[bA.Button] |= bA.GetValue();
+                            break;
+                        }
+                    case ActionType.Touchpad:
+                        {
+                            var tA = (TouchpadActions)action;
+                            tA.Execute(button, pressed, shiftSlot, deltaMs);
+                            ApplyTouchpadAction(tA, ref selectedTouchpadSample);
                             break;
                         }
                     case ActionType.Keyboard:
@@ -709,6 +743,9 @@ public class LayoutManager : IManager
             if (ControllerState.AxisTouchButtons.TryGetValue(layout.flags, out var touchButton))
                 touched = state.ButtonState[touchButton];
 
+            if (TouchpadActions.IsTouchpadAxis(flag))
+                touchpadHaptics.UpdateMovementHaptics(flag, layout.vector, touched, shiftSlot, actions);
+
             for (int i = 0; i < actions.Length; i++)
             {
                 var action = actions[i];
@@ -719,20 +756,14 @@ public class LayoutManager : IManager
                         {
                             var bA = (ButtonActions)action;
                             bA.Execute(layout, shiftSlot, deltaMs);
-                            if (bA is TouchpadActions touchpadAction)
-                            {
-                                if (touchpadAction.TryGetTouch(out TouchpadSample sample))
-                                {
-                                    outputState.ButtonState[touchpadAction.Button] |= true;
-                                    if (selectedTouchpadSample is null ||
-                                        sample.Priority > selectedTouchpadSample.Value.Priority)
-                                        selectedTouchpadSample = sample;
-                                }
-                            }
-                            else
-                            {
-                                outputState.ButtonState[bA.Button] |= bA.GetValue();
-                            }
+                            outputState.ButtonState[bA.Button] |= bA.GetValue();
+                            break;
+                        }
+                    case ActionType.Touchpad:
+                        {
+                            var tA = (TouchpadActions)action;
+                            tA.Execute(layout, touched, shiftSlot, deltaMs);
+                            ApplyTouchpadAction(tA, ref selectedTouchpadSample);
                             break;
                         }
                     case ActionType.Keyboard:
@@ -764,6 +795,34 @@ public class LayoutManager : IManager
                 ApplyActionStateSideEffects(actions, i);
             }
         }
+    }
+
+    private void ApplyTouchpadAction(TouchpadActions action, ref TouchpadSample? selectedTouchpadSample)
+    {
+        if (action.TargetType == TouchpadTargetType.Axis)
+        {
+            var xyOut = _axisXY[action.Axis];
+            Vector2 value = action.GetAxisValue();
+            outputState.AxisState[xyOut.X] = ClampShort(outputState.AxisState[xyOut.X] + value.X);
+            outputState.AxisState[xyOut.Y] = ClampShort(outputState.AxisState[xyOut.Y] + value.Y);
+
+            if (ControllerState.AxisTouchButtons.TryGetValue(action.Axis, out ButtonFlags touchButton))
+                outputState.ButtonState[touchButton] |= action.GetTouchValue();
+            return;
+        }
+
+        if (TouchpadActions.IsCoordinateTarget(action.Button))
+        {
+            if (action.TryGetTouch(out TouchpadSample sample))
+            {
+                outputState.ButtonState[action.Button] |= true;
+                if (selectedTouchpadSample is null || sample.Priority > selectedTouchpadSample.Value.Priority)
+                    selectedTouchpadSample = sample;
+            }
+            return;
+        }
+
+        outputState.ButtonState[action.Button] |= action.GetButtonValue();
     }
 
     /// <summary>
@@ -810,6 +869,26 @@ public class LayoutManager : IManager
                             touched = state.ButtonState[touchButton];
 
                         mA.Execute(layout, touched, shiftSlot, deltaMs);
+                    }
+                    break;
+
+                case ActionType.Touchpad:
+                    if (action is TouchpadActions { TargetType: TouchpadTargetType.Axis } touchpadAction)
+                    {
+                        touchpadAction.Execute(layout, touched: false, shiftSlot, deltaMs);
+
+                        var xyOut = _axisXY[touchpadAction.Axis];
+                        var current = new Vector2(outputState.AxisState[xyOut.X], outputState.AxisState[xyOut.Y]);
+
+                        float padNorm = Math.Clamp(current.Length() / short.MaxValue, 0f, 1f);
+                        float weightFactor = touchpadAction.gyroWeight - padNorm;
+                        var blended = current + touchpadAction.GetAxisValue() * weightFactor;
+
+                        outputState.AxisState[xyOut.X] = ClampShort(blended.X);
+                        outputState.AxisState[xyOut.Y] = ClampShort(blended.Y);
+
+                        if (ControllerState.AxisTouchButtons.TryGetValue(touchpadAction.Axis, out ButtonFlags touchButton))
+                            outputState.ButtonState[touchButton] |= touchpadAction.GetTouchValue();
                     }
                     break;
             }

--- a/HandheldCompanion/Managers/LayoutManager.cs
+++ b/HandheldCompanion/Managers/LayoutManager.cs
@@ -579,18 +579,16 @@ public class LayoutManager : IManager
             outputState.ButtonState.Clear();
             outputState.AxisState.Clear();
             outputState.GyroState.CopyFrom(controllerState.GyroState);
-            TouchpadActions.BeginOutputFrame();
+            DS4Touch.ClearOutputTouches();
 
-            // delta arrives in seconds; all timer logic expects milliseconds
+            // delta arrives in seconds; all timer logic expoodects milliseconds
             float deltaMs = delta * 1000f;
 
             ShiftSlot shiftSlot = ComputeShiftSlot(controllerState, deltaMs);
-            TouchpadActions.UpdateClickHaptics(controllerState, shiftSlot, _buttonPlan);
 
             ProcessButtonActions(controllerState, shiftSlot, deltaMs);
             ProcessAxisActions(controllerState, shiftSlot, deltaMs);
             ProcessGyroActions(controllerState, shiftSlot, deltaMs);
-            TouchpadActions.CommitOutputFrame();
         }
 
         return outputState;
@@ -673,8 +671,7 @@ public class LayoutManager : IManager
                         {
                             var tA = (TouchpadActions)action;
                             tA.Execute(button, pressed, shiftSlot, deltaMs);
-                            var xyOut = tA.TargetType == TouchpadTargetType.Axis ? _axisXY[tA.Axis] : default;
-                            tA.ApplyOutput(outputState, xyOut.X, xyOut.Y);
+                            tA.ApplyOutput(outputState);
                             break;
                         }
                     case ActionType.Keyboard:
@@ -728,9 +725,6 @@ public class LayoutManager : IManager
             if (ControllerState.AxisTouchButtons.TryGetValue(layout.flags, out var touchButton))
                 touched = state.ButtonState[touchButton];
 
-            if (TouchpadActions.IsTouchpadAxis(flag))
-                TouchpadActions.UpdateMovementHaptics(flag, layout.vector, touched, shiftSlot, actions);
-
             for (int i = 0; i < actions.Length; i++)
             {
                 var action = actions[i];
@@ -748,15 +742,7 @@ public class LayoutManager : IManager
                         {
                             var tA = (TouchpadActions)action;
                             tA.Execute(layout, touched, shiftSlot, deltaMs);
-                            if (tA.TargetType == TouchpadTargetType.Axis)
-                            {
-                                var xyOut = _axisXY[tA.Axis];
-                                tA.ApplyOutput(outputState, xyOut.X, xyOut.Y);
-                            }
-                            else
-                            {
-                                tA.ApplyOutput(outputState);
-                            }
+                            tA.ApplyOutput(outputState);
                             break;
                         }
                     case ActionType.Keyboard:
@@ -841,19 +827,7 @@ public class LayoutManager : IManager
                     if (action is TouchpadActions { TargetType: TouchpadTargetType.Axis } touchpadAction)
                     {
                         touchpadAction.Execute(layout, touched: false, shiftSlot, deltaMs);
-
-                        var xyOut = _axisXY[touchpadAction.Axis];
-                        var current = new Vector2(outputState.AxisState[xyOut.X], outputState.AxisState[xyOut.Y]);
-
-                        float padNorm = Math.Clamp(current.Length() / short.MaxValue, 0f, 1f);
-                        float weightFactor = touchpadAction.gyroWeight - padNorm;
-                        var blended = current + touchpadAction.GetAxisValue() * weightFactor;
-
-                        outputState.AxisState[xyOut.X] = ClampShort(blended.X);
-                        outputState.AxisState[xyOut.Y] = ClampShort(blended.Y);
-
-                        if (ControllerState.AxisTouchButtons.TryGetValue(touchpadAction.Axis, out ButtonFlags touchButton))
-                            outputState.ButtonState[touchButton] |= touchpadAction.GetTouchValue();
+                        touchpadAction.ApplyGyroOutput(outputState);
                     }
                     break;
             }

--- a/HandheldCompanion/Managers/LayoutManager.cs
+++ b/HandheldCompanion/Managers/LayoutManager.cs
@@ -627,7 +627,19 @@ public class LayoutManager : IManager
                         {
                             var bA = (ButtonActions)action;
                             bA.Execute(button, pressed, shiftSlot, deltaMs);
-                            outputState.ButtonState[bA.Button] |= bA.GetValue();
+                            if (bA is TouchpadActions touchpadAction)
+                            {
+                                if (touchpadAction.TryGetTouch(out int x, out int y, out bool click))
+                                {
+                                    outputState.ButtonState[touchpadAction.Button] = true;
+                                    outputState.AxisState[AxisFlags.RightPadX] = CoordinateToAxis(x, DS4Touch.TOUCHPAD_WIDTH);
+                                    outputState.AxisState[AxisFlags.RightPadY] = CoordinateToAxis(DS4Touch.TOUCHPAD_HEIGHT - 1 - y, DS4Touch.TOUCHPAD_HEIGHT);
+                                }
+                            }
+                            else
+                            {
+                                outputState.ButtonState[bA.Button] |= bA.GetValue();
+                            }
                             break;
                         }
                     case ActionType.Keyboard:
@@ -660,6 +672,13 @@ public class LayoutManager : IManager
                 ApplyActionStateSideEffects(actions, i);
             }
         }
+    }
+
+    private static short CoordinateToAxis(int value, int extent)
+    {
+        int clamped = Math.Clamp(value, 0, extent - 1);
+        return (short)Math.Clamp((long)clamped * ushort.MaxValue / (extent - 1) + short.MinValue,
+            short.MinValue, short.MaxValue);
     }
 
     /// <summary>

--- a/HandheldCompanion/Managers/LayoutManager.cs
+++ b/HandheldCompanion/Managers/LayoutManager.cs
@@ -551,7 +551,7 @@ public class LayoutManager : IManager
             ShiftSlot shiftSlot = ComputeShiftSlot(controllerState, deltaMs);
 
             ProcessButtonActions(controllerState, shiftSlot, deltaMs, ref touchpadSample);
-            ProcessAxisActions(controllerState, shiftSlot, deltaMs);
+            ProcessAxisActions(controllerState, shiftSlot, deltaMs, ref touchpadSample);
             ApplyTouchpadCoordinates(touchpadSample);
             ProcessGyroActions(controllerState, shiftSlot, deltaMs);
         }
@@ -692,7 +692,8 @@ public class LayoutManager : IManager
     /// <summary>
     /// Third pass: process axis (stick / pad / trigger) actions and write to outputState.
     /// </summary>
-    private void ProcessAxisActions(ControllerState state, ShiftSlot shiftSlot, float deltaMs)
+    private void ProcessAxisActions(ControllerState state, ShiftSlot shiftSlot, float deltaMs,
+        ref TouchpadSample? selectedTouchpadSample)
     {
         for (int a = 0; a < _plannedAxes.Length; a++)
         {
@@ -718,7 +719,20 @@ public class LayoutManager : IManager
                         {
                             var bA = (ButtonActions)action;
                             bA.Execute(layout, shiftSlot, deltaMs);
-                            outputState.ButtonState[bA.Button] |= bA.GetValue();
+                            if (bA is TouchpadActions touchpadAction)
+                            {
+                                if (touchpadAction.TryGetTouch(out TouchpadSample sample))
+                                {
+                                    outputState.ButtonState[touchpadAction.Button] |= true;
+                                    if (selectedTouchpadSample is null ||
+                                        sample.Priority > selectedTouchpadSample.Value.Priority)
+                                        selectedTouchpadSample = sample;
+                                }
+                            }
+                            else
+                            {
+                                outputState.ButtonState[bA.Button] |= bA.GetValue();
+                            }
                             break;
                         }
                     case ActionType.Keyboard:

--- a/HandheldCompanion/Managers/LayoutManager.cs
+++ b/HandheldCompanion/Managers/LayoutManager.cs
@@ -40,7 +40,6 @@ public class LayoutManager : IManager
     private Layout? desktopLayout = null;
 
     private readonly ControllerState outputState = new();
-    private readonly TouchpadActions touchpadHaptics = new();
     private readonly Notification trackpadClickHapticOverrideNotification = new(
         Properties.Resources.ControllerPage_TrackpadClickHapticsOverride,
         Properties.Resources.ControllerPage_TrackpadClickHapticsOverrideDesc,
@@ -522,26 +521,24 @@ public class LayoutManager : IManager
         foreach (var actions in _axisPlan.Values)
             foreach (var action in actions)
             {
-                if (action is AxisActions aa) EnsureAxisXY(aa.Axis);
-                if (action is TriggerActions ta) EnsureAxisXY(ta.Axis);
-                if (action is TouchpadActions { TargetType: TouchpadTargetType.Axis } touchpadAction)
-                    EnsureAxisXY(touchpadAction.Axis);
+                if (action is AxisActions axisAction) EnsureAxisXY(axisAction.Axis);
+                if (action is TriggerActions triggerAction) EnsureAxisXY(triggerAction.Axis);
+                if (action is TouchpadActions touchpadAction) EnsureAxisXY(touchpadAction.Axis);
             }
 
         foreach (var actions in _buttonPlan.Values)
             foreach (var action in actions)
             {
-                if (action is AxisActions aa) EnsureAxisXY(aa.Axis);
-                if (action is TriggerActions ta) EnsureAxisXY(ta.Axis);
-                if (action is TouchpadActions { TargetType: TouchpadTargetType.Axis } touchpadAction)
-                    EnsureAxisXY(touchpadAction.Axis);
+                if (action is AxisActions axisAction) EnsureAxisXY(axisAction.Axis);
+                if (action is TriggerActions triggerAction) EnsureAxisXY(triggerAction.Axis);
+                if (action is TouchpadActions touchpadAction) EnsureAxisXY(touchpadAction.Axis);
             }
 
         foreach (var action in _gyroPlan.Values)
         {
             if (action is AxisActions axisAction)
                 EnsureAxisXY(axisAction.Axis);
-            if (action is TouchpadActions { TargetType: TouchpadTargetType.Axis } touchpadAction)
+            if (action is TouchpadActions touchpadAction)
                 EnsureAxisXY(touchpadAction.Axis);
         }
 
@@ -582,19 +579,18 @@ public class LayoutManager : IManager
             outputState.ButtonState.Clear();
             outputState.AxisState.Clear();
             outputState.GyroState.CopyFrom(controllerState.GyroState);
-            DS4Touch.ClearOutputTouches();
-            TouchpadSample?[] touchpadSamples = new TouchpadSample?[2];
+            TouchpadActions.BeginOutputFrame();
 
             // delta arrives in seconds; all timer logic expects milliseconds
             float deltaMs = delta * 1000f;
 
             ShiftSlot shiftSlot = ComputeShiftSlot(controllerState, deltaMs);
-            touchpadHaptics.UpdateClickHaptics(controllerState, shiftSlot, _buttonPlan);
+            TouchpadActions.UpdateClickHaptics(controllerState, shiftSlot, _buttonPlan);
 
-            ProcessButtonActions(controllerState, shiftSlot, deltaMs, ref touchpadSamples);
-            ProcessAxisActions(controllerState, shiftSlot, deltaMs, ref touchpadSamples);
+            ProcessButtonActions(controllerState, shiftSlot, deltaMs);
+            ProcessAxisActions(controllerState, shiftSlot, deltaMs);
             ProcessGyroActions(controllerState, shiftSlot, deltaMs);
-            ApplyTouchpadCoordinates(touchpadSamples);
+            TouchpadActions.CommitOutputFrame();
         }
 
         return outputState;
@@ -652,8 +648,7 @@ public class LayoutManager : IManager
     /// <summary>
     /// Second pass: process all non-Shift button actions and write to outputState.
     /// </summary>
-    private void ProcessButtonActions(ControllerState state, ShiftSlot shiftSlot, float deltaMs,
-        ref TouchpadSample?[] touchpadSamples)
+    private void ProcessButtonActions(ControllerState state, ShiftSlot shiftSlot, float deltaMs)
     {
         for (int b = 0; b < _plannedButtons.Length; b++)
         {
@@ -678,7 +673,8 @@ public class LayoutManager : IManager
                         {
                             var tA = (TouchpadActions)action;
                             tA.Execute(button, pressed, shiftSlot, deltaMs);
-                            ApplyTouchpadAction(tA, ref touchpadSamples);
+                            var xyOut = tA.TargetType == TouchpadTargetType.Axis ? _axisXY[tA.Axis] : default;
+                            tA.ApplyOutput(outputState, xyOut.X, xyOut.Y);
                             break;
                         }
                     case ActionType.Keyboard:
@@ -713,23 +709,10 @@ public class LayoutManager : IManager
         }
     }
 
-    private void ApplyTouchpadCoordinates(TouchpadSample?[] samples)
-    {
-        foreach (TouchpadSample? sample in samples)
-        {
-            if (sample is null)
-                continue;
-
-            TouchpadSample value = sample.Value;
-            DS4Touch.SetOutputTouch(value.Finger, value.X, value.Y);
-        }
-    }
-
     /// <summary>
     /// Third pass: process axis (stick / pad / trigger) actions and write to outputState.
     /// </summary>
-    private void ProcessAxisActions(ControllerState state, ShiftSlot shiftSlot, float deltaMs,
-        ref TouchpadSample?[] touchpadSamples)
+    private void ProcessAxisActions(ControllerState state, ShiftSlot shiftSlot, float deltaMs)
     {
         for (int a = 0; a < _plannedAxes.Length; a++)
         {
@@ -746,7 +729,7 @@ public class LayoutManager : IManager
                 touched = state.ButtonState[touchButton];
 
             if (TouchpadActions.IsTouchpadAxis(flag))
-                touchpadHaptics.UpdateMovementHaptics(flag, layout.vector, touched, shiftSlot, actions);
+                TouchpadActions.UpdateMovementHaptics(flag, layout.vector, touched, shiftSlot, actions);
 
             for (int i = 0; i < actions.Length; i++)
             {
@@ -765,7 +748,15 @@ public class LayoutManager : IManager
                         {
                             var tA = (TouchpadActions)action;
                             tA.Execute(layout, touched, shiftSlot, deltaMs);
-                            ApplyTouchpadAction(tA, ref touchpadSamples);
+                            if (tA.TargetType == TouchpadTargetType.Axis)
+                            {
+                                var xyOut = _axisXY[tA.Axis];
+                                tA.ApplyOutput(outputState, xyOut.X, xyOut.Y);
+                            }
+                            else
+                            {
+                                tA.ApplyOutput(outputState);
+                            }
                             break;
                         }
                     case ActionType.Keyboard:
@@ -797,35 +788,6 @@ public class LayoutManager : IManager
                 ApplyActionStateSideEffects(actions, i);
             }
         }
-    }
-
-    private void ApplyTouchpadAction(TouchpadActions action, ref TouchpadSample?[] touchpadSamples)
-    {
-        if (action.TargetType == TouchpadTargetType.Axis)
-        {
-            var xyOut = _axisXY[action.Axis];
-            Vector2 value = action.GetAxisValue();
-            outputState.AxisState[xyOut.X] = ClampShort(outputState.AxisState[xyOut.X] + value.X);
-            outputState.AxisState[xyOut.Y] = ClampShort(outputState.AxisState[xyOut.Y] + value.Y);
-
-            if (ControllerState.AxisTouchButtons.TryGetValue(action.Axis, out ButtonFlags touchButton))
-                outputState.ButtonState[touchButton] |= action.GetTouchValue();
-            return;
-        }
-
-        if (TouchpadActions.IsGestureTarget(action.Button))
-        {
-            if (action.TryGetTouch(out TouchpadSample sample))
-            {
-                outputState.ButtonState[action.Button] |= true;
-                int fingerIndex = sample.Finger - 1;
-                if (touchpadSamples[fingerIndex] is null || sample.Priority > touchpadSamples[fingerIndex]!.Value.Priority)
-                    touchpadSamples[fingerIndex] = sample;
-            }
-            return;
-        }
-
-        outputState.ButtonState[action.Button] |= action.GetButtonValue();
     }
 
     /// <summary>

--- a/HandheldCompanion/Managers/LayoutManager.cs
+++ b/HandheldCompanion/Managers/LayoutManager.cs
@@ -50,9 +50,6 @@ public class LayoutManager : IManager
     private Dictionary<ButtonFlags, IActions[]> _buttonPlan = new();
     private Dictionary<AxisLayoutFlags, IActions[]> _axisPlan = new();
     private Dictionary<AxisLayoutFlags, IActions> _gyroPlan = new();  // one action per axis flag
-    private long touchpadAxisXSum;
-    private long touchpadAxisYSum;
-    private int touchpadCoordinateCount;
 
     // X/Y AxisFlags for each AxisLayoutFlags — cached to avoid per-tick lookups
     private readonly Dictionary<AxisLayoutFlags, (AxisFlags X, AxisFlags Y)> _axisXY = new();
@@ -546,18 +543,16 @@ public class LayoutManager : IManager
             outputState.ButtonState.Clear();
             outputState.AxisState.Clear();
             outputState.GyroState.CopyFrom(controllerState.GyroState);
-            touchpadAxisXSum = 0;
-            touchpadAxisYSum = 0;
-            touchpadCoordinateCount = 0;
+            TouchpadSample? touchpadSample = null;
 
             // delta arrives in seconds; all timer logic expects milliseconds
             float deltaMs = delta * 1000f;
 
             ShiftSlot shiftSlot = ComputeShiftSlot(controllerState, deltaMs);
 
-            ProcessButtonActions(controllerState, shiftSlot, deltaMs);
+            ProcessButtonActions(controllerState, shiftSlot, deltaMs, ref touchpadSample);
             ProcessAxisActions(controllerState, shiftSlot, deltaMs);
-            ApplyTouchpadCoordinates();
+            ApplyTouchpadCoordinates(touchpadSample);
             ProcessGyroActions(controllerState, shiftSlot, deltaMs);
         }
 
@@ -616,7 +611,8 @@ public class LayoutManager : IManager
     /// <summary>
     /// Second pass: process all non-Shift button actions and write to outputState.
     /// </summary>
-    private void ProcessButtonActions(ControllerState state, ShiftSlot shiftSlot, float deltaMs)
+    private void ProcessButtonActions(ControllerState state, ShiftSlot shiftSlot, float deltaMs,
+        ref TouchpadSample? selectedTouchpadSample)
     {
         for (int b = 0; b < _plannedButtons.Length; b++)
         {
@@ -636,12 +632,12 @@ public class LayoutManager : IManager
                             bA.Execute(button, pressed, shiftSlot, deltaMs);
                             if (bA is TouchpadActions touchpadAction)
                             {
-                                if (touchpadAction.ConsumeTouch(out int x, out int y))
+                                if (touchpadAction.TryGetTouch(out TouchpadSample sample))
                                 {
                                     outputState.ButtonState[touchpadAction.Button] |= true;
-                                    touchpadAxisXSum += DS4Touch.CoordinateToAxis(x, DS4Touch.TOUCHPAD_WIDTH);
-                                    touchpadAxisYSum += DS4Touch.CoordinateToAxis(DS4Touch.TOUCHPAD_HEIGHT - 1 - y, DS4Touch.TOUCHPAD_HEIGHT);
-                                    touchpadCoordinateCount++;
+                                    if (selectedTouchpadSample is null ||
+                                        sample.Priority > selectedTouchpadSample.Value.Priority)
+                                        selectedTouchpadSample = sample;
                                 }
                             }
                             else
@@ -682,15 +678,15 @@ public class LayoutManager : IManager
         }
     }
 
-    private void ApplyTouchpadCoordinates()
+    private void ApplyTouchpadCoordinates(TouchpadSample? sample)
     {
-        if (touchpadCoordinateCount == 0)
+        if (sample is null)
             return;
 
-        outputState.AxisState[AxisFlags.RightPadX] = (short)Math.Clamp(
-            Math.Round((double)touchpadAxisXSum / touchpadCoordinateCount), short.MinValue, short.MaxValue);
-        outputState.AxisState[AxisFlags.RightPadY] = (short)Math.Clamp(
-            Math.Round((double)touchpadAxisYSum / touchpadCoordinateCount), short.MinValue, short.MaxValue);
+        outputState.AxisState[AxisFlags.RightPadX] = DS4Touch.CoordinateToAxis(
+            sample.Value.X, DS4Touch.TOUCHPAD_WIDTH);
+        outputState.AxisState[AxisFlags.RightPadY] = DS4Touch.CoordinateToAxis(
+            DS4Touch.TOUCHPAD_HEIGHT - 1 - sample.Value.Y, DS4Touch.TOUCHPAD_HEIGHT);
     }
 
     /// <summary>

--- a/HandheldCompanion/Managers/LayoutManager.cs
+++ b/HandheldCompanion/Managers/LayoutManager.cs
@@ -50,6 +50,9 @@ public class LayoutManager : IManager
     private Dictionary<ButtonFlags, IActions[]> _buttonPlan = new();
     private Dictionary<AxisLayoutFlags, IActions[]> _axisPlan = new();
     private Dictionary<AxisLayoutFlags, IActions> _gyroPlan = new();  // one action per axis flag
+    private long touchpadAxisXSum;
+    private long touchpadAxisYSum;
+    private int touchpadCoordinateCount;
 
     // X/Y AxisFlags for each AxisLayoutFlags — cached to avoid per-tick lookups
     private readonly Dictionary<AxisLayoutFlags, (AxisFlags X, AxisFlags Y)> _axisXY = new();
@@ -543,6 +546,9 @@ public class LayoutManager : IManager
             outputState.ButtonState.Clear();
             outputState.AxisState.Clear();
             outputState.GyroState.CopyFrom(controllerState.GyroState);
+            touchpadAxisXSum = 0;
+            touchpadAxisYSum = 0;
+            touchpadCoordinateCount = 0;
 
             // delta arrives in seconds; all timer logic expects milliseconds
             float deltaMs = delta * 1000f;
@@ -551,6 +557,7 @@ public class LayoutManager : IManager
 
             ProcessButtonActions(controllerState, shiftSlot, deltaMs);
             ProcessAxisActions(controllerState, shiftSlot, deltaMs);
+            ApplyTouchpadCoordinates();
             ProcessGyroActions(controllerState, shiftSlot, deltaMs);
         }
 
@@ -629,11 +636,12 @@ public class LayoutManager : IManager
                             bA.Execute(button, pressed, shiftSlot, deltaMs);
                             if (bA is TouchpadActions touchpadAction)
                             {
-                                if (touchpadAction.TryGetTouch(out int x, out int y, out bool click))
+                                if (touchpadAction.ConsumeTouch(out int x, out int y))
                                 {
-                                    outputState.ButtonState[touchpadAction.Button] = true;
-                                    outputState.AxisState[AxisFlags.RightPadX] = CoordinateToAxis(x, DS4Touch.TOUCHPAD_WIDTH);
-                                    outputState.AxisState[AxisFlags.RightPadY] = CoordinateToAxis(DS4Touch.TOUCHPAD_HEIGHT - 1 - y, DS4Touch.TOUCHPAD_HEIGHT);
+                                    outputState.ButtonState[touchpadAction.Button] |= true;
+                                    touchpadAxisXSum += DS4Touch.CoordinateToAxis(x, DS4Touch.TOUCHPAD_WIDTH);
+                                    touchpadAxisYSum += DS4Touch.CoordinateToAxis(DS4Touch.TOUCHPAD_HEIGHT - 1 - y, DS4Touch.TOUCHPAD_HEIGHT);
+                                    touchpadCoordinateCount++;
                                 }
                             }
                             else
@@ -674,11 +682,15 @@ public class LayoutManager : IManager
         }
     }
 
-    private static short CoordinateToAxis(int value, int extent)
+    private void ApplyTouchpadCoordinates()
     {
-        int clamped = Math.Clamp(value, 0, extent - 1);
-        return (short)Math.Clamp((long)clamped * ushort.MaxValue / (extent - 1) + short.MinValue,
-            short.MinValue, short.MaxValue);
+        if (touchpadCoordinateCount == 0)
+            return;
+
+        outputState.AxisState[AxisFlags.RightPadX] = (short)Math.Clamp(
+            Math.Round((double)touchpadAxisXSum / touchpadCoordinateCount), short.MinValue, short.MaxValue);
+        outputState.AxisState[AxisFlags.RightPadY] = (short)Math.Clamp(
+            Math.Round((double)touchpadAxisYSum / touchpadCoordinateCount), short.MinValue, short.MaxValue);
     }
 
     /// <summary>

--- a/HandheldCompanion/Managers/LayoutManager.cs
+++ b/HandheldCompanion/Managers/LayoutManager.cs
@@ -811,7 +811,7 @@ public class LayoutManager : IManager
             return;
         }
 
-        if (TouchpadActions.IsCoordinateTarget(action.Button))
+        if (TouchpadActions.IsGestureTarget(action.Button))
         {
             if (action.TryGetTouch(out TouchpadSample sample))
             {

--- a/HandheldCompanion/Managers/LayoutManager.cs
+++ b/HandheldCompanion/Managers/LayoutManager.cs
@@ -40,13 +40,6 @@ public class LayoutManager : IManager
     private Layout? desktopLayout = null;
 
     private readonly ControllerState outputState = new();
-    private readonly Notification trackpadClickHapticOverrideNotification = new(
-        Properties.Resources.ControllerPage_TrackpadClickHapticsOverride,
-        Properties.Resources.ControllerPage_TrackpadClickHapticsOverrideDesc,
-        string.Empty,
-        InfoBarSeverity.Warning);
-    private bool hasTrackpadClickHapticOverrides;
-
     private const string desktopLayoutFile = "desktop";
 
     public string TemplatesPath;
@@ -542,23 +535,6 @@ public class LayoutManager : IManager
                 EnsureAxisXY(touchpadAction.Axis);
         }
 
-        UpdateTrackpadClickHapticOverrideNotification();
-    }
-
-    private void UpdateTrackpadClickHapticOverrideNotification()
-    {
-        bool hasOverrides = _buttonPlan.Any(pair =>
-            TouchpadActions.IsPhysicalClick(pair.Key) &&
-            pair.Value.Any(TouchpadActions.HasCustomHapticSettings));
-
-        if (hasOverrides == hasTrackpadClickHapticOverrides)
-            return;
-
-        hasTrackpadClickHapticOverrides = hasOverrides;
-        if (hasOverrides)
-            ManagerFactory.notificationManager.Add(trackpadClickHapticOverrideNotification);
-        else
-            ManagerFactory.notificationManager.Discard(trackpadClickHapticOverrideNotification);
     }
 
     private void EnsureAxisXY(AxisLayoutFlags flag)

--- a/HandheldCompanion/Managers/LayoutManager.cs
+++ b/HandheldCompanion/Managers/LayoutManager.cs
@@ -582,7 +582,8 @@ public class LayoutManager : IManager
             outputState.ButtonState.Clear();
             outputState.AxisState.Clear();
             outputState.GyroState.CopyFrom(controllerState.GyroState);
-            TouchpadSample? touchpadSample = null;
+            DS4Touch.ClearOutputTouches();
+            TouchpadSample?[] touchpadSamples = new TouchpadSample?[2];
 
             // delta arrives in seconds; all timer logic expects milliseconds
             float deltaMs = delta * 1000f;
@@ -590,10 +591,10 @@ public class LayoutManager : IManager
             ShiftSlot shiftSlot = ComputeShiftSlot(controllerState, deltaMs);
             touchpadHaptics.UpdateClickHaptics(controllerState, shiftSlot, _buttonPlan);
 
-            ProcessButtonActions(controllerState, shiftSlot, deltaMs, ref touchpadSample);
-            ProcessAxisActions(controllerState, shiftSlot, deltaMs, ref touchpadSample);
+            ProcessButtonActions(controllerState, shiftSlot, deltaMs, ref touchpadSamples);
+            ProcessAxisActions(controllerState, shiftSlot, deltaMs, ref touchpadSamples);
             ProcessGyroActions(controllerState, shiftSlot, deltaMs);
-            ApplyTouchpadCoordinates(touchpadSample);
+            ApplyTouchpadCoordinates(touchpadSamples);
         }
 
         return outputState;
@@ -652,7 +653,7 @@ public class LayoutManager : IManager
     /// Second pass: process all non-Shift button actions and write to outputState.
     /// </summary>
     private void ProcessButtonActions(ControllerState state, ShiftSlot shiftSlot, float deltaMs,
-        ref TouchpadSample? selectedTouchpadSample)
+        ref TouchpadSample?[] touchpadSamples)
     {
         for (int b = 0; b < _plannedButtons.Length; b++)
         {
@@ -677,7 +678,7 @@ public class LayoutManager : IManager
                         {
                             var tA = (TouchpadActions)action;
                             tA.Execute(button, pressed, shiftSlot, deltaMs);
-                            ApplyTouchpadAction(tA, ref selectedTouchpadSample);
+                            ApplyTouchpadAction(tA, ref touchpadSamples);
                             break;
                         }
                     case ActionType.Keyboard:
@@ -712,22 +713,34 @@ public class LayoutManager : IManager
         }
     }
 
-    private void ApplyTouchpadCoordinates(TouchpadSample? sample)
+    private void ApplyTouchpadCoordinates(TouchpadSample?[] samples)
     {
-        if (sample is null)
+        TouchpadSample? primarySample = null;
+        foreach (TouchpadSample? sample in samples)
+        {
+            if (sample is null)
+                continue;
+
+            TouchpadSample value = sample.Value;
+            DS4Touch.SetOutputTouch(value.Finger, value.X, value.Y);
+            if (primarySample is null || value.Priority > primarySample.Value.Priority)
+                primarySample = value;
+        }
+
+        if (primarySample is null)
             return;
 
         outputState.AxisState[AxisFlags.RightPadX] = DS4Touch.CoordinateToAxis(
-            sample.Value.X, DS4Touch.TOUCHPAD_WIDTH);
+            primarySample.Value.X, DS4Touch.TOUCHPAD_WIDTH);
         outputState.AxisState[AxisFlags.RightPadY] = DS4Touch.CoordinateToAxis(
-            DS4Touch.TOUCHPAD_HEIGHT - 1 - sample.Value.Y, DS4Touch.TOUCHPAD_HEIGHT);
+            DS4Touch.TOUCHPAD_HEIGHT - 1 - primarySample.Value.Y, DS4Touch.TOUCHPAD_HEIGHT);
     }
 
     /// <summary>
     /// Third pass: process axis (stick / pad / trigger) actions and write to outputState.
     /// </summary>
     private void ProcessAxisActions(ControllerState state, ShiftSlot shiftSlot, float deltaMs,
-        ref TouchpadSample? selectedTouchpadSample)
+        ref TouchpadSample?[] touchpadSamples)
     {
         for (int a = 0; a < _plannedAxes.Length; a++)
         {
@@ -763,7 +776,7 @@ public class LayoutManager : IManager
                         {
                             var tA = (TouchpadActions)action;
                             tA.Execute(layout, touched, shiftSlot, deltaMs);
-                            ApplyTouchpadAction(tA, ref selectedTouchpadSample);
+                            ApplyTouchpadAction(tA, ref touchpadSamples);
                             break;
                         }
                     case ActionType.Keyboard:
@@ -797,7 +810,7 @@ public class LayoutManager : IManager
         }
     }
 
-    private void ApplyTouchpadAction(TouchpadActions action, ref TouchpadSample? selectedTouchpadSample)
+    private void ApplyTouchpadAction(TouchpadActions action, ref TouchpadSample?[] touchpadSamples)
     {
         if (action.TargetType == TouchpadTargetType.Axis)
         {
@@ -816,8 +829,9 @@ public class LayoutManager : IManager
             if (action.TryGetTouch(out TouchpadSample sample))
             {
                 outputState.ButtonState[action.Button] |= true;
-                if (selectedTouchpadSample is null || sample.Priority > selectedTouchpadSample.Value.Priority)
-                    selectedTouchpadSample = sample;
+                int fingerIndex = sample.Finger - 1;
+                if (touchpadSamples[fingerIndex] is null || sample.Priority > touchpadSamples[fingerIndex]!.Value.Priority)
+                    touchpadSamples[fingerIndex] = sample;
             }
             return;
         }

--- a/HandheldCompanion/Managers/ProfileManager.cs
+++ b/HandheldCompanion/Managers/ProfileManager.cs
@@ -659,7 +659,11 @@ public class ProfileManager : IManager
     {
         foreach (Profile profile in GetProfiles())
         {
-            if (profile.Collections.Remove(collectionId))
+            bool removed;
+            lock (profile.SyncRoot)
+                removed = profile.Collections.Remove(collectionId);
+
+            if (removed)
                 SerializeProfile(profile);
         }
     }
@@ -979,10 +983,18 @@ public class ProfileManager : IManager
         string profilePath = Path.Combine(ManagerPath, profile.GetFileName());
         pendingCreation.TryAdd(profilePath, 0);
 
-        // update profile version to current build
-        profile.Version = App.CurrentVersion;
+        Profile snapshot;
+        lock (profile.SyncRoot)
+        {
+            lock (profile.Layout.SyncRoot)
+            {
+                // update profile version to current build
+                profile.Version = App.CurrentVersion;
+                snapshot = (Profile)profile.Clone();
+            }
+        }
 
-        string jsonString = JsonConvert.SerializeObject(profile, Formatting.Indented, new JsonSerializerSettings
+        string jsonString = JsonConvert.SerializeObject(snapshot, Formatting.Indented, new JsonSerializerSettings
         {
             TypeNameHandling = TypeNameHandling.All
         });
@@ -1070,7 +1082,8 @@ public class ProfileManager : IManager
         if (ManagerFactory.collectionManager.Status == ManagerStatus.Initialized)
         {
             HashSet<Guid> knownIds = ManagerFactory.collectionManager.GetCollections().Select(c => c.Id).ToHashSet();
-            profileToSanitize.Collections.RemoveWhere(id => id != GameCollection.FavoritesId && !knownIds.Contains(id));
+            lock (profileToSanitize.SyncRoot)
+                profileToSanitize.Collections.RemoveWhere(id => id != GameCollection.FavoritesId && !knownIds.Contains(id));
         }
     }
 

--- a/HandheldCompanion/Misc/DS4Touch.cs
+++ b/HandheldCompanion/Misc/DS4Touch.cs
@@ -34,7 +34,6 @@ public static class DS4Touch
     public static TrackPadTouch OutputLeftPadTouch = new(TOUCH0_ID, true);
     public static TrackPadTouch OutputRightPadTouch = new(TOUCH1_ID, true);
     public static byte TouchPacketCounter;
-    public static byte OutputFinger;
 
     private static short TouchX, TouchY;
     public static bool OutputClickButton;

--- a/HandheldCompanion/Misc/DS4Touch.cs
+++ b/HandheldCompanion/Misc/DS4Touch.cs
@@ -168,6 +168,19 @@ public static class DS4Touch
         }
     }
 
+    public static short CoordinateToAxis(int value, int extent)
+    {
+        int clamped = Math.Clamp(value, 0, extent - 1);
+        long numerator = (long)clamped * ushort.MaxValue + (extent - 1) / 2;
+        return (short)Math.Clamp(numerator / (extent - 1) + short.MinValue, short.MinValue, short.MaxValue);
+    }
+
+    public static int AxisToCoordinate(short value, int extent)
+    {
+        long numerator = ((long)value - short.MinValue) * (extent - 1) + ushort.MaxValue / 2;
+        return (int)Math.Clamp(numerator / ushort.MaxValue, 0, extent - 1);
+    }
+
     public class TrackPadTouch
     {
         public byte Id;

--- a/HandheldCompanion/Misc/DS4Touch.cs
+++ b/HandheldCompanion/Misc/DS4Touch.cs
@@ -31,10 +31,27 @@ public static class DS4Touch
 
     public static TrackPadTouch LeftPadTouch = new(TOUCH0_ID, true);
     public static TrackPadTouch RightPadTouch = new(TOUCH1_ID, true);
+    public static TrackPadTouch OutputLeftPadTouch = new(TOUCH0_ID, true);
+    public static TrackPadTouch OutputRightPadTouch = new(TOUCH1_ID, true);
     public static byte TouchPacketCounter;
+    public static byte OutputFinger;
 
     private static short TouchX, TouchY;
     public static bool OutputClickButton;
+
+    public static void ClearOutputTouches()
+    {
+        OutputLeftPadTouch.IsActive = false;
+        OutputRightPadTouch.IsActive = false;
+    }
+
+    public static void SetOutputTouch(byte finger, int x, int y)
+    {
+        TrackPadTouch touch = finger == 1 ? OutputLeftPadTouch : OutputRightPadTouch;
+        touch.X = (short)Math.Clamp(x, short.MinValue, short.MaxValue);
+        touch.Y = (short)Math.Clamp(y, short.MinValue, short.MaxValue);
+        touch.IsActive = true;
+    }
 
     private static bool prevLeftPadTouch, prevRightPadTouch;
     private static bool prevLeftPadClick, prevRightPadClick;

--- a/HandheldCompanion/Misc/Layout.cs
+++ b/HandheldCompanion/Misc/Layout.cs
@@ -62,9 +62,15 @@ public partial class Layout : ICloneable, IDisposable
             if (ButtonState.UIButtons.Contains(button) || ButtonState.OEMButtons.Contains(button))
                 continue;
 
-            ButtonLayout[button] = TouchpadActions.IsTouchpadButton(button)
-                ? [new TouchpadActions(button)]
-                : [new ButtonActions { Button = button }];
+            ButtonLayout[button] = button switch
+            {
+                // ButtonFlags.LeftPadTouch => [new TouchpadActions(ButtonFlags.TouchpadTouch) { Finger = 1 }],
+                // ButtonFlags.RightPadTouch => [new TouchpadActions(ButtonFlags.TouchpadTouch) { Finger = 2 }],
+                ButtonFlags.LeftPadClick => [new TouchpadActions(ButtonFlags.TouchpadClick) { Finger = 1 }],
+                ButtonFlags.RightPadClick => [new TouchpadActions(ButtonFlags.TouchpadClick) { Finger = 2 }],
+                _ when TouchpadActions.IsTouchpadButton(button) => [new TouchpadActions(button)],
+                _ => [new ButtonActions { Button = button }],
+            };
         }
 
         // Generic axis mappings
@@ -74,7 +80,7 @@ public partial class Layout : ICloneable, IDisposable
             {
                 default:
                     AxisLayout[axis] = TouchpadActions.IsTouchpadAxis(axis)
-                        ? [new TouchpadActions(axis)]
+                        ? [new TouchpadActions(axis) { HapticMode = HapticMode.Down, HapticStrength = HapticStrength.Low }]
                         : [new AxisActions { Axis = axis }];
                     break;
                 case AxisLayoutFlags.Gyroscope:

--- a/HandheldCompanion/Misc/Layout.cs
+++ b/HandheldCompanion/Misc/Layout.cs
@@ -5,18 +5,12 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.Serialization;
 
 namespace HandheldCompanion;
 
 [Serializable]
 public partial class Layout : ICloneable, IDisposable
 {
-    private const int CurrentSchemaVersion = 1;
-
-    [JsonProperty]
-    public int SchemaVersion { get; private set; } = CurrentSchemaVersion;
-
     public SortedDictionary<ButtonFlags, List<IActions>> ButtonLayout { get; set; } = [];
     public SortedDictionary<AxisLayoutFlags, List<IActions>> AxisLayout { get; set; } = [];
     public SortedDictionary<AxisLayoutFlags, IActions> GyroLayout { get; set; } = [];
@@ -27,39 +21,6 @@ public partial class Layout : ICloneable, IDisposable
 
     public Layout()
     {
-    }
-
-    [OnDeserializing]
-    private void OnDeserializing(StreamingContext _)
-    {
-        // A saved layout without this property predates schema versioning.
-        SchemaVersion = 0;
-    }
-
-    [OnDeserialized]
-    private void OnDeserialized(StreamingContext _)
-    {
-        if (SchemaVersion < CurrentSchemaVersion)
-            EnableTrackpadHaptics();
-
-        SchemaVersion = CurrentSchemaVersion;
-    }
-
-    private void EnableTrackpadHaptics()
-    {
-        foreach (AxisLayoutFlags axis in new[] { AxisLayoutFlags.LeftPad, AxisLayoutFlags.RightPad })
-        {
-            if (!AxisLayout.TryGetValue(axis, out List<IActions>? actions))
-                continue;
-
-            foreach (MouseActions action in actions.OfType<MouseActions>())
-            {
-                if (action.MouseType is MouseActionsType.Move or MouseActionsType.Scroll &&
-                    action.HapticMode == HapticMode.Off)
-                    action.HapticMode = HapticMode.Down;
-            }
-        }
-
     }
 
     ~Layout()

--- a/HandheldCompanion/Misc/Layout.cs
+++ b/HandheldCompanion/Misc/Layout.cs
@@ -5,12 +5,18 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
 
 namespace HandheldCompanion;
 
 [Serializable]
 public partial class Layout : ICloneable, IDisposable
 {
+    private const int CurrentSchemaVersion = 1;
+
+    [JsonProperty]
+    public int SchemaVersion { get; private set; } = CurrentSchemaVersion;
+
     public SortedDictionary<ButtonFlags, List<IActions>> ButtonLayout { get; set; } = [];
     public SortedDictionary<AxisLayoutFlags, List<IActions>> AxisLayout { get; set; } = [];
     public SortedDictionary<AxisLayoutFlags, IActions> GyroLayout { get; set; } = [];
@@ -21,6 +27,39 @@ public partial class Layout : ICloneable, IDisposable
 
     public Layout()
     {
+    }
+
+    [OnDeserializing]
+    private void OnDeserializing(StreamingContext _)
+    {
+        // A saved layout without this property predates schema versioning.
+        SchemaVersion = 0;
+    }
+
+    [OnDeserialized]
+    private void OnDeserialized(StreamingContext _)
+    {
+        if (SchemaVersion < CurrentSchemaVersion)
+            EnableTrackpadHaptics();
+
+        SchemaVersion = CurrentSchemaVersion;
+    }
+
+    private void EnableTrackpadHaptics()
+    {
+        foreach (AxisLayoutFlags axis in new[] { AxisLayoutFlags.LeftPad, AxisLayoutFlags.RightPad })
+        {
+            if (!AxisLayout.TryGetValue(axis, out List<IActions>? actions))
+                continue;
+
+            foreach (MouseActions action in actions.OfType<MouseActions>())
+            {
+                if (action.MouseType is MouseActionsType.Move or MouseActionsType.Scroll &&
+                    action.HapticMode == HapticMode.Off)
+                    action.HapticMode = HapticMode.Down;
+            }
+        }
+
     }
 
     ~Layout()

--- a/HandheldCompanion/Misc/Layout.cs
+++ b/HandheldCompanion/Misc/Layout.cs
@@ -64,8 +64,8 @@ public partial class Layout : ICloneable, IDisposable
 
             ButtonLayout[button] = button switch
             {
-                // ButtonFlags.LeftPadTouch => [new TouchpadActions(ButtonFlags.TouchpadTouch) { Finger = 1 }],
-                // ButtonFlags.RightPadTouch => [new TouchpadActions(ButtonFlags.TouchpadTouch) { Finger = 2 }],
+                ButtonFlags.LeftPadTouch => [new TouchpadActions(ButtonFlags.TouchpadTouch) { Finger = 1 }],
+                ButtonFlags.RightPadTouch => [new TouchpadActions(ButtonFlags.TouchpadTouch) { Finger = 2 }],
                 ButtonFlags.LeftPadClick => [new TouchpadActions(ButtonFlags.TouchpadClick) { Finger = 1 }],
                 ButtonFlags.RightPadClick => [new TouchpadActions(ButtonFlags.TouchpadClick) { Finger = 2 }],
                 _ when TouchpadActions.IsTouchpadButton(button) => [new TouchpadActions(button)],

--- a/HandheldCompanion/Misc/Layout.cs
+++ b/HandheldCompanion/Misc/Layout.cs
@@ -62,7 +62,9 @@ public partial class Layout : ICloneable, IDisposable
             if (ButtonState.UIButtons.Contains(button) || ButtonState.OEMButtons.Contains(button))
                 continue;
 
-            ButtonLayout[button] = new List<IActions> { new ButtonActions { Button = button } };
+            ButtonLayout[button] = TouchpadActions.IsTouchpadButton(button)
+                ? [new TouchpadActions(button)]
+                : [new ButtonActions { Button = button }];
         }
 
         // Generic axis mappings
@@ -71,7 +73,9 @@ public partial class Layout : ICloneable, IDisposable
             switch (axis)
             {
                 default:
-                    AxisLayout[axis] = new List<IActions> { new AxisActions { Axis = axis } };
+                    AxisLayout[axis] = TouchpadActions.IsTouchpadAxis(axis)
+                        ? [new TouchpadActions(axis)]
+                        : [new AxisActions { Axis = axis }];
                     break;
                 case AxisLayoutFlags.Gyroscope:
                     break;

--- a/HandheldCompanion/Misc/LayoutTemplate.cs
+++ b/HandheldCompanion/Misc/LayoutTemplate.cs
@@ -46,38 +46,54 @@ namespace HandheldCompanion.Misc
 
             template.Layout.ButtonLayout[ButtonFlags.DPadUp] =
             [
-                CreateTouchpadAction(AxisLayoutFlags.LeftPad, y: 28672),
-                new TouchpadActions(ButtonFlags.LeftPadTouch),
-                new TouchpadActions(ButtonFlags.LeftPadClick)
+                new TouchpadActions(ButtonFlags.TouchpadClick)
+                {
+                    Finger = 1,
+                    Y = -28672,
+                }
             ];
 
             template.Layout.ButtonLayout[ButtonFlags.DPadDown] =
             [
-                new TouchpadActions(ButtonFlags.LeftPadClick),
-                CreateTouchpadAction(AxisLayoutFlags.LeftPad, y: -28672),
-                new TouchpadActions(ButtonFlags.LeftPadTouch)
+                new TouchpadActions(ButtonFlags.TouchpadClick)
+                {
+                    Finger = 1,
+                    Y = 28672,
+                }
             ];
 
             template.Layout.ButtonLayout[ButtonFlags.DPadLeft] =
             [
-                new TouchpadActions(ButtonFlags.LeftPadClick),
-                new TouchpadActions(ButtonFlags.LeftPadTouch),
-                CreateTouchpadAction(AxisLayoutFlags.LeftPad, x: -28672)
+                new TouchpadActions(ButtonFlags.TouchpadClick)
+                {
+                    Finger = 1,
+                    X = -28672,
+                }
             ];
 
             template.Layout.ButtonLayout[ButtonFlags.DPadRight] =
             [
-                new TouchpadActions(ButtonFlags.LeftPadTouch),
-                new TouchpadActions(ButtonFlags.LeftPadClick),
-                CreateTouchpadAction(AxisLayoutFlags.LeftPad, x: 28672)
+                new TouchpadActions(ButtonFlags.TouchpadClick)
+                {
+                    Finger = 1,
+                    X = 28672,
+                }
             ];
 
-            template.Layout.ButtonLayout[ButtonFlags.RightStickClick] = [new TouchpadActions(ButtonFlags.RightPadClick)];
+            template.Layout.ButtonLayout[ButtonFlags.RightStickClick] =
+            [
+                new TouchpadActions(ButtonFlags.TouchpadClick)
+                {
+                    Finger = 2
+                }
+            ];
 
             template.Layout.AxisLayout[AxisLayoutFlags.RightStick] =
             [
-                new TouchpadActions(AxisLayoutFlags.RightPad),
-                CreateTouchpadAction(ButtonFlags.RightPadTouch, Utils.DeflectionDirection.Any, 1000)
+                new TouchpadActions(AxisLayoutFlags.RightPad)
+                {
+                    AxisDeadZoneInner = 5
+                }
             ];
 
             return template;

--- a/HandheldCompanion/Misc/LayoutTemplate.cs
+++ b/HandheldCompanion/Misc/LayoutTemplate.cs
@@ -46,38 +46,38 @@ namespace HandheldCompanion.Misc
 
             template.Layout.ButtonLayout[ButtonFlags.DPadUp] =
             [
-                CreateAxisAction(AxisLayoutFlags.LeftPad, y: 28672),
-                CreateButtonAction(ButtonFlags.LeftPadTouch),
-                CreateButtonAction(ButtonFlags.LeftPadClick)
+                CreateTouchpadAction(AxisLayoutFlags.LeftPad, y: 28672),
+                new TouchpadActions(ButtonFlags.LeftPadTouch),
+                new TouchpadActions(ButtonFlags.LeftPadClick)
             ];
 
             template.Layout.ButtonLayout[ButtonFlags.DPadDown] =
             [
-                CreateButtonAction(ButtonFlags.LeftPadClick),
-                CreateAxisAction(AxisLayoutFlags.LeftPad, y: -28672),
-                CreateButtonAction(ButtonFlags.LeftPadTouch)
+                new TouchpadActions(ButtonFlags.LeftPadClick),
+                CreateTouchpadAction(AxisLayoutFlags.LeftPad, y: -28672),
+                new TouchpadActions(ButtonFlags.LeftPadTouch)
             ];
 
             template.Layout.ButtonLayout[ButtonFlags.DPadLeft] =
             [
-                CreateButtonAction(ButtonFlags.LeftPadClick),
-                CreateButtonAction(ButtonFlags.LeftPadTouch),
-                CreateAxisAction(AxisLayoutFlags.LeftPad, x: -28672)
+                new TouchpadActions(ButtonFlags.LeftPadClick),
+                new TouchpadActions(ButtonFlags.LeftPadTouch),
+                CreateTouchpadAction(AxisLayoutFlags.LeftPad, x: -28672)
             ];
 
             template.Layout.ButtonLayout[ButtonFlags.DPadRight] =
             [
-                CreateButtonAction(ButtonFlags.LeftPadTouch),
-                CreateButtonAction(ButtonFlags.LeftPadClick),
-                CreateAxisAction(AxisLayoutFlags.LeftPad, x: 28672)
+                new TouchpadActions(ButtonFlags.LeftPadTouch),
+                new TouchpadActions(ButtonFlags.LeftPadClick),
+                CreateTouchpadAction(AxisLayoutFlags.LeftPad, x: 28672)
             ];
 
-            template.Layout.ButtonLayout[ButtonFlags.RightStickClick] = [CreateButtonAction(ButtonFlags.RightPadClick)];
+            template.Layout.ButtonLayout[ButtonFlags.RightStickClick] = [new TouchpadActions(ButtonFlags.RightPadClick)];
 
             template.Layout.AxisLayout[AxisLayoutFlags.RightStick] =
             [
-                CreateAxisAction(AxisLayoutFlags.RightPad),
-                CreateButtonAction(ButtonFlags.RightPadTouch, Utils.DeflectionDirection.Any, 1000)
+                new TouchpadActions(AxisLayoutFlags.RightPad),
+                CreateTouchpadAction(ButtonFlags.RightPadTouch, Utils.DeflectionDirection.Any, 1000)
             ];
 
             return template;
@@ -123,6 +123,24 @@ namespace HandheldCompanion.Misc
                 Axis = axis,
                 ButtonX = x,
                 ButtonY = y,
+            };
+        }
+
+        private static TouchpadActions CreateTouchpadAction(AxisLayoutFlags axis, short x = 0, short y = 0)
+        {
+            return new TouchpadActions(axis)
+            {
+                ButtonX = x,
+                ButtonY = y,
+            };
+        }
+
+        private static TouchpadActions CreateTouchpadAction(ButtonFlags button, Utils.DeflectionDirection motionDirection, float motionThreshold)
+        {
+            return new TouchpadActions(button)
+            {
+                motionDirection = motionDirection,
+                motionThreshold = motionThreshold,
             };
         }
 

--- a/HandheldCompanion/Misc/LayoutTemplate.cs
+++ b/HandheldCompanion/Misc/LayoutTemplate.cs
@@ -92,7 +92,7 @@ namespace HandheldCompanion.Misc
             [
                 new TouchpadActions(AxisLayoutFlags.RightPad)
                 {
-                    AxisDeadZoneInner = 5
+                    AxisDeadZoneInner   = 5
                 }
             ];
 

--- a/HandheldCompanion/Misc/LayoutTemplate.cs
+++ b/HandheldCompanion/Misc/LayoutTemplate.cs
@@ -49,6 +49,7 @@ namespace HandheldCompanion.Misc
                 new TouchpadActions(ButtonFlags.TouchpadClick)
                 {
                     Finger = 1,
+                    UseCoordinates = true,
                     Y = -28672,
                 }
             ];
@@ -58,6 +59,7 @@ namespace HandheldCompanion.Misc
                 new TouchpadActions(ButtonFlags.TouchpadClick)
                 {
                     Finger = 1,
+                    UseCoordinates = true,
                     Y = 28672,
                 }
             ];
@@ -67,6 +69,7 @@ namespace HandheldCompanion.Misc
                 new TouchpadActions(ButtonFlags.TouchpadClick)
                 {
                     Finger = 1,
+                    UseCoordinates = true,
                     X = -28672,
                 }
             ];
@@ -76,6 +79,7 @@ namespace HandheldCompanion.Misc
                 new TouchpadActions(ButtonFlags.TouchpadClick)
                 {
                     Finger = 1,
+                    UseCoordinates = true,
                     X = 28672,
                 }
             ];

--- a/HandheldCompanion/Misc/LayoutTemplate.cs
+++ b/HandheldCompanion/Misc/LayoutTemplate.cs
@@ -104,7 +104,7 @@ namespace HandheldCompanion.Misc
             };
         }
 
-        private static MouseActions CreateMouseAction(MouseActionsType mouseType, ModifierSet modifiers = ModifierSet.None, Utils.DeflectionDirection motionDirection = Utils.DeflectionDirection.None, float motionThreshold = 4000)
+        private static MouseActions CreateMouseAction(MouseActionsType mouseType, ModifierSet modifiers = ModifierSet.None, Utils.DeflectionDirection motionDirection = Utils.DeflectionDirection.None, float motionThreshold = 4000, HapticMode hapticMode = HapticMode.Off)
         {
             return new MouseActions
             {
@@ -112,6 +112,7 @@ namespace HandheldCompanion.Misc
                 Modifiers = modifiers,
                 motionDirection = motionDirection,
                 motionThreshold = motionThreshold,
+                HapticMode = hapticMode,
             };
         }
 
@@ -154,8 +155,8 @@ namespace HandheldCompanion.Misc
                         {
                             { AxisLayoutFlags.LeftStick, new List<IActions>() { CreateMouseAction(MouseActionsType.Scroll) } },
                             { AxisLayoutFlags.RightStick, new List<IActions>() { CreateMouseAction(MouseActionsType.Move) } },
-                            { AxisLayoutFlags.LeftPad, new List<IActions>() { CreateMouseAction(MouseActionsType.Scroll) } },
-                            { AxisLayoutFlags.RightPad, new List<IActions>() { CreateMouseAction(MouseActionsType.Move) } },
+                            { AxisLayoutFlags.LeftPad, new List<IActions>() { CreateMouseAction(MouseActionsType.Scroll, hapticMode: HapticMode.Down) } },
+                            { AxisLayoutFlags.RightPad, new List<IActions>() { CreateMouseAction(MouseActionsType.Move, hapticMode: HapticMode.Down) } },
                             {
                                 AxisLayoutFlags.L2, new List<IActions>()
                                 {
@@ -208,7 +209,7 @@ namespace HandheldCompanion.Misc
                         Layout.AxisLayout = new()
                         {
                             { AxisLayoutFlags.RightStick, new List<IActions>() { CreateMouseAction(MouseActionsType.Move) } },
-                            { AxisLayoutFlags.RightPad, new List<IActions>() { CreateMouseAction(MouseActionsType.Move) } },
+                            { AxisLayoutFlags.RightPad, new List<IActions>() { CreateMouseAction(MouseActionsType.Move, hapticMode: HapticMode.Down) } },
                             {
                                 AxisLayoutFlags.LeftStick, new List<IActions>()
                                 {
@@ -265,7 +266,7 @@ namespace HandheldCompanion.Misc
 
                 case "GamepadMouse":
                     {
-                        Layout.AxisLayout[AxisLayoutFlags.RightPad] = new List<IActions>() { CreateMouseAction(MouseActionsType.Move) };
+                        Layout.AxisLayout[AxisLayoutFlags.RightPad] = new List<IActions>() { CreateMouseAction(MouseActionsType.Move, hapticMode: HapticMode.Down) };
                     }
                     break;
 

--- a/HandheldCompanion/Misc/Profile.cs
+++ b/HandheldCompanion/Misc/Profile.cs
@@ -76,6 +76,8 @@ public class ProcessWindowSettings
 [Serializable]
 public partial class Profile : ICloneable, IComparable, INotifyPropertyChanged
 {
+    internal object SyncRoot { get; } = new();
+
     [JsonIgnore]
     public const int SensivityArraySize = 49; // x + 1 (hidden)
 
@@ -168,16 +170,23 @@ public partial class Profile : ICloneable, IComparable, INotifyPropertyChanged
     // automatically migrate on deserialization — the setter adds FavoritesId.
     public bool IsLiked
     {
-        get => Collections.Contains(GameCollection.FavoritesId);
+        get
+        {
+            lock (SyncRoot)
+                return Collections.Contains(GameCollection.FavoritesId);
+        }
         set
         {
-            if (Collections.Contains(GameCollection.FavoritesId) == value)
-                return;
-            if (value)
-                Collections.Add(GameCollection.FavoritesId);
-            else
-                Collections.Remove(GameCollection.FavoritesId);
-            OnPropertyChanged();
+            lock (SyncRoot)
+            {
+                if (Collections.Contains(GameCollection.FavoritesId) == value)
+                    return;
+                if (value)
+                    Collections.Add(GameCollection.FavoritesId);
+                else
+                    Collections.Remove(GameCollection.FavoritesId);
+                OnPropertyChanged();
+            }
         }
     }
 

--- a/HandheldCompanion/Properties/Resources.Designer.cs
+++ b/HandheldCompanion/Properties/Resources.Designer.cs
@@ -916,60 +916,6 @@ namespace HandheldCompanion.Properties {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Trackpad click haptics.
-        /// </summary>
-        public static string ControllerPage_TrackpadClickHaptics {
-            get {
-                return ResourceManager.GetString("ControllerPage_TrackpadClickHaptics", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Controls press and release feedback for trackpad clicks.
-        /// </summary>
-        public static string ControllerPage_TrackpadClickHapticsDesc {
-            get {
-                return ResourceManager.GetString("ControllerPage_TrackpadClickHapticsDesc", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to High.
-        /// </summary>
-        public static string ControllerPage_TrackpadClickHapticsHigh {
-            get {
-                return ResourceManager.GetString("ControllerPage_TrackpadClickHapticsHigh", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Low.
-        /// </summary>
-        public static string ControllerPage_TrackpadClickHapticsLow {
-            get {
-                return ResourceManager.GetString("ControllerPage_TrackpadClickHapticsLow", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Medium.
-        /// </summary>
-        public static string ControllerPage_TrackpadClickHapticsMedium {
-            get {
-                return ResourceManager.GetString("ControllerPage_TrackpadClickHapticsMedium", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Off.
-        /// </summary>
-        public static string ControllerPage_TrackpadClickHapticsOff {
-            get {
-                return ResourceManager.GetString("ControllerPage_TrackpadClickHapticsOff", resourceCulture);
-            }
-        }
-
-        /// <summary>
         ///   Looks up a localized string similar to Trackpad click haptics overridden.
         /// </summary>
         public static string ControllerPage_TrackpadClickHapticsOverride {
@@ -979,7 +925,7 @@ namespace HandheldCompanion.Properties {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to The active layout has custom trackpad click haptic settings. Those settings take precedence over the global Controller page setting.
+        ///   Looks up a localized string similar to The active layout has custom trackpad click haptic settings.
         /// </summary>
         public static string ControllerPage_TrackpadClickHapticsOverrideDesc {
             get {

--- a/HandheldCompanion/Properties/Resources.Designer.cs
+++ b/HandheldCompanion/Properties/Resources.Designer.cs
@@ -914,7 +914,88 @@ namespace HandheldCompanion.Properties {
                 return ResourceManager.GetString("ControllerPage_TestControllerInputs", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Trackpad click haptics.
+        /// </summary>
+        public static string ControllerPage_TrackpadClickHaptics {
+            get {
+                return ResourceManager.GetString("ControllerPage_TrackpadClickHaptics", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Controls press and release feedback for trackpad clicks.
+        /// </summary>
+        public static string ControllerPage_TrackpadClickHapticsDesc {
+            get {
+                return ResourceManager.GetString("ControllerPage_TrackpadClickHapticsDesc", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to High.
+        /// </summary>
+        public static string ControllerPage_TrackpadClickHapticsHigh {
+            get {
+                return ResourceManager.GetString("ControllerPage_TrackpadClickHapticsHigh", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Low.
+        /// </summary>
+        public static string ControllerPage_TrackpadClickHapticsLow {
+            get {
+                return ResourceManager.GetString("ControllerPage_TrackpadClickHapticsLow", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Medium.
+        /// </summary>
+        public static string ControllerPage_TrackpadClickHapticsMedium {
+            get {
+                return ResourceManager.GetString("ControllerPage_TrackpadClickHapticsMedium", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Off.
+        /// </summary>
+        public static string ControllerPage_TrackpadClickHapticsOff {
+            get {
+                return ResourceManager.GetString("ControllerPage_TrackpadClickHapticsOff", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Trackpad click haptics overridden.
+        /// </summary>
+        public static string ControllerPage_TrackpadClickHapticsOverride {
+            get {
+                return ResourceManager.GetString("ControllerPage_TrackpadClickHapticsOverride", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The active layout has custom trackpad click haptic settings. Those settings take precedence over the global Controller page setting.
+        /// </summary>
+        public static string ControllerPage_TrackpadClickHapticsOverrideDesc {
+            get {
+                return ResourceManager.GetString("ControllerPage_TrackpadClickHapticsOverrideDesc", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Trackpad settings.
+        /// </summary>
+        public static string ControllerPage_TrackpadSettings {
+            get {
+                return ResourceManager.GetString("ControllerPage_TrackpadSettings", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Troobleshooting bluetooth controllers connection issues.
         /// </summary>
@@ -3299,6 +3380,15 @@ namespace HandheldCompanion.Properties {
                 return ResourceManager.GetString("Enum_MotionOutput_LeftStick", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Left Pad.
+        /// </summary>
+        public static string Enum_MotionOutput_LeftPad {
+            get {
+                return ResourceManager.GetString("Enum_MotionOutput_LeftPad", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Move Cursor.
@@ -3315,6 +3405,15 @@ namespace HandheldCompanion.Properties {
         public static string Enum_MotionOutput_RightStick {
             get {
                 return ResourceManager.GetString("Enum_MotionOutput_RightStick", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Right Pad.
+        /// </summary>
+        public static string Enum_MotionOutput_RightPad {
+            get {
+                return ResourceManager.GetString("Enum_MotionOutput_RightPad", resourceCulture);
             }
         }
         
@@ -6198,7 +6297,61 @@ namespace HandheldCompanion.Properties {
                 return ResourceManager.GetString("LayoutPage_ActionType_Trigger", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Touchpad.
+        /// </summary>
+        public static string LayoutPage_ActionType_Touchpad {
+            get {
+                return ResourceManager.GetString("LayoutPage_ActionType_Touchpad", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Touchpad coordinates: X 0-{0}, Y 0-{1}.
+        /// </summary>
+        public static string LayoutPage_TouchpadCoordinateRange {
+            get {
+                return ResourceManager.GetString("LayoutPage_TouchpadCoordinateRange", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to End position.
+        /// </summary>
+        public static string LayoutPage_TouchpadEndPosition {
+            get {
+                return ResourceManager.GetString("LayoutPage_TouchpadEndPosition", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Touchpad.
+        /// </summary>
+        public static string LayoutPage_TouchpadSettings {
+            get {
+                return ResourceManager.GetString("LayoutPage_TouchpadSettings", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Start position.
+        /// </summary>
+        public static string LayoutPage_TouchpadStartPosition {
+            get {
+                return ResourceManager.GetString("LayoutPage_TouchpadStartPosition", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Swipe duration.
+        /// </summary>
+        public static string LayoutPage_TouchpadSwipeDuration {
+            get {
+                return ResourceManager.GetString("LayoutPage_TouchpadSwipeDuration", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Apply template.
         /// </summary>
@@ -6306,7 +6459,16 @@ namespace HandheldCompanion.Properties {
                 return ResourceManager.GetString("LayoutPage_HapticFeedback", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Use global click haptics.
+        /// </summary>
+        public static string LayoutPage_UseGlobalTrackpadClickHaptics {
+            get {
+                return ResourceManager.GetString("LayoutPage_UseGlobalTrackpadClickHaptics", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Hold to repeat.
         /// </summary>

--- a/HandheldCompanion/Properties/Resources.Designer.cs
+++ b/HandheldCompanion/Properties/Resources.Designer.cs
@@ -2059,7 +2059,7 @@ namespace HandheldCompanion.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Left-finger swipe.
+        ///   Looks up a localized string similar to Left-finger touch.
         /// </summary>
         public static string Enum_DualShock4Controller_AxisLayoutFlags_LeftPad {
             get {
@@ -2068,7 +2068,7 @@ namespace HandheldCompanion.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Right-finger swipe.
+        ///   Looks up a localized string similar to Right-finger touch.
         /// </summary>
         public static string Enum_DualShock4Controller_AxisLayoutFlags_RightPad {
             get {

--- a/HandheldCompanion/Properties/Resources.Designer.cs
+++ b/HandheldCompanion/Properties/Resources.Designer.cs
@@ -6407,15 +6407,6 @@ namespace HandheldCompanion.Properties {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Use global click haptics.
-        /// </summary>
-        public static string LayoutPage_UseGlobalTrackpadClickHaptics {
-            get {
-                return ResourceManager.GetString("LayoutPage_UseGlobalTrackpadClickHaptics", resourceCulture);
-            }
-        }
-
-        /// <summary>
         ///   Looks up a localized string similar to Hold to repeat.
         /// </summary>
         public static string LayoutPage_HoldToRepeat {

--- a/HandheldCompanion/Properties/Resources.de-DE.resx
+++ b/HandheldCompanion/Properties/Resources.de-DE.resx
@@ -3055,10 +3055,10 @@ Wenn die Bewegungseingabe aktiviert ist, verwenden Sie die ausgewählte(n) Taste
     <value>Optionen</value>
   </data>
   <data name="Enum_DualShock4Controller_AxisLayoutFlags_LeftPad" xml:space="preserve">
-    <value>Left-finger swipe</value>
+    <value>Left-finger touch</value>
   </data>
   <data name="Enum_DualShock4Controller_AxisLayoutFlags_RightPad" xml:space="preserve">
-    <value>Right-finger swipe</value>
+    <value>Right-finger touch</value>
   </data>
   <data name="Enum_DualShock4Controller_ButtonFlags_LeftPadClick" xml:space="preserve">
     <value>Left-finger click</value>

--- a/HandheldCompanion/Properties/Resources.it-IT.resx
+++ b/HandheldCompanion/Properties/Resources.it-IT.resx
@@ -3047,10 +3047,10 @@
     <value>Opzioni</value>
   </data>
   <data name="Enum_DualShock4Controller_AxisLayoutFlags_LeftPad" xml:space="preserve">
-    <value>Left-finger swipe</value>
+    <value>Left-finger touch</value>
   </data>
   <data name="Enum_DualShock4Controller_AxisLayoutFlags_RightPad" xml:space="preserve">
-    <value>Right-finger swipe</value>
+    <value>Right-finger touch</value>
   </data>
   <data name="Enum_DualShock4Controller_ButtonFlags_LeftPadClick" xml:space="preserve">
     <value>Left-finger click</value>

--- a/HandheldCompanion/Properties/Resources.ja-JP.resx
+++ b/HandheldCompanion/Properties/Resources.ja-JP.resx
@@ -3087,10 +3087,10 @@
     <value>Options</value>
   </data>
   <data name="Enum_DualShock4Controller_AxisLayoutFlags_LeftPad" xml:space="preserve">
-    <value>Left-finger swipe</value>
+    <value>Left-finger touch</value>
   </data>
   <data name="Enum_DualShock4Controller_AxisLayoutFlags_RightPad" xml:space="preserve">
-    <value>Right-finger swipe</value>
+    <value>Right-finger touch</value>
   </data>
   <data name="Enum_DualShock4Controller_ButtonFlags_LeftPadClick" xml:space="preserve">
     <value>Left-finger click</value>

--- a/HandheldCompanion/Properties/Resources.resx
+++ b/HandheldCompanion/Properties/Resources.resx
@@ -3672,32 +3672,11 @@ Thank you for using HC and helping us make it better.</value>
   <data name="LayoutPage_TouchpadCoordinateRange" xml:space="preserve">
     <value>Touchpad coordinates: X 0-{0}, Y 0-{1}</value>
   </data>
-  <data name="ControllerPage_TrackpadSettings" xml:space="preserve">
-    <value>Trackpad settings</value>
-  </data>
-  <data name="ControllerPage_TrackpadClickHaptics" xml:space="preserve">
-    <value>Trackpad click haptics</value>
-  </data>
-  <data name="ControllerPage_TrackpadClickHapticsDesc" xml:space="preserve">
-    <value>Controls press and release feedback for trackpad clicks</value>
-  </data>
-  <data name="ControllerPage_TrackpadClickHapticsOff" xml:space="preserve">
-    <value>Off</value>
-  </data>
-  <data name="ControllerPage_TrackpadClickHapticsLow" xml:space="preserve">
-    <value>Low</value>
-  </data>
-  <data name="ControllerPage_TrackpadClickHapticsMedium" xml:space="preserve">
-    <value>Medium</value>
-  </data>
-  <data name="ControllerPage_TrackpadClickHapticsHigh" xml:space="preserve">
-    <value>High</value>
-  </data>
   <data name="ControllerPage_TrackpadClickHapticsOverride" xml:space="preserve">
     <value>Trackpad click haptics overridden</value>
   </data>
   <data name="ControllerPage_TrackpadClickHapticsOverrideDesc" xml:space="preserve">
-    <value>The active layout has custom trackpad click haptic settings. Those settings take precedence over the global Controller page setting.</value>
+     <value>The active layout has custom trackpad click haptic settings.</value>
   </data>
   <data name="LayoutPage_HoldToRepeat" xml:space="preserve">
     <value>Hold to repeat</value>

--- a/HandheldCompanion/Properties/Resources.resx
+++ b/HandheldCompanion/Properties/Resources.resx
@@ -1827,8 +1827,14 @@ Motion input toggle: press selected button(s) to switch motion state.</value>
   <data name="Enum_MotionOutput_LeftStick" xml:space="preserve">
     <value>Left Stick</value>
   </data>
+  <data name="Enum_MotionOutput_LeftPad" xml:space="preserve">
+    <value>Left Pad</value>
+  </data>
   <data name="Enum_MotionOutput_RightStick" xml:space="preserve">
     <value>Right Stick</value>
+  </data>
+  <data name="Enum_MotionOutput_RightPad" xml:space="preserve">
+    <value>Right Pad</value>
   </data>
   <data name="Enum_XInputController_AxisLayoutFlags_L2" xml:space="preserve">
     <value>L2</value>
@@ -3648,6 +3654,51 @@ Thank you for using HC and helping us make it better.</value>
   <data name="LayoutPage_ActionType_Inherit" xml:space="preserve">
     <value>Inherit</value>
   </data>
+  <data name="LayoutPage_ActionType_Touchpad" xml:space="preserve">
+    <value>Touchpad</value>
+  </data>
+  <data name="LayoutPage_TouchpadSettings" xml:space="preserve">
+    <value>Touchpad</value>
+  </data>
+  <data name="LayoutPage_TouchpadStartPosition" xml:space="preserve">
+    <value>Start position</value>
+  </data>
+  <data name="LayoutPage_TouchpadEndPosition" xml:space="preserve">
+    <value>End position</value>
+  </data>
+  <data name="LayoutPage_TouchpadSwipeDuration" xml:space="preserve">
+    <value>Swipe duration</value>
+  </data>
+  <data name="LayoutPage_TouchpadCoordinateRange" xml:space="preserve">
+    <value>Touchpad coordinates: X 0-{0}, Y 0-{1}</value>
+  </data>
+  <data name="ControllerPage_TrackpadSettings" xml:space="preserve">
+    <value>Trackpad settings</value>
+  </data>
+  <data name="ControllerPage_TrackpadClickHaptics" xml:space="preserve">
+    <value>Trackpad click haptics</value>
+  </data>
+  <data name="ControllerPage_TrackpadClickHapticsDesc" xml:space="preserve">
+    <value>Controls press and release feedback for trackpad clicks</value>
+  </data>
+  <data name="ControllerPage_TrackpadClickHapticsOff" xml:space="preserve">
+    <value>Off</value>
+  </data>
+  <data name="ControllerPage_TrackpadClickHapticsLow" xml:space="preserve">
+    <value>Low</value>
+  </data>
+  <data name="ControllerPage_TrackpadClickHapticsMedium" xml:space="preserve">
+    <value>Medium</value>
+  </data>
+  <data name="ControllerPage_TrackpadClickHapticsHigh" xml:space="preserve">
+    <value>High</value>
+  </data>
+  <data name="ControllerPage_TrackpadClickHapticsOverride" xml:space="preserve">
+    <value>Trackpad click haptics overridden</value>
+  </data>
+  <data name="ControllerPage_TrackpadClickHapticsOverrideDesc" xml:space="preserve">
+    <value>The active layout has custom trackpad click haptic settings. Those settings take precedence over the global Controller page setting.</value>
+  </data>
   <data name="LayoutPage_HoldToRepeat" xml:space="preserve">
     <value>Hold to repeat</value>
   </data>
@@ -3659,6 +3710,9 @@ Thank you for using HC and helping us make it better.</value>
   </data>
   <data name="LayoutPage_HapticFeedback" xml:space="preserve">
     <value>Haptic feedback</value>
+  </data>
+  <data name="LayoutPage_UseGlobalTrackpadClickHaptics" xml:space="preserve">
+    <value>Use global click haptics</value>
   </data>
   <data name="LayoutPage_InputShift" xml:space="preserve">
     <value>Input shift</value>

--- a/HandheldCompanion/Properties/Resources.resx
+++ b/HandheldCompanion/Properties/Resources.resx
@@ -3772,10 +3772,10 @@ Thank you for using HC and helping us make it better.</value>
     <value>Options</value>
   </data>
   <data name="Enum_DualShock4Controller_AxisLayoutFlags_LeftPad" xml:space="preserve">
-    <value>Left-finger swipe</value>
+    <value>Left-finger touch</value>
   </data>
   <data name="Enum_DualShock4Controller_AxisLayoutFlags_RightPad" xml:space="preserve">
-    <value>Right-finger swipe</value>
+    <value>Right-finger touch</value>
   </data>
   <data name="Enum_DualShock4Controller_ButtonFlags_LeftPadClick" xml:space="preserve">
     <value>Left-finger click</value>

--- a/HandheldCompanion/Properties/Resources.resx
+++ b/HandheldCompanion/Properties/Resources.resx
@@ -3690,9 +3690,6 @@ Thank you for using HC and helping us make it better.</value>
   <data name="LayoutPage_HapticFeedback" xml:space="preserve">
     <value>Haptic feedback</value>
   </data>
-  <data name="LayoutPage_UseGlobalTrackpadClickHaptics" xml:space="preserve">
-    <value>Use global click haptics</value>
-  </data>
   <data name="LayoutPage_InputShift" xml:space="preserve">
     <value>Input shift</value>
   </data>

--- a/HandheldCompanion/Properties/Resources.ru-RU.resx
+++ b/HandheldCompanion/Properties/Resources.ru-RU.resx
@@ -3039,10 +3039,10 @@
     <value>Options</value>
   </data>
   <data name="Enum_DualShock4Controller_AxisLayoutFlags_LeftPad" xml:space="preserve">
-    <value>Left-finger swipe</value>
+    <value>Left-finger touch</value>
   </data>
   <data name="Enum_DualShock4Controller_AxisLayoutFlags_RightPad" xml:space="preserve">
-    <value>Right-finger swipe</value>
+    <value>Right-finger touch</value>
   </data>
   <data name="Enum_DualShock4Controller_ButtonFlags_LeftPadClick" xml:space="preserve">
     <value>Left-finger click</value>

--- a/HandheldCompanion/Properties/Resources.zh-Hans.resx
+++ b/HandheldCompanion/Properties/Resources.zh-Hans.resx
@@ -3390,10 +3390,10 @@
     <value>Options</value>
   </data>
   <data name="Enum_DualShock4Controller_AxisLayoutFlags_LeftPad" xml:space="preserve">
-    <value>Left-finger swipe</value>
+    <value>Left-finger touch</value>
   </data>
   <data name="Enum_DualShock4Controller_AxisLayoutFlags_RightPad" xml:space="preserve">
-    <value>Right-finger swipe</value>
+    <value>Right-finger touch</value>
   </data>
   <data name="Enum_DualShock4Controller_ButtonFlags_LeftPadClick" xml:space="preserve">
     <value>Left-finger click</value>

--- a/HandheldCompanion/Properties/Settings.Designer.cs
+++ b/HandheldCompanion/Properties/Settings.Designer.cs
@@ -505,18 +505,6 @@ namespace HandheldCompanion.Properties
 
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("3")]
-        public int TrackpadClickHaptics {
-            get {
-                return ((int)(this["TrackpadClickHaptics"]));
-            }
-            set {
-                this["TrackpadClickHaptics"] = value;
-            }
-        }
-
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("True")]
         public bool HIDcloakonconnect {
             get {

--- a/HandheldCompanion/Properties/Settings.Designer.cs
+++ b/HandheldCompanion/Properties/Settings.Designer.cs
@@ -506,12 +506,12 @@ namespace HandheldCompanion.Properties
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("3")]
-        public int SteamTrackpadClickHaptics {
+        public int TrackpadClickHaptics {
             get {
-                return ((int)(this["SteamTrackpadClickHaptics"]));
+                return ((int)(this["TrackpadClickHaptics"]));
             }
             set {
-                this["SteamTrackpadClickHaptics"] = value;
+                this["TrackpadClickHaptics"] = value;
             }
         }
 

--- a/HandheldCompanion/Properties/Settings.Designer.cs
+++ b/HandheldCompanion/Properties/Settings.Designer.cs
@@ -502,7 +502,19 @@ namespace HandheldCompanion.Properties
                 this["SteamControllerMode"] = value;
             }
         }
-        
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("3")]
+        public int SteamTrackpadClickHaptics {
+            get {
+                return ((int)(this["SteamTrackpadClickHaptics"]));
+            }
+            set {
+                this["SteamTrackpadClickHaptics"] = value;
+            }
+        }
+
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("True")]

--- a/HandheldCompanion/Properties/Settings.settings
+++ b/HandheldCompanion/Properties/Settings.settings
@@ -122,9 +122,6 @@
     <Setting Name="SteamControllerMode" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">0</Value>
     </Setting>
-    <Setting Name="TrackpadClickHaptics" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">3</Value>
-    </Setting>
     <Setting Name="HIDcloakonconnect" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>

--- a/HandheldCompanion/Properties/Settings.settings
+++ b/HandheldCompanion/Properties/Settings.settings
@@ -122,6 +122,9 @@
     <Setting Name="SteamControllerMode" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">0</Value>
     </Setting>
+    <Setting Name="SteamTrackpadClickHaptics" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">3</Value>
+    </Setting>
     <Setting Name="HIDcloakonconnect" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>

--- a/HandheldCompanion/Properties/Settings.settings
+++ b/HandheldCompanion/Properties/Settings.settings
@@ -122,7 +122,7 @@
     <Setting Name="SteamControllerMode" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">0</Value>
     </Setting>
-    <Setting Name="SteamTrackpadClickHaptics" Type="System.Int32" Scope="User">
+    <Setting Name="TrackpadClickHaptics" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">3</Value>
     </Setting>
     <Setting Name="HIDcloakonconnect" Type="System.Boolean" Scope="User">

--- a/HandheldCompanion/Targets/DualSenseTarget.cs
+++ b/HandheldCompanion/Targets/DualSenseTarget.cs
@@ -42,18 +42,25 @@ namespace HandheldCompanion.Targets
             bool leftPadClick = inputs.ButtonState[ButtonFlags.LeftPadClick];
             bool rightPadClick = inputs.ButtonState[ButtonFlags.RightPadClick];
             bool touchpadClick = inputs.ButtonState[ButtonFlags.TouchpadClick];
-            bool touchpadTouch = inputs.ButtonState[ButtonFlags.TouchpadTouch];
 
             int coordinateX = DS4Touch.AxisToCoordinate(inputs.AxisState[AxisFlags.RightPadX], DS4Touch.TOUCHPAD_WIDTH);
-            int coordinateY = DS4Touch.TOUCHPAD_HEIGHT - 1 -
-                DS4Touch.AxisToCoordinate(inputs.AxisState[AxisFlags.RightPadY], DS4Touch.TOUCHPAD_HEIGHT);
+            var leftOutputTouch = DS4Touch.OutputLeftPadTouch.IsActive
+                ? DS4Touch.OutputLeftPadTouch
+                : DS4Touch.LeftPadTouch;
+            var rightOutputTouch = DS4Touch.OutputRightPadTouch.IsActive
+                ? DS4Touch.OutputRightPadTouch
+                : DS4Touch.RightPadTouch;
 
-            ClickRegion requestedRegion = touchpadClick ? coordinateX < DS4Touch.TOUCHPAD_WIDTH / 2
-                ? ClickRegion.Left : ClickRegion.Right :
+            ClickRegion requestedRegion = touchpadClick ?
+                DS4Touch.OutputLeftPadTouch.IsActive && !DS4Touch.OutputRightPadTouch.IsActive
+                    ? ClickRegion.Left :
+                DS4Touch.OutputRightPadTouch.IsActive && !DS4Touch.OutputLeftPadTouch.IsActive
+                    ? ClickRegion.Right :
+                coordinateX < DS4Touch.TOUCHPAD_WIDTH / 2 ? ClickRegion.Left : ClickRegion.Right :
                 leftPadClick ? ClickRegion.Left :
                 rightPadClick ? ClickRegion.Right : ClickRegion.None;
 
-            TouchpadClickFrame clickFrame = touchpadClickSequencer.Resolve(requestedRegion);
+            TouchpadClickFrame clickFrame = touchpadClickSequencer.Resolve(requestedRegion, touchpadClick);
 
             uint buttons = 0;
             if (inputs.ButtonState[ButtonFlags.B1]) buttons |= 0x0020;
@@ -67,7 +74,7 @@ namespace HandheldCompanion.Targets
             if (inputs.ButtonState[ButtonFlags.LeftStickClick]) buttons |= 0x4000;
             if (inputs.ButtonState[ButtonFlags.RightStickClick]) buttons |= 0x8000;
             if (inputs.ButtonState[ButtonFlags.Special]) buttons |= 0x00010000;
-            if (clickFrame.EmitClick) buttons |= 0x00020000;
+            if (touchpadClick || clickFrame.EmitClick) buttons |= 0x00020000;
             if (inputs.ButtonState[ButtonFlags.MicrophoneMute]) buttons |= 0x00040000;
             data[4] = (byte)(buttons & 0xFF);
             data[5] = (byte)((buttons >> 8) & 0xFF);
@@ -83,20 +90,15 @@ namespace HandheldCompanion.Targets
             data[9] = (byte)inputs.AxisState[AxisFlags.L2];
             data[10] = (byte)inputs.AxisState[AxisFlags.R2];
 
-            bool coordinateTouch = touchpadTouch ||
-                inputs.ButtonState[ButtonFlags.TouchpadSwipe];
+            if (leftOutputTouch.IsActive)
+                WriteTouch(data, 11, leftOutputTouch.X, leftOutputTouch.Y);
+            if (rightOutputTouch.IsActive)
+                WriteTouch(data, 16, rightOutputTouch.X, rightOutputTouch.Y);
 
-            data[15] = 0; // VIIPER Touch1Active validity flag
-            if (clickFrame.Region == ClickRegion.Left)
-                WriteTouch(data, DS4Touch.TOUCHPAD_WIDTH / 4, DS4Touch.TOUCHPAD_HEIGHT / 2);
-            else if (clickFrame.Region == ClickRegion.Right)
-                WriteTouch(data, DS4Touch.TOUCHPAD_WIDTH * 3 / 4, DS4Touch.TOUCHPAD_HEIGHT / 2);
-            else if (coordinateTouch)
-                WriteTouch(data, coordinateX, coordinateY);
-            else if (DS4Touch.LeftPadTouch.IsActive)
-                WriteTouch(data, DS4Touch.LeftPadTouch.X, DS4Touch.LeftPadTouch.Y);
-            else if (DS4Touch.RightPadTouch.IsActive)
-                WriteTouch(data, DS4Touch.RightPadTouch.X, DS4Touch.RightPadTouch.Y);
+            if (clickFrame.Region == ClickRegion.Left && !leftOutputTouch.IsActive)
+                WriteTouch(data, 11, DS4Touch.TOUCHPAD_WIDTH / 4, DS4Touch.TOUCHPAD_HEIGHT / 2);
+            else if (clickFrame.Region == ClickRegion.Right && !rightOutputTouch.IsActive)
+                WriteTouch(data, 16, DS4Touch.TOUCHPAD_WIDTH * 3 / 4, DS4Touch.TOUCHPAD_HEIGHT / 2);
 
             if (gamepadMotion is not null)
             {
@@ -136,15 +138,15 @@ namespace HandheldCompanion.Targets
             return data;
         }
 
-        private static void WriteTouch(byte[] data, int x, int y)
+        private static void WriteTouch(byte[] data, int offset, int x, int y)
         {
             ushort touchX = InputUtils.ClampToUShort(x, 0, DS4Touch.TOUCHPAD_WIDTH - 1);
             ushort touchY = InputUtils.ClampToUShort(y, 0, DS4Touch.TOUCHPAD_HEIGHT - 1);
-            data[11] = (byte)(touchX & 0xFF);
-            data[12] = (byte)((touchX >> 8) & 0xFF);
-            data[13] = (byte)(touchY & 0xFF);
-            data[14] = (byte)((touchY >> 8) & 0xFF);
-            data[15] = 1;
+            data[offset] = (byte)(touchX & 0xFF);
+            data[offset + 1] = (byte)((touchX >> 8) & 0xFF);
+            data[offset + 2] = (byte)(touchY & 0xFF);
+            data[offset + 3] = (byte)((touchY >> 8) & 0xFF);
+            data[offset + 4] = 1;
         }
 
         private readonly record struct TouchpadClickFrame(bool EmitClick, ClickRegion Region);
@@ -153,7 +155,7 @@ namespace HandheldCompanion.Targets
         {
             private ClickRegion preparedRegion;
             private bool preparedClickEmitted;
-            public TouchpadClickFrame Resolve(ClickRegion requestedRegion)
+            public TouchpadClickFrame Resolve(ClickRegion requestedRegion, bool directClick)
             {
                 bool emitClick = false;
                 ClickRegion touchRegion = requestedRegion;
@@ -162,13 +164,14 @@ namespace HandheldCompanion.Targets
                 {
                     if (preparedRegion == requestedRegion)
                     {
-                        emitClick = true;
+                        emitClick = directClick && !preparedClickEmitted || !directClick;
                         preparedClickEmitted = true;
                     }
                     else
                     {
                         preparedRegion = requestedRegion;
-                        preparedClickEmitted = false;
+                        preparedClickEmitted = directClick;
+                        emitClick = directClick;
                     }
                 }
                 else if (preparedRegion != ClickRegion.None && !preparedClickEmitted)

--- a/HandheldCompanion/Targets/DualSenseTarget.cs
+++ b/HandheldCompanion/Targets/DualSenseTarget.cs
@@ -13,6 +13,10 @@ namespace HandheldCompanion.Targets
         protected override string DeviceType => "dualsenseedge";
         protected override int InputLength => 33;
 
+        private enum ClickRegion : byte { None, Left, Right }
+        private ClickRegion preparedClickRegion;
+        private bool preparedCoordinateClick;
+
         public DualSenseTarget(ushort vendorId, ushort productId) : base(vendorId, productId)
         {
             HID = HIDmode.DualSenseController;
@@ -36,6 +40,36 @@ namespace HandheldCompanion.Targets
             data[2] = (byte)(inputs.AxisState[AxisFlags.RightStickX] >> 8);
             data[3] = (byte)(InputUtils.NegateClampToShort((short)inputs.AxisState[AxisFlags.RightStickY]) >> 8);
 
+            bool leftPadClick = inputs.ButtonState[ButtonFlags.LeftPadClick];
+            bool rightPadClick = inputs.ButtonState[ButtonFlags.RightPadClick];
+            bool coordinateClick = inputs.ButtonState[ButtonFlags.TouchpadCoordinateClick];
+            bool centerPadClick = inputs.ButtonState[ButtonFlags.CenterPadClick] ||
+                (DS4Touch.OutputClickButton && !leftPadClick && !rightPadClick);
+
+            ClickRegion requestedRegion = leftPadClick ? ClickRegion.Left :
+                rightPadClick ? ClickRegion.Right : ClickRegion.None;
+
+            // Steam must see the regional touch before the shared click transitions
+            // down. Otherwise it first classifies the press as the center button.
+            bool emitPadClick = centerPadClick;
+            if (coordinateClick)
+            {
+                emitPadClick = preparedCoordinateClick;
+                preparedCoordinateClick = true;
+                preparedClickRegion = ClickRegion.None;
+            }
+            else if (requestedRegion != ClickRegion.None)
+            {
+                emitPadClick = preparedClickRegion == requestedRegion;
+                preparedClickRegion = requestedRegion;
+                preparedCoordinateClick = false;
+            }
+            else
+            {
+                preparedClickRegion = ClickRegion.None;
+                preparedCoordinateClick = false;
+            }
+
             uint buttons = 0;
             if (inputs.ButtonState[ButtonFlags.B1]) buttons |= 0x0020;
             if (inputs.ButtonState[ButtonFlags.B2]) buttons |= 0x0040;
@@ -48,7 +82,8 @@ namespace HandheldCompanion.Targets
             if (inputs.ButtonState[ButtonFlags.LeftStickClick]) buttons |= 0x4000;
             if (inputs.ButtonState[ButtonFlags.RightStickClick]) buttons |= 0x8000;
             if (inputs.ButtonState[ButtonFlags.Special]) buttons |= 0x00010000;
-            if (inputs.ButtonState[ButtonFlags.LeftPadClick] || inputs.ButtonState[ButtonFlags.RightPadClick] || DS4Touch.OutputClickButton) buttons |= 0x00020000;
+            if (emitPadClick) buttons |= 0x00020000;
+            if (inputs.ButtonState[ButtonFlags.MicrophoneMute]) buttons |= 0x00040000;
             data[4] = (byte)(buttons & 0xFF);
             data[5] = (byte)((buttons >> 8) & 0xFF);
             data[6] = (byte)((buttons >> 16) & 0xFF);
@@ -63,18 +98,24 @@ namespace HandheldCompanion.Targets
             data[9] = (byte)inputs.AxisState[AxisFlags.L2];
             data[10] = (byte)inputs.AxisState[AxisFlags.R2];
 
-            if (DS4Touch.RightPadTouch.IsActive)
-            {
-                ushort touchX = InputUtils.ClampToUShort((int)DS4Touch.RightPadTouch.X, 0, DS4Touch.TOUCHPAD_WIDTH - 1);
-                ushort touchYRaw = InputUtils.ClampToUShort((int)DS4Touch.RightPadTouch.Y, 0, DS4Touch.TOUCHPAD_HEIGHT - 1);
-                ushort touchXScaled = InputUtils.ClampToUShort(touchX * DS4Touch.TOUCHPAD_WIDTH / 1023, 0, DS4Touch.TOUCHPAD_WIDTH);
-                ushort touchYScaled = InputUtils.ClampToUShort(touchYRaw * 1080 / (DS4Touch.TOUCHPAD_HEIGHT - 1), 0, 1080);
-                data[11] = (byte)(touchXScaled & 0xFF);
-                data[12] = (byte)((touchXScaled >> 8) & 0xFF);
-                data[13] = (byte)(touchYScaled & 0xFF);
-                data[14] = (byte)((touchYScaled >> 8) & 0xFF);
-                data[15] = 1;
-            }
+            // A DualSense only has one physical touchpad-click button. Steam splits
+            // left and right from center using a touch which is already active when
+            // that button goes down. A center click is sent without an active touch.
+            bool coordinateTouch = coordinateClick || inputs.ButtonState[ButtonFlags.TouchpadCoordinateTouch] ||
+                inputs.ButtonState[ButtonFlags.TouchpadSwipe];
+
+            if (coordinateTouch)
+                WriteTouch(data,
+                    AxisToCoordinate(inputs.AxisState[AxisFlags.RightPadX], DS4Touch.TOUCHPAD_WIDTH),
+                    DS4Touch.TOUCHPAD_HEIGHT - 1 - AxisToCoordinate(inputs.AxisState[AxisFlags.RightPadY], DS4Touch.TOUCHPAD_HEIGHT));
+            else if (leftPadClick)
+                WriteTouch(data, DS4Touch.TOUCHPAD_WIDTH / 4, DS4Touch.TOUCHPAD_HEIGHT / 2);
+            else if (rightPadClick)
+                WriteTouch(data, DS4Touch.TOUCHPAD_WIDTH * 3 / 4, DS4Touch.TOUCHPAD_HEIGHT / 2);
+            else if (!centerPadClick && DS4Touch.LeftPadTouch.IsActive)
+                WriteTouch(data, DS4Touch.LeftPadTouch.X, DS4Touch.LeftPadTouch.Y);
+            else if (!centerPadClick && DS4Touch.RightPadTouch.IsActive)
+                WriteTouch(data, DS4Touch.RightPadTouch.X, DS4Touch.RightPadTouch.Y);
 
             if (gamepadMotion is not null)
             {
@@ -112,6 +153,23 @@ namespace HandheldCompanion.Targets
             }
 
             return data;
+        }
+
+        private static void WriteTouch(byte[] data, int x, int y)
+        {
+            ushort touchX = InputUtils.ClampToUShort(x, 0, DS4Touch.TOUCHPAD_WIDTH - 1);
+            ushort touchY = InputUtils.ClampToUShort(y, 0, DS4Touch.TOUCHPAD_HEIGHT - 1);
+            data[11] = (byte)(touchX & 0xFF);
+            data[12] = (byte)((touchX >> 8) & 0xFF);
+            data[13] = (byte)(touchY & 0xFF);
+            data[14] = (byte)((touchY >> 8) & 0xFF);
+            data[15] = 1;
+        }
+
+        private static int AxisToCoordinate(short value, int extent)
+        {
+            return (int)Math.Clamp(((long)value - short.MinValue) * (extent - 1) / ushort.MaxValue,
+                0, extent - 1);
         }
     }
 }

--- a/HandheldCompanion/Targets/DualSenseTarget.cs
+++ b/HandheldCompanion/Targets/DualSenseTarget.cs
@@ -66,7 +66,7 @@ namespace HandheldCompanion.Targets
             if (inputs.ButtonState[ButtonFlags.RightStickClick]) buttons |= 0x8000;
             if (inputs.ButtonState[ButtonFlags.Special]) buttons |= 0x00010000;
             if (touchpadClick || emitClick) buttons |= 0x00020000;
-            if (inputs.ButtonState[ButtonFlags.MicrophoneMute]) buttons |= 0x00040000;
+            if (inputs.ButtonState[ButtonFlags.B5]) buttons |= 0x00040000;
             data[4] = (byte)(buttons & 0xFF);
             data[5] = (byte)((buttons >> 8) & 0xFF);
             data[6] = (byte)((buttons >> 16) & 0xFF);

--- a/HandheldCompanion/Targets/DualSenseTarget.cs
+++ b/HandheldCompanion/Targets/DualSenseTarget.cs
@@ -13,8 +13,8 @@ namespace HandheldCompanion.Targets
         protected override string DeviceType => "dualsenseedge";
         protected override int InputLength => 33;
 
-        private enum ClickRegion : byte { None, Left, Right }
-        private readonly TouchpadClickSequencer touchpadClickSequencer = new();
+        private byte preparedClickFinger;
+        private bool preparedClickEmitted;
 
         public DualSenseTarget(ushort vendorId, ushort productId) : base(vendorId, productId)
         {
@@ -43,24 +43,15 @@ namespace HandheldCompanion.Targets
             bool rightPadClick = inputs.ButtonState[ButtonFlags.RightPadClick];
             bool touchpadClick = inputs.ButtonState[ButtonFlags.TouchpadClick];
 
-            int coordinateX = DS4Touch.AxisToCoordinate(inputs.AxisState[AxisFlags.RightPadX], DS4Touch.TOUCHPAD_WIDTH);
-            var leftOutputTouch = DS4Touch.OutputLeftPadTouch.IsActive
-                ? DS4Touch.OutputLeftPadTouch
-                : DS4Touch.LeftPadTouch;
-            var rightOutputTouch = DS4Touch.OutputRightPadTouch.IsActive
-                ? DS4Touch.OutputRightPadTouch
-                : DS4Touch.RightPadTouch;
+            var leftOutputTouch = DS4Touch.OutputLeftPadTouch.IsActive ? DS4Touch.OutputLeftPadTouch : DS4Touch.LeftPadTouch;
+            var rightOutputTouch = DS4Touch.OutputRightPadTouch.IsActive ? DS4Touch.OutputRightPadTouch : DS4Touch.RightPadTouch;
 
-            ClickRegion requestedRegion = touchpadClick ?
-                DS4Touch.OutputLeftPadTouch.IsActive && !DS4Touch.OutputRightPadTouch.IsActive
-                    ? ClickRegion.Left :
-                DS4Touch.OutputRightPadTouch.IsActive && !DS4Touch.OutputLeftPadTouch.IsActive
-                    ? ClickRegion.Right :
-                coordinateX < DS4Touch.TOUCHPAD_WIDTH / 2 ? ClickRegion.Left : ClickRegion.Right :
-                leftPadClick ? ClickRegion.Left :
-                rightPadClick ? ClickRegion.Right : ClickRegion.None;
-
-            TouchpadClickFrame clickFrame = touchpadClickSequencer.Resolve(requestedRegion, touchpadClick);
+            byte requestedClickFinger = touchpadClick
+                ? DS4Touch.OutputLeftPadTouch.IsActive ? (byte)1
+                    : DS4Touch.OutputRightPadTouch.IsActive ? (byte)2 : (byte)0
+                : leftPadClick ? (byte)1
+                : rightPadClick ? (byte)2 : (byte)0;
+            ResolveClickFinger(requestedClickFinger, touchpadClick, out bool emitClick);
 
             uint buttons = 0;
             if (inputs.ButtonState[ButtonFlags.B1]) buttons |= 0x0020;
@@ -74,7 +65,7 @@ namespace HandheldCompanion.Targets
             if (inputs.ButtonState[ButtonFlags.LeftStickClick]) buttons |= 0x4000;
             if (inputs.ButtonState[ButtonFlags.RightStickClick]) buttons |= 0x8000;
             if (inputs.ButtonState[ButtonFlags.Special]) buttons |= 0x00010000;
-            if (touchpadClick || clickFrame.EmitClick) buttons |= 0x00020000;
+            if (touchpadClick || emitClick) buttons |= 0x00020000;
             if (inputs.ButtonState[ButtonFlags.MicrophoneMute]) buttons |= 0x00040000;
             data[4] = (byte)(buttons & 0xFF);
             data[5] = (byte)((buttons >> 8) & 0xFF);
@@ -94,11 +85,6 @@ namespace HandheldCompanion.Targets
                 WriteTouch(data, 11, leftOutputTouch.X, leftOutputTouch.Y);
             if (rightOutputTouch.IsActive)
                 WriteTouch(data, 16, rightOutputTouch.X, rightOutputTouch.Y);
-
-            if (clickFrame.Region == ClickRegion.Left && !leftOutputTouch.IsActive)
-                WriteTouch(data, 11, DS4Touch.TOUCHPAD_WIDTH / 4, DS4Touch.TOUCHPAD_HEIGHT / 2);
-            else if (clickFrame.Region == ClickRegion.Right && !rightOutputTouch.IsActive)
-                WriteTouch(data, 16, DS4Touch.TOUCHPAD_WIDTH * 3 / 4, DS4Touch.TOUCHPAD_HEIGHT / 2);
 
             if (gamepadMotion is not null)
             {
@@ -149,52 +135,40 @@ namespace HandheldCompanion.Targets
             data[offset + 4] = 1;
         }
 
-        private readonly record struct TouchpadClickFrame(bool EmitClick, ClickRegion Region);
-
-        private sealed class TouchpadClickSequencer
+        private void ResolveClickFinger(byte requestedFinger, bool directClick, out bool emitClick)
         {
-            private ClickRegion preparedRegion;
-            private bool preparedClickEmitted;
-            public TouchpadClickFrame Resolve(ClickRegion requestedRegion, bool directClick)
-            {
-                bool emitClick = false;
-                ClickRegion touchRegion = requestedRegion;
+            emitClick = false;
 
-                if (requestedRegion != ClickRegion.None)
+            if (requestedFinger != 0)
+            {
+                if (preparedClickFinger == requestedFinger)
                 {
-                    if (preparedRegion == requestedRegion)
-                    {
-                        emitClick = directClick && !preparedClickEmitted || !directClick;
-                        preparedClickEmitted = true;
-                    }
-                    else
-                    {
-                        preparedRegion = requestedRegion;
-                        preparedClickEmitted = directClick;
-                        emitClick = directClick;
-                    }
-                }
-                else if (preparedRegion != ClickRegion.None && !preparedClickEmitted)
-                {
-                    // Preserve a one-report tap long enough to emit the click after
-                    // its preparatory touch report.
-                    emitClick = true;
-                    touchRegion = preparedRegion;
-                    Clear();
+                    emitClick = directClick && !preparedClickEmitted || !directClick;
+                    preparedClickEmitted = true;
                 }
                 else
                 {
-                    Clear();
+                    preparedClickFinger = requestedFinger;
+                    preparedClickEmitted = directClick;
+                    emitClick = directClick;
                 }
-
-                return new TouchpadClickFrame(emitClick, touchRegion);
             }
-
-            private void Clear()
+            else if (preparedClickFinger != 0 && !preparedClickEmitted)
             {
-                preparedRegion = ClickRegion.None;
-                preparedClickEmitted = false;
+                emitClick = true;
+                ClearPreparedClick();
             }
+            else
+            {
+                ClearPreparedClick();
+            }
+
+        }
+
+        private void ClearPreparedClick()
+        {
+            preparedClickFinger = 0;
+            preparedClickEmitted = false;
         }
     }
 }

--- a/HandheldCompanion/Targets/DualSenseTarget.cs
+++ b/HandheldCompanion/Targets/DualSenseTarget.cs
@@ -13,9 +13,11 @@ namespace HandheldCompanion.Targets
         protected override string DeviceType => "dualsenseedge";
         protected override int InputLength => 33;
 
-        private enum ClickRegion : byte { None, Left, Right }
+        private enum ClickRegion : byte { None, Left, Right, Coordinate }
         private ClickRegion preparedClickRegion;
-        private bool preparedCoordinateClick;
+        private bool preparedClickEmitted;
+        private int preparedTouchX;
+        private int preparedTouchY;
 
         public DualSenseTarget(ushort vendorId, ushort productId) : base(vendorId, productId)
         {
@@ -43,31 +45,53 @@ namespace HandheldCompanion.Targets
             bool leftPadClick = inputs.ButtonState[ButtonFlags.LeftPadClick];
             bool rightPadClick = inputs.ButtonState[ButtonFlags.RightPadClick];
             bool coordinateClick = inputs.ButtonState[ButtonFlags.TouchpadCoordinateClick];
-            bool centerPadClick = inputs.ButtonState[ButtonFlags.CenterPadClick] ||
-                (DS4Touch.OutputClickButton && !leftPadClick && !rightPadClick);
+            bool centerPadClick = !coordinateClick && !leftPadClick && !rightPadClick &&
+                (inputs.ButtonState[ButtonFlags.CenterPadClick] ||
+                (DS4Touch.OutputClickButton && !leftPadClick && !rightPadClick));
 
-            ClickRegion requestedRegion = leftPadClick ? ClickRegion.Left :
+            int coordinateX = DS4Touch.AxisToCoordinate(inputs.AxisState[AxisFlags.RightPadX], DS4Touch.TOUCHPAD_WIDTH);
+            int coordinateY = DS4Touch.TOUCHPAD_HEIGHT - 1 -
+                DS4Touch.AxisToCoordinate(inputs.AxisState[AxisFlags.RightPadY], DS4Touch.TOUCHPAD_HEIGHT);
+
+            ClickRegion requestedRegion = coordinateClick ? ClickRegion.Coordinate :
+                leftPadClick ? ClickRegion.Left :
                 rightPadClick ? ClickRegion.Right : ClickRegion.None;
 
             // Steam must see the regional touch before the shared click transitions
             // down. Otherwise it first classifies the press as the center button.
             bool emitPadClick = centerPadClick;
-            if (coordinateClick)
+            ClickRegion touchClickRegion = requestedRegion;
+            bool consumePreparedClick = false;
+            if (requestedRegion != ClickRegion.None)
             {
-                emitPadClick = preparedCoordinateClick;
-                preparedCoordinateClick = true;
-                preparedClickRegion = ClickRegion.None;
+                if (requestedRegion == ClickRegion.Coordinate)
+                {
+                    preparedTouchX = coordinateX;
+                    preparedTouchY = coordinateY;
+                }
+
+                if (preparedClickRegion == requestedRegion)
+                {
+                    emitPadClick = true;
+                    preparedClickEmitted = true;
+                }
+                else
+                {
+                    preparedClickRegion = requestedRegion;
+                    preparedClickEmitted = false;
+                }
             }
-            else if (requestedRegion != ClickRegion.None)
+            else if (preparedClickRegion != ClickRegion.None && !preparedClickEmitted)
             {
-                emitPadClick = preparedClickRegion == requestedRegion;
-                preparedClickRegion = requestedRegion;
-                preparedCoordinateClick = false;
+                // Preserve a one-report tap long enough to emit the click after
+                // its preparatory touch report.
+                emitPadClick = true;
+                touchClickRegion = preparedClickRegion;
+                consumePreparedClick = true;
             }
             else
             {
-                preparedClickRegion = ClickRegion.None;
-                preparedCoordinateClick = false;
+                ClearPreparedClick();
             }
 
             uint buttons = 0;
@@ -104,18 +128,23 @@ namespace HandheldCompanion.Targets
             bool coordinateTouch = coordinateClick || inputs.ButtonState[ButtonFlags.TouchpadCoordinateTouch] ||
                 inputs.ButtonState[ButtonFlags.TouchpadSwipe];
 
-            if (coordinateTouch)
-                WriteTouch(data,
-                    AxisToCoordinate(inputs.AxisState[AxisFlags.RightPadX], DS4Touch.TOUCHPAD_WIDTH),
-                    DS4Touch.TOUCHPAD_HEIGHT - 1 - AxisToCoordinate(inputs.AxisState[AxisFlags.RightPadY], DS4Touch.TOUCHPAD_HEIGHT));
-            else if (leftPadClick)
+            data[15] = 0; // VIIPER Touch1Active validity flag
+            if (touchClickRegion == ClickRegion.Coordinate)
+                WriteTouch(data, coordinateClick ? coordinateX : preparedTouchX,
+                    coordinateClick ? coordinateY : preparedTouchY);
+            else if (touchClickRegion == ClickRegion.Left)
                 WriteTouch(data, DS4Touch.TOUCHPAD_WIDTH / 4, DS4Touch.TOUCHPAD_HEIGHT / 2);
-            else if (rightPadClick)
+            else if (touchClickRegion == ClickRegion.Right)
                 WriteTouch(data, DS4Touch.TOUCHPAD_WIDTH * 3 / 4, DS4Touch.TOUCHPAD_HEIGHT / 2);
+            else if (coordinateTouch)
+                WriteTouch(data, coordinateX, coordinateY);
             else if (!centerPadClick && DS4Touch.LeftPadTouch.IsActive)
                 WriteTouch(data, DS4Touch.LeftPadTouch.X, DS4Touch.LeftPadTouch.Y);
             else if (!centerPadClick && DS4Touch.RightPadTouch.IsActive)
                 WriteTouch(data, DS4Touch.RightPadTouch.X, DS4Touch.RightPadTouch.Y);
+
+            if (consumePreparedClick)
+                ClearPreparedClick();
 
             if (gamepadMotion is not null)
             {
@@ -166,10 +195,10 @@ namespace HandheldCompanion.Targets
             data[15] = 1;
         }
 
-        private static int AxisToCoordinate(short value, int extent)
+        private void ClearPreparedClick()
         {
-            return (int)Math.Clamp(((long)value - short.MinValue) * (extent - 1) / ushort.MaxValue,
-                0, extent - 1);
+            preparedClickRegion = ClickRegion.None;
+            preparedClickEmitted = false;
         }
     }
 }

--- a/HandheldCompanion/Targets/DualSenseTarget.cs
+++ b/HandheldCompanion/Targets/DualSenseTarget.cs
@@ -14,10 +14,7 @@ namespace HandheldCompanion.Targets
         protected override int InputLength => 33;
 
         private enum ClickRegion : byte { None, Left, Right, Coordinate }
-        private ClickRegion preparedClickRegion;
-        private bool preparedClickEmitted;
-        private int preparedTouchX;
-        private int preparedTouchY;
+        private readonly TouchpadClickSequencer touchpadClickSequencer = new();
 
         public DualSenseTarget(ushort vendorId, ushort productId) : base(vendorId, productId)
         {
@@ -57,42 +54,8 @@ namespace HandheldCompanion.Targets
                 leftPadClick ? ClickRegion.Left :
                 rightPadClick ? ClickRegion.Right : ClickRegion.None;
 
-            // Steam must see the regional touch before the shared click transitions
-            // down. Otherwise it first classifies the press as the center button.
-            bool emitPadClick = centerPadClick;
-            ClickRegion touchClickRegion = requestedRegion;
-            bool consumePreparedClick = false;
-            if (requestedRegion != ClickRegion.None)
-            {
-                if (requestedRegion == ClickRegion.Coordinate)
-                {
-                    preparedTouchX = coordinateX;
-                    preparedTouchY = coordinateY;
-                }
-
-                if (preparedClickRegion == requestedRegion)
-                {
-                    emitPadClick = true;
-                    preparedClickEmitted = true;
-                }
-                else
-                {
-                    preparedClickRegion = requestedRegion;
-                    preparedClickEmitted = false;
-                }
-            }
-            else if (preparedClickRegion != ClickRegion.None && !preparedClickEmitted)
-            {
-                // Preserve a one-report tap long enough to emit the click after
-                // its preparatory touch report.
-                emitPadClick = true;
-                touchClickRegion = preparedClickRegion;
-                consumePreparedClick = true;
-            }
-            else
-            {
-                ClearPreparedClick();
-            }
+            TouchpadClickFrame clickFrame = touchpadClickSequencer.Resolve(
+                requestedRegion, centerPadClick, coordinateX, coordinateY);
 
             uint buttons = 0;
             if (inputs.ButtonState[ButtonFlags.B1]) buttons |= 0x0020;
@@ -106,7 +69,7 @@ namespace HandheldCompanion.Targets
             if (inputs.ButtonState[ButtonFlags.LeftStickClick]) buttons |= 0x4000;
             if (inputs.ButtonState[ButtonFlags.RightStickClick]) buttons |= 0x8000;
             if (inputs.ButtonState[ButtonFlags.Special]) buttons |= 0x00010000;
-            if (emitPadClick) buttons |= 0x00020000;
+            if (clickFrame.EmitClick) buttons |= 0x00020000;
             if (inputs.ButtonState[ButtonFlags.MicrophoneMute]) buttons |= 0x00040000;
             data[4] = (byte)(buttons & 0xFF);
             data[5] = (byte)((buttons >> 8) & 0xFF);
@@ -129,12 +92,11 @@ namespace HandheldCompanion.Targets
                 inputs.ButtonState[ButtonFlags.TouchpadSwipe];
 
             data[15] = 0; // VIIPER Touch1Active validity flag
-            if (touchClickRegion == ClickRegion.Coordinate)
-                WriteTouch(data, coordinateClick ? coordinateX : preparedTouchX,
-                    coordinateClick ? coordinateY : preparedTouchY);
-            else if (touchClickRegion == ClickRegion.Left)
+            if (clickFrame.Region == ClickRegion.Coordinate)
+                WriteTouch(data, clickFrame.X, clickFrame.Y);
+            else if (clickFrame.Region == ClickRegion.Left)
                 WriteTouch(data, DS4Touch.TOUCHPAD_WIDTH / 4, DS4Touch.TOUCHPAD_HEIGHT / 2);
-            else if (touchClickRegion == ClickRegion.Right)
+            else if (clickFrame.Region == ClickRegion.Right)
                 WriteTouch(data, DS4Touch.TOUCHPAD_WIDTH * 3 / 4, DS4Touch.TOUCHPAD_HEIGHT / 2);
             else if (coordinateTouch)
                 WriteTouch(data, coordinateX, coordinateY);
@@ -142,9 +104,6 @@ namespace HandheldCompanion.Targets
                 WriteTouch(data, DS4Touch.LeftPadTouch.X, DS4Touch.LeftPadTouch.Y);
             else if (!centerPadClick && DS4Touch.RightPadTouch.IsActive)
                 WriteTouch(data, DS4Touch.RightPadTouch.X, DS4Touch.RightPadTouch.Y);
-
-            if (consumePreparedClick)
-                ClearPreparedClick();
 
             if (gamepadMotion is not null)
             {
@@ -195,10 +154,62 @@ namespace HandheldCompanion.Targets
             data[15] = 1;
         }
 
-        private void ClearPreparedClick()
+        private readonly record struct TouchpadClickFrame(bool EmitClick, ClickRegion Region, int X, int Y);
+
+        private sealed class TouchpadClickSequencer
         {
-            preparedClickRegion = ClickRegion.None;
-            preparedClickEmitted = false;
+            private ClickRegion preparedRegion;
+            private bool preparedClickEmitted;
+            private int preparedX;
+            private int preparedY;
+
+            public TouchpadClickFrame Resolve(ClickRegion requestedRegion, bool centerClick, int x, int y)
+            {
+                bool emitClick = centerClick;
+                ClickRegion touchRegion = requestedRegion;
+
+                if (requestedRegion != ClickRegion.None)
+                {
+                    if (requestedRegion == ClickRegion.Coordinate)
+                    {
+                        preparedX = x;
+                        preparedY = y;
+                    }
+
+                    if (preparedRegion == requestedRegion)
+                    {
+                        emitClick = true;
+                        preparedClickEmitted = true;
+                    }
+                    else
+                    {
+                        preparedRegion = requestedRegion;
+                        preparedClickEmitted = false;
+                    }
+                }
+                else if (preparedRegion != ClickRegion.None && !preparedClickEmitted)
+                {
+                    // Preserve a one-report tap long enough to emit the click after
+                    // its preparatory touch report.
+                    emitClick = true;
+                    touchRegion = preparedRegion;
+                    Clear();
+                }
+                else
+                {
+                    Clear();
+                }
+
+                return new TouchpadClickFrame(emitClick, touchRegion,
+                    touchRegion == ClickRegion.Coordinate ? preparedX : x,
+                    touchRegion == ClickRegion.Coordinate ? preparedY : y);
+            }
+
+            private void Clear()
+            {
+                preparedRegion = ClickRegion.None;
+                preparedClickEmitted = false;
+            }
         }
     }
 }

--- a/HandheldCompanion/Targets/DualSenseTarget.cs
+++ b/HandheldCompanion/Targets/DualSenseTarget.cs
@@ -13,7 +13,7 @@ namespace HandheldCompanion.Targets
         protected override string DeviceType => "dualsenseedge";
         protected override int InputLength => 33;
 
-        private enum ClickRegion : byte { None, Left, Right, Coordinate }
+        private enum ClickRegion : byte { None, Left, Right }
         private readonly TouchpadClickSequencer touchpadClickSequencer = new();
 
         public DualSenseTarget(ushort vendorId, ushort productId) : base(vendorId, productId)
@@ -41,21 +41,19 @@ namespace HandheldCompanion.Targets
 
             bool leftPadClick = inputs.ButtonState[ButtonFlags.LeftPadClick];
             bool rightPadClick = inputs.ButtonState[ButtonFlags.RightPadClick];
-            bool coordinateClick = inputs.ButtonState[ButtonFlags.TouchpadCoordinateClick];
-            bool centerPadClick = !coordinateClick && !leftPadClick && !rightPadClick &&
-                (inputs.ButtonState[ButtonFlags.CenterPadClick] ||
-                (DS4Touch.OutputClickButton && !leftPadClick && !rightPadClick));
+            bool touchpadClick = inputs.ButtonState[ButtonFlags.TouchpadClick];
+            bool touchpadTouch = inputs.ButtonState[ButtonFlags.TouchpadTouch];
 
             int coordinateX = DS4Touch.AxisToCoordinate(inputs.AxisState[AxisFlags.RightPadX], DS4Touch.TOUCHPAD_WIDTH);
             int coordinateY = DS4Touch.TOUCHPAD_HEIGHT - 1 -
                 DS4Touch.AxisToCoordinate(inputs.AxisState[AxisFlags.RightPadY], DS4Touch.TOUCHPAD_HEIGHT);
 
-            ClickRegion requestedRegion = coordinateClick ? ClickRegion.Coordinate :
+            ClickRegion requestedRegion = touchpadClick ? coordinateX < DS4Touch.TOUCHPAD_WIDTH / 2
+                ? ClickRegion.Left : ClickRegion.Right :
                 leftPadClick ? ClickRegion.Left :
                 rightPadClick ? ClickRegion.Right : ClickRegion.None;
 
-            TouchpadClickFrame clickFrame = touchpadClickSequencer.Resolve(
-                requestedRegion, centerPadClick, coordinateX, coordinateY);
+            TouchpadClickFrame clickFrame = touchpadClickSequencer.Resolve(requestedRegion);
 
             uint buttons = 0;
             if (inputs.ButtonState[ButtonFlags.B1]) buttons |= 0x0020;
@@ -85,24 +83,19 @@ namespace HandheldCompanion.Targets
             data[9] = (byte)inputs.AxisState[AxisFlags.L2];
             data[10] = (byte)inputs.AxisState[AxisFlags.R2];
 
-            // A DualSense only has one physical touchpad-click button. Steam splits
-            // left and right from center using a touch which is already active when
-            // that button goes down. A center click is sent without an active touch.
-            bool coordinateTouch = coordinateClick || inputs.ButtonState[ButtonFlags.TouchpadCoordinateTouch] ||
+            bool coordinateTouch = touchpadTouch ||
                 inputs.ButtonState[ButtonFlags.TouchpadSwipe];
 
             data[15] = 0; // VIIPER Touch1Active validity flag
-            if (clickFrame.Region == ClickRegion.Coordinate)
-                WriteTouch(data, clickFrame.X, clickFrame.Y);
-            else if (clickFrame.Region == ClickRegion.Left)
+            if (clickFrame.Region == ClickRegion.Left)
                 WriteTouch(data, DS4Touch.TOUCHPAD_WIDTH / 4, DS4Touch.TOUCHPAD_HEIGHT / 2);
             else if (clickFrame.Region == ClickRegion.Right)
                 WriteTouch(data, DS4Touch.TOUCHPAD_WIDTH * 3 / 4, DS4Touch.TOUCHPAD_HEIGHT / 2);
             else if (coordinateTouch)
                 WriteTouch(data, coordinateX, coordinateY);
-            else if (!centerPadClick && DS4Touch.LeftPadTouch.IsActive)
+            else if (DS4Touch.LeftPadTouch.IsActive)
                 WriteTouch(data, DS4Touch.LeftPadTouch.X, DS4Touch.LeftPadTouch.Y);
-            else if (!centerPadClick && DS4Touch.RightPadTouch.IsActive)
+            else if (DS4Touch.RightPadTouch.IsActive)
                 WriteTouch(data, DS4Touch.RightPadTouch.X, DS4Touch.RightPadTouch.Y);
 
             if (gamepadMotion is not null)
@@ -154,28 +147,19 @@ namespace HandheldCompanion.Targets
             data[15] = 1;
         }
 
-        private readonly record struct TouchpadClickFrame(bool EmitClick, ClickRegion Region, int X, int Y);
+        private readonly record struct TouchpadClickFrame(bool EmitClick, ClickRegion Region);
 
         private sealed class TouchpadClickSequencer
         {
             private ClickRegion preparedRegion;
             private bool preparedClickEmitted;
-            private int preparedX;
-            private int preparedY;
-
-            public TouchpadClickFrame Resolve(ClickRegion requestedRegion, bool centerClick, int x, int y)
+            public TouchpadClickFrame Resolve(ClickRegion requestedRegion)
             {
-                bool emitClick = centerClick;
+                bool emitClick = false;
                 ClickRegion touchRegion = requestedRegion;
 
                 if (requestedRegion != ClickRegion.None)
                 {
-                    if (requestedRegion == ClickRegion.Coordinate)
-                    {
-                        preparedX = x;
-                        preparedY = y;
-                    }
-
                     if (preparedRegion == requestedRegion)
                     {
                         emitClick = true;
@@ -200,9 +184,7 @@ namespace HandheldCompanion.Targets
                     Clear();
                 }
 
-                return new TouchpadClickFrame(emitClick, touchRegion,
-                    touchRegion == ClickRegion.Coordinate ? preparedX : x,
-                    touchRegion == ClickRegion.Coordinate ? preparedY : y);
+                return new TouchpadClickFrame(emitClick, touchRegion);
             }
 
             private void Clear()

--- a/HandheldCompanion/Targets/DualShock4Target.cs
+++ b/HandheldCompanion/Targets/DualShock4Target.cs
@@ -44,7 +44,7 @@ namespace HandheldCompanion.Targets
             if (inputs.ButtonState[ButtonFlags.LeftStickClick]) buttons |= 0x4000;
             if (inputs.ButtonState[ButtonFlags.RightStickClick]) buttons |= 0x8000;
             if (inputs.ButtonState[ButtonFlags.Special]) buttons |= 0x0001;
-            if (inputs.ButtonState[ButtonFlags.LeftPadClick] || inputs.ButtonState[ButtonFlags.RightPadClick] || DS4Touch.OutputClickButton) buttons |= 0x0002;
+            if (inputs.ButtonState[ButtonFlags.LeftPadClick] || inputs.ButtonState[ButtonFlags.RightPadClick] || inputs.ButtonState[ButtonFlags.TouchpadClick] || DS4Touch.OutputClickButton) buttons |= 0x0002;
             data[4] = (byte)(buttons & 0xFF);
             data[5] = (byte)((buttons >> 8) & 0xFF);
 
@@ -57,10 +57,13 @@ namespace HandheldCompanion.Targets
             data[7] = (byte)inputs.AxisState[AxisFlags.L2];
             data[8] = (byte)inputs.AxisState[AxisFlags.R2];
 
-            if (DS4Touch.LeftPadTouch.IsActive)
+            var leftPadTouch = DS4Touch.OutputLeftPadTouch.IsActive
+                ? DS4Touch.OutputLeftPadTouch
+                : DS4Touch.LeftPadTouch;
+            if (leftPadTouch.IsActive)
             {
-                ushort x = InputUtils.ClampToUShort((int)DS4Touch.LeftPadTouch.X, 0, DS4Touch.TOUCHPAD_WIDTH - 1);
-                ushort y = InputUtils.ClampToUShort((int)DS4Touch.LeftPadTouch.Y, 0, DS4Touch.TOUCHPAD_HEIGHT - 1);
+                ushort x = InputUtils.ClampToUShort((int)leftPadTouch.X, 0, DS4Touch.TOUCHPAD_WIDTH - 1);
+                ushort y = InputUtils.ClampToUShort((int)leftPadTouch.Y, 0, DS4Touch.TOUCHPAD_HEIGHT - 1);
                 data[9] = (byte)(x & 0xFF);
                 data[10] = (byte)((x >> 8) & 0xFF);
                 data[11] = (byte)(y & 0xFF);
@@ -68,10 +71,13 @@ namespace HandheldCompanion.Targets
                 data[13] = 1;
             }
 
-            if (DS4Touch.RightPadTouch.IsActive)
+            var rightPadTouch = DS4Touch.OutputRightPadTouch.IsActive
+                ? DS4Touch.OutputRightPadTouch
+                : DS4Touch.RightPadTouch;
+            if (rightPadTouch.IsActive)
             {
-                ushort x = InputUtils.ClampToUShort((int)DS4Touch.RightPadTouch.X, 0, DS4Touch.TOUCHPAD_WIDTH - 1);
-                ushort y = InputUtils.ClampToUShort((int)DS4Touch.RightPadTouch.Y, 0, DS4Touch.TOUCHPAD_HEIGHT - 1);
+                ushort x = InputUtils.ClampToUShort((int)rightPadTouch.X, 0, DS4Touch.TOUCHPAD_WIDTH - 1);
+                ushort y = InputUtils.ClampToUShort((int)rightPadTouch.Y, 0, DS4Touch.TOUCHPAD_HEIGHT - 1);
                 data[14] = (byte)(x & 0xFF);
                 data[15] = (byte)((x >> 8) & 0xFF);
                 data[16] = (byte)(y & 0xFF);

--- a/HandheldCompanion/Utils/InputUtils.cs
+++ b/HandheldCompanion/Utils/InputUtils.cs
@@ -38,7 +38,7 @@ namespace HandheldCompanion.Utils
         JoystickSteering = 3
     }
 
-    public enum MotionOutput { Disabled, LeftStick, RightStick, MoveCursor, ScrollWheel }
+    public enum MotionOutput { Disabled, LeftStick, RightStick, MoveCursor, ScrollWheel, LeftPad, RightPad }
     public enum MotionMode { Off, On, Toggle }
 
     [Flags]

--- a/HandheldCompanion/ViewModels/HotkeyViewModel.cs
+++ b/HandheldCompanion/ViewModels/HotkeyViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using HandheldCompanion.Commands;
 using HandheldCompanion.Commands.Functions.HC;
+using HandheldCompanion.Actions;
 using HandheldCompanion.Commands.Functions.Windows;
 using HandheldCompanion.Controllers;
 using HandheldCompanion.Devices;
@@ -778,6 +779,9 @@ namespace HandheldCompanion.ViewModels
             {
                 foreach (var button in controller.GetTargetButtons())
                 {
+                    if (TouchpadActions.IsTouchpadTarget(button))
+                        continue;
+
                     newValues.Add(new MappingTargetViewModel
                     {
                         Tag = button,

--- a/HandheldCompanion/ViewModels/HotkeyViewModel.cs
+++ b/HandheldCompanion/ViewModels/HotkeyViewModel.cs
@@ -1,6 +1,5 @@
 ﻿using HandheldCompanion.Commands;
 using HandheldCompanion.Commands.Functions.HC;
-using HandheldCompanion.Actions;
 using HandheldCompanion.Commands.Functions.Windows;
 using HandheldCompanion.Controllers;
 using HandheldCompanion.Devices;
@@ -779,9 +778,6 @@ namespace HandheldCompanion.ViewModels
             {
                 foreach (var button in controller.GetTargetButtons())
                 {
-                    if (TouchpadActions.IsTouchpadTarget(button))
-                        continue;
-
                     newValues.Add(new MappingTargetViewModel
                     {
                         Tag = button,

--- a/HandheldCompanion/ViewModels/Layout/LayoutItemPageViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/LayoutItemPageViewModel.cs
@@ -121,6 +121,7 @@ namespace HandheldCompanion.ViewModels
                     5 => "Trigger",
                     6 => "Shift",
                     7 => "Inherit",
+                    8 => "Touchpad",
                     _ => "Unknown"
                 };
 

--- a/HandheldCompanion/ViewModels/Layout/Mappings/AxisMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/AxisMappingViewModel.cs
@@ -751,9 +751,6 @@ namespace HandheldCompanion.ViewModels
                 MappingTargetViewModel? matchingTargetVm = null;
                 foreach (var button in controller.GetTargetButtons())
                 {
-                    if (TouchpadActions.IsTouchpadTarget(button))
-                        continue;
-
                     var mappingTargetVm = CreateTarget(button, controller.GetButtonName(button));
                     targets.Add(mappingTargetVm);
 

--- a/HandheldCompanion/ViewModels/Layout/Mappings/AxisMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/AxisMappingViewModel.cs
@@ -20,6 +20,16 @@ namespace HandheldCompanion.ViewModels
 {
     public class AxisMappingViewModel : MappingViewModel
     {
+        public override ActionType[] SupportedActionTypes =>
+        [
+            ActionType.Disabled,
+            ActionType.Button,
+            ActionType.Joystick,
+            ActionType.Keyboard,
+            ActionType.Mouse,
+            ActionType.Touchpad
+        ];
+
         #region Axis Action Properties
 
         #region Axis2Button

--- a/HandheldCompanion/ViewModels/Layout/Mappings/AxisMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/AxisMappingViewModel.cs
@@ -111,7 +111,13 @@ namespace HandheldCompanion.ViewModels
 
         public override int Axis2AxisInnerDeadzone
         {
-            get => (Action is AxisActions axisAction) ? axisAction.AxisDeadZoneInner : (Action is TriggerActions triggerAction) ? triggerAction.AxisDeadZoneInner : 0;
+            get => Action switch
+            {
+                AxisActions axisAction => axisAction.AxisDeadZoneInner,
+                TouchpadActions touchpadAction => touchpadAction.AxisDeadZoneInner,
+                TriggerActions triggerAction => triggerAction.AxisDeadZoneInner,
+                _ => 0,
+            };
             set
             {
                 if (Action is AxisActions axisAction && value != Axis2AxisInnerDeadzone)
@@ -119,6 +125,11 @@ namespace HandheldCompanion.ViewModels
                     axisAction.AxisDeadZoneInner = value;
                     OnPropertyChanged(nameof(Axis2AxisInnerDeadzone));
                     OnPropertyChanged(nameof(AxisVisualizerInnerDeadzoneSize));
+                }
+                else if (Action is TouchpadActions touchpadAction && value != Axis2AxisInnerDeadzone)
+                {
+                    touchpadAction.AxisDeadZoneInner = value;
+                    OnPropertyChanged(nameof(Axis2AxisInnerDeadzone));
                 }
                 else if (Action is TriggerActions triggerAction && value != Axis2AxisInnerDeadzone)
                 {
@@ -131,7 +142,13 @@ namespace HandheldCompanion.ViewModels
 
         public override int Axis2AxisOuterDeadzone
         {
-            get => (Action is AxisActions axisAction) ? axisAction.AxisDeadZoneOuter : (Action is TriggerActions triggerAction) ? triggerAction.AxisDeadZoneOuter : 0;
+            get => Action switch
+            {
+                AxisActions axisAction => axisAction.AxisDeadZoneOuter,
+                TouchpadActions touchpadAction => touchpadAction.AxisDeadZoneOuter,
+                TriggerActions triggerAction => triggerAction.AxisDeadZoneOuter,
+                _ => 0,
+            };
             set
             {
                 if (Action is AxisActions axisAction && value != Axis2AxisOuterDeadzone)
@@ -139,6 +156,11 @@ namespace HandheldCompanion.ViewModels
                     axisAction.AxisDeadZoneOuter = value;
                     OnPropertyChanged(nameof(Axis2AxisOuterDeadzone));
                     OnPropertyChanged(nameof(AxisVisualizerOuterDeadzoneSize));
+                }
+                else if (Action is TouchpadActions touchpadAction && value != Axis2AxisOuterDeadzone)
+                {
+                    touchpadAction.AxisDeadZoneOuter = value;
+                    OnPropertyChanged(nameof(Axis2AxisOuterDeadzone));
                 }
                 else if (Action is TriggerActions triggerAction && value != Axis2AxisOuterDeadzone)
                 {
@@ -151,7 +173,13 @@ namespace HandheldCompanion.ViewModels
 
         public override int Axis2AxisAntiDeadzone
         {
-            get => (Action is AxisActions axisAction) ? axisAction.AxisAntiDeadZone : (Action is TriggerActions triggerAction) ? triggerAction.AxisAntiDeadZone : 0;
+            get => Action switch
+            {
+                AxisActions axisAction => axisAction.AxisAntiDeadZone,
+                TouchpadActions touchpadAction => touchpadAction.AxisAntiDeadZone,
+                TriggerActions triggerAction => triggerAction.AxisAntiDeadZone,
+                _ => 0,
+            };
             set
             {
                 if (Action is AxisActions axisAction && value != Axis2AxisAntiDeadzone)
@@ -159,6 +187,11 @@ namespace HandheldCompanion.ViewModels
                     axisAction.AxisAntiDeadZone = value;
                     OnPropertyChanged(nameof(Axis2AxisAntiDeadzone));
                     OnPropertyChanged(nameof(AxisVisualizerAntiDeadzoneSize));
+                }
+                else if (Action is TouchpadActions touchpadAction && value != Axis2AxisAntiDeadzone)
+                {
+                    touchpadAction.AxisAntiDeadZone = value;
+                    OnPropertyChanged(nameof(Axis2AxisAntiDeadzone));
                 }
                 else if (Action is TriggerActions triggerAction && value != Axis2AxisAntiDeadzone)
                 {
@@ -168,6 +201,11 @@ namespace HandheldCompanion.ViewModels
                 }
             }
         }
+
+        public override Visibility AxisDeadzoneVisibility =>
+            ActionTypeIndex is (int)ActionType.Joystick or (int)ActionType.Touchpad
+                ? Visibility.Visible
+                : Visibility.Collapsed;
 
         public override Visibility AxisResponseCurveVisibility
         {
@@ -356,6 +394,7 @@ namespace HandheldCompanion.ViewModels
                     OnPropertyChanged(nameof(AxisThresholdVisibility));
                     OnPropertyChanged(nameof(GeneralActionVisibility));
                     OnPropertyChanged(nameof(AxisInvertVisibility));
+                    OnPropertyChanged(nameof(AxisVisualizerVisibility));
                     OnPropertyChanged(nameof(TouchpadVisualizerVisibility));
                     break;
             }
@@ -412,7 +451,7 @@ namespace HandheldCompanion.ViewModels
             }
         }
 
-        public override Visibility AxisVisualizerVisibility => AxisInvertVisibility;
+        public override Visibility AxisVisualizerVisibility => AxisDeadzoneVisibility;
         public override double AxisVisualizerDotX => 0.0d;
         public override double AxisVisualizerDotY => 0.0d;
         public override double AxisVisualizerDotTranslateX => 0.0d;

--- a/HandheldCompanion/ViewModels/Layout/Mappings/AxisMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/AxisMappingViewModel.cs
@@ -391,7 +391,7 @@ namespace HandheldCompanion.ViewModels
         public override Visibility TouchpadSettingsVisibility =>
             ActionTypeIndex == (int)ActionType.Touchpad &&
             Action is TouchpadActions { TargetType: TouchpadTargetType.Button } touchpadAction &&
-            TouchpadActions.IsCoordinateTarget(touchpadAction.Button)
+            TouchpadActions.IsGestureTarget(touchpadAction.Button)
                 ? Visibility.Visible : Visibility.Collapsed;
         public override Visibility TouchpadSwipeSettingsVisibility =>
             ActionTypeIndex == (int)ActionType.Touchpad &&

--- a/HandheldCompanion/ViewModels/Layout/Mappings/AxisMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/AxisMappingViewModel.cs
@@ -378,10 +378,13 @@ namespace HandheldCompanion.ViewModels
 
         public override bool IsAxisMapping => true;
         public override Visibility TouchpadSettingsVisibility =>
-            ActionTypeIndex == (int)ActionType.Button && Action is TouchpadActions
+            ActionTypeIndex == (int)ActionType.Touchpad &&
+            Action is TouchpadActions { TargetType: TouchpadTargetType.Button } touchpadAction &&
+            TouchpadActions.IsCoordinateTarget(touchpadAction.Button)
                 ? Visibility.Visible : Visibility.Collapsed;
         public override Visibility TouchpadSwipeSettingsVisibility =>
-            ActionTypeIndex == (int)ActionType.Button && Action is TouchpadActions { Button: ButtonFlags.TouchpadSwipe }
+            ActionTypeIndex == (int)ActionType.Touchpad &&
+            Action is TouchpadActions { TargetType: TouchpadTargetType.Button, Button: ButtonFlags.TouchpadSwipe }
                 ? Visibility.Visible : Visibility.Collapsed;
 
         // Axis Direction and Threshold are only visible when converting Axis to Button
@@ -721,7 +724,7 @@ namespace HandheldCompanion.ViewModels
                 }
 
                 MappingTargetViewModel? matchingTargetVm = null;
-                foreach (var axis in controller.GetTargetAxis())
+                foreach (var axis in GetJoystickTargets(controller))
                 {
                     var mappingTargetVm = CreateTarget(axis, controller.GetAxisName(axis));
                     targets.Add(mappingTargetVm);
@@ -769,6 +772,56 @@ namespace HandheldCompanion.ViewModels
                     matchingTargetVm = CreateUnsupportedTarget(((ButtonActions)Action).Button,
                         controller.GetButtonName(((ButtonActions)Action).Button));
                     targets.Add(matchingTargetVm);
+                }
+
+                ReplaceTargets(targets, matchingTargetVm);
+            }
+            else if (actionType == ActionType.Touchpad)
+            {
+                bool preserveMissingTarget = Action is TouchpadActions;
+                TouchpadActions touchpadAction = Action as TouchpadActions ?? new TouchpadActions
+                {
+                    motionThreshold = Gamepad.LeftThumbDeadZone,
+                    ShiftSlot = ShiftSlot.Any,
+                    ShiftMatchAny = false
+                };
+                if (!preserveMissingTarget)
+                    Action = touchpadAction;
+
+                MappingTargetViewModel? matchingTargetVm = null;
+
+                foreach (AxisLayoutFlags axis in TouchpadActions.GetAxisTargets(controller))
+                {
+                    var mappingTargetVm = CreateTarget(axis, controller.GetAxisName(axis));
+                    targets.Add(mappingTargetVm);
+
+                    if (touchpadAction.TargetType == TouchpadTargetType.Axis && axis == touchpadAction.Axis)
+                        matchingTargetVm = mappingTargetVm;
+                }
+
+                foreach (ButtonFlags button in TouchpadActions.GetButtonTargets(controller))
+                {
+                    var mappingTargetVm = CreateTarget(button, controller.GetButtonName(button));
+                    targets.Add(mappingTargetVm);
+
+                    if (touchpadAction.TargetType == TouchpadTargetType.Button && button == touchpadAction.Button)
+                        matchingTargetVm = mappingTargetVm;
+                }
+
+                if (matchingTargetVm is null && preserveMissingTarget)
+                {
+                    if (touchpadAction.TargetType == TouchpadTargetType.Axis && touchpadAction.Axis != AxisLayoutFlags.None)
+                    {
+                        matchingTargetVm = CreateUnsupportedTarget(touchpadAction.Axis,
+                            controller.GetAxisName(touchpadAction.Axis));
+                        targets.Add(matchingTargetVm);
+                    }
+                    else if (touchpadAction.TargetType == TouchpadTargetType.Button && touchpadAction.Button != ButtonFlags.None)
+                    {
+                        matchingTargetVm = CreateUnsupportedTarget(touchpadAction.Button,
+                            controller.GetButtonName(touchpadAction.Button));
+                        targets.Add(matchingTargetVm);
+                    }
                 }
 
                 ReplaceTargets(targets, matchingTargetVm);
@@ -849,8 +902,13 @@ namespace HandheldCompanion.ViewModels
             {
                 case ActionType.Button:
                     if (SelectedTarget.Tag is ButtonFlags buttonFlags)
+                        ((ButtonActions)Action).Button = buttonFlags;
+                    break;
+
+                case ActionType.Touchpad:
+                    if (SelectedTarget.Tag is not null)
                     {
-                        SetButtonTarget(buttonFlags);
+                        SetTouchpadTarget(SelectedTarget.Tag);
                         OnPropertyChanged(string.Empty);
                     }
                     break;

--- a/HandheldCompanion/ViewModels/Layout/Mappings/AxisMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/AxisMappingViewModel.cs
@@ -751,6 +751,9 @@ namespace HandheldCompanion.ViewModels
                 MappingTargetViewModel? matchingTargetVm = null;
                 foreach (var button in controller.GetTargetButtons())
                 {
+                    if (TouchpadActions.IsTouchpadTarget(button))
+                        continue;
+
                     var mappingTargetVm = CreateTarget(button, controller.GetButtonName(button));
                     targets.Add(mappingTargetVm);
 

--- a/HandheldCompanion/ViewModels/Layout/Mappings/AxisMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/AxisMappingViewModel.cs
@@ -379,7 +379,7 @@ namespace HandheldCompanion.ViewModels
         private int _responseCurveDragIndex = -1;
         private const double Epsilon = 0.0001;
 
-        public Func<double, string> ResponseCurveAxisYFormatter { get; } = v => v.ToString("0.0");
+        public Func<double, string> ResponseCurveAxisYFormatter { get; } = v => Math.Round(v, 1).ToString("0.0");
 
         public event Action<double[]>? ResponseCurveUpdateRequested;
 

--- a/HandheldCompanion/ViewModels/Layout/Mappings/AxisMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/AxisMappingViewModel.cs
@@ -356,6 +356,7 @@ namespace HandheldCompanion.ViewModels
                     OnPropertyChanged(nameof(AxisThresholdVisibility));
                     OnPropertyChanged(nameof(GeneralActionVisibility));
                     OnPropertyChanged(nameof(AxisInvertVisibility));
+                    OnPropertyChanged(nameof(TouchpadVisualizerVisibility));
                     break;
             }
 

--- a/HandheldCompanion/ViewModels/Layout/Mappings/AxisMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/AxisMappingViewModel.cs
@@ -377,6 +377,12 @@ namespace HandheldCompanion.ViewModels
         public override Visibility Axis2JoystickVisibility => Axis2MouseVisibility == Visibility.Visible && JoystickVisibility == Visibility.Visible ? Visibility.Visible : Visibility.Collapsed;
 
         public override bool IsAxisMapping => true;
+        public override Visibility TouchpadSettingsVisibility =>
+            ActionTypeIndex == (int)ActionType.Button && Action is TouchpadActions
+                ? Visibility.Visible : Visibility.Collapsed;
+        public override Visibility TouchpadSwipeSettingsVisibility =>
+            ActionTypeIndex == (int)ActionType.Button && Action is TouchpadActions { Button: ButtonFlags.TouchpadSwipe }
+                ? Visibility.Visible : Visibility.Collapsed;
 
         // Axis Direction and Threshold are only visible when converting Axis to Button
         public override Visibility AxisDirectionVisibility => Axis2ButtonVisibility;
@@ -749,7 +755,7 @@ namespace HandheldCompanion.ViewModels
                 }
 
                 MappingTargetViewModel? matchingTargetVm = null;
-                foreach (var button in controller.GetTargetButtons())
+                foreach (var button in GetButtonTargets(controller))
                 {
                     var mappingTargetVm = CreateTarget(button, controller.GetButtonName(button));
                     targets.Add(mappingTargetVm);
@@ -843,7 +849,10 @@ namespace HandheldCompanion.ViewModels
             {
                 case ActionType.Button:
                     if (SelectedTarget.Tag is ButtonFlags buttonFlags)
-                        ((ButtonActions)Action).Button = buttonFlags;
+                    {
+                        SetButtonTarget(buttonFlags);
+                        OnPropertyChanged(string.Empty);
+                    }
                     break;
 
                 case ActionType.Keyboard:

--- a/HandheldCompanion/ViewModels/Layout/Mappings/ButtonMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/ButtonMappingViewModel.cs
@@ -17,6 +17,19 @@ namespace HandheldCompanion.ViewModels
 {
     public class ButtonMappingViewModel : MappingViewModel
     {
+        public override ActionType[] SupportedActionTypes =>
+        [
+            ActionType.Disabled,
+            ActionType.Button,
+            ActionType.Joystick,
+            ActionType.Keyboard,
+            ActionType.Mouse,
+            ActionType.Trigger,
+            ActionType.Shift,
+            ActionType.Inherit,
+            ActionType.Touchpad
+        ];
+
         private static HashSet<MouseActionsType> _unsupportedMouseActionTypes =
         [
             MouseActionsType.Move,

--- a/HandheldCompanion/ViewModels/Layout/Mappings/ButtonMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/ButtonMappingViewModel.cs
@@ -576,15 +576,6 @@ namespace HandheldCompanion.ViewModels
                         matchingTargetVm = mappingTargetVm;
                 }
 
-                foreach (AxisLayoutFlags axis in TouchpadActions.GetAxisTargets(controller))
-                {
-                    var mappingTargetVm = CreateTarget(axis, controller.GetAxisName(axis));
-                    targets.Add(mappingTargetVm);
-
-                    if (touchpadAction.TargetType == TouchpadTargetType.Axis && axis == touchpadAction.Axis)
-                        matchingTargetVm = mappingTargetVm;
-                }
-
                 if (matchingTargetVm is null && preserveMissingTarget)
                 {
                     if (touchpadAction.TargetType == TouchpadTargetType.Button && touchpadAction.Button != ButtonFlags.None)

--- a/HandheldCompanion/ViewModels/Layout/Mappings/ButtonMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/ButtonMappingViewModel.cs
@@ -348,10 +348,7 @@ namespace HandheldCompanion.ViewModels
                 if (Action is not null && value != HapticModeIndex)
                 {
                     Action.HapticMode = (HapticMode)value;
-                    Action.HapticOverride = true;
                     OnPropertyChanged(nameof(HapticModeIndex));
-                    OnPropertyChanged(nameof(UseGlobalTrackpadClickHaptics));
-                    OnPropertyChanged(nameof(HapticControlsEnabled));
                 }
             }
         }
@@ -364,10 +361,7 @@ namespace HandheldCompanion.ViewModels
                 if (Action is not null && value != HapticStrengthIndex)
                 {
                     Action.HapticStrength = (HapticStrength)value;
-                    Action.HapticOverride = true;
                     OnPropertyChanged(nameof(HapticStrengthIndex));
-                    OnPropertyChanged(nameof(UseGlobalTrackpadClickHaptics));
-                    OnPropertyChanged(nameof(HapticControlsEnabled));
                 }
             }
         }

--- a/HandheldCompanion/ViewModels/Layout/Mappings/ButtonMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/ButtonMappingViewModel.cs
@@ -464,6 +464,7 @@ namespace HandheldCompanion.ViewModels
                     OnPropertyChanged(nameof(AxisVisualizerAntiDeadzoneSize));
                     OnPropertyChanged(nameof(TouchpadSettingsVisibility));
                     OnPropertyChanged(nameof(TouchpadSwipeSettingsVisibility));
+                    OnPropertyChanged(nameof(TouchpadVisualizerVisibility));
                     break;
             }
 

--- a/HandheldCompanion/ViewModels/Layout/Mappings/ButtonMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/ButtonMappingViewModel.cs
@@ -382,6 +382,10 @@ namespace HandheldCompanion.ViewModels
         public Visibility TouchpadSettingsVisibility => Action is TouchpadActions ? Visibility.Visible : Visibility.Collapsed;
         public Visibility TouchpadSwipeSettingsVisibility => Action is TouchpadActions touchpad && touchpad.Button == ButtonFlags.TouchpadSwipe
             ? Visibility.Visible : Visibility.Collapsed;
+        public int TouchpadMaxX => DS4Touch.TOUCHPAD_WIDTH - 1;
+        public int TouchpadMaxY => DS4Touch.TOUCHPAD_HEIGHT - 1;
+        public double TouchpadMaxDuration => 5000.0;
+        public string TouchpadCoordinateRangeDescription => $"DualSense coordinates: X 0–{TouchpadMaxX}, Y 0–{TouchpadMaxY}";
         public int TouchpadX { get => Action is TouchpadActions a ? a.X : 0; set { if (Action is TouchpadActions a) { a.X = Math.Clamp(value, 0, DS4Touch.TOUCHPAD_WIDTH - 1); OnPropertyChanged(nameof(TouchpadX)); } } }
         public int TouchpadY { get => Action is TouchpadActions a ? a.Y : 0; set { if (Action is TouchpadActions a) { a.Y = Math.Clamp(value, 0, DS4Touch.TOUCHPAD_HEIGHT - 1); OnPropertyChanged(nameof(TouchpadY)); } } }
         public int TouchpadEndX { get => Action is TouchpadActions a ? a.EndX : 0; set { if (Action is TouchpadActions a) { a.EndX = Math.Clamp(value, 0, DS4Touch.TOUCHPAD_WIDTH - 1); OnPropertyChanged(nameof(TouchpadEndX)); } } }
@@ -651,9 +655,17 @@ namespace HandheldCompanion.ViewModels
                             ButtonFlags.TouchpadCoordinateTouch or ButtonFlags.TouchpadSwipe;
 
                         if (isTouchpadAction && Action is not TouchpadActions)
-                            Action = new TouchpadActions(buttonFlags) { pressType = (PressType)_pressTypeFallbackIndex };
+                        {
+                            IActions previous = Action;
+                            Action = new TouchpadActions(buttonFlags);
+                            Action.CopyConfigurationFrom(previous);
+                        }
                         else if (!isTouchpadAction && Action is TouchpadActions)
-                            Action = new ButtonActions(buttonFlags) { pressType = (PressType)_pressTypeFallbackIndex };
+                        {
+                            IActions previous = Action;
+                            Action = new ButtonActions(buttonFlags);
+                            Action.CopyConfigurationFrom(previous);
+                        }
                         else
                             ((ButtonActions)Action).Button = buttonFlags;
 

--- a/HandheldCompanion/ViewModels/Layout/Mappings/ButtonMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/ButtonMappingViewModel.cs
@@ -225,7 +225,12 @@ namespace HandheldCompanion.ViewModels
 
         public override int Button2AxisX
         {
-            get => (Action is AxisActions axisAction) ? axisAction.ButtonX : 0;
+            get => Action switch
+            {
+                AxisActions axisAction => axisAction.ButtonX,
+                TouchpadActions { TargetType: TouchpadTargetType.Axis } touchpadAction => touchpadAction.ButtonX,
+                _ => 0,
+            };
             set
             {
                 if (Action is AxisActions axisAction && value != Button2AxisX)
@@ -235,12 +240,24 @@ namespace HandheldCompanion.ViewModels
                     OnPropertyChanged(nameof(AxisVisualizerDotX));
                     OnPropertyChanged(nameof(AxisVisualizerDotTranslateX));
                 }
+                else if (Action is TouchpadActions { TargetType: TouchpadTargetType.Axis } touchpadAction && value != Button2AxisX)
+                {
+                    touchpadAction.ButtonX = (short)Math.Clamp(value, short.MinValue, short.MaxValue);
+                    OnPropertyChanged(nameof(Button2AxisX));
+                    OnPropertyChanged(nameof(AxisVisualizerDotX));
+                    OnPropertyChanged(nameof(AxisVisualizerDotTranslateX));
+                }
             }
         }
 
         public override int Button2AxisY
         {
-            get => (Action is AxisActions axisAction) ? axisAction.ButtonY : 0;
+            get => Action switch
+            {
+                AxisActions axisAction => axisAction.ButtonY,
+                TouchpadActions { TargetType: TouchpadTargetType.Axis } touchpadAction => touchpadAction.ButtonY,
+                _ => 0,
+            };
             set
             {
                 if (Action is AxisActions axisAction && value != Button2AxisY)
@@ -250,12 +267,25 @@ namespace HandheldCompanion.ViewModels
                     OnPropertyChanged(nameof(AxisVisualizerDotY));
                     OnPropertyChanged(nameof(AxisVisualizerDotTranslateY));
                 }
+                else if (Action is TouchpadActions { TargetType: TouchpadTargetType.Axis } touchpadAction && value != Button2AxisY)
+                {
+                    touchpadAction.ButtonY = (short)Math.Clamp(value, short.MinValue, short.MaxValue);
+                    OnPropertyChanged(nameof(Button2AxisY));
+                    OnPropertyChanged(nameof(AxisVisualizerDotY));
+                    OnPropertyChanged(nameof(AxisVisualizerDotTranslateY));
+                }
             }
         }
 
-        public override Visibility Button2AxisVisibility => ActionTypeIndex == (int)ActionType.Joystick ? Visibility.Visible : Visibility.Collapsed;
-        public override Visibility AxisInvertVisibility => Button2AxisVisibility;
-        public override Visibility AxisVisualizerVisibility => ActionTypeIndex == (int)ActionType.Joystick ? Visibility.Visible : Visibility.Collapsed;
+        public override Visibility Button2AxisVisibility =>
+            ActionTypeIndex == (int)ActionType.Joystick ||
+            ActionTypeIndex == (int)ActionType.Touchpad &&
+            Action is TouchpadActions { TargetType: TouchpadTargetType.Axis }
+                ? Visibility.Visible
+                : Visibility.Collapsed;
+        public override Visibility AxisInvertVisibility =>
+            ActionTypeIndex == (int)ActionType.Joystick ? Visibility.Visible : Visibility.Collapsed;
+        public override Visibility AxisVisualizerVisibility => Button2AxisVisibility;
 
         public override double AxisVisualizerDotX => GetVisualizerDotOffset(GetVisualizerVector().X);
         public override double AxisVisualizerDotY => GetVisualizerDotOffset(GetVisualizerVector().Y);
@@ -267,10 +297,10 @@ namespace HandheldCompanion.ViewModels
 
         private Vector2 GetVisualizerVector()
         {
-            if (Action is not AxisActions axisAction)
-                return Vector2.Zero;
-
             Vector2 vector = new(Button2AxisX, Button2AxisY);
+
+            if (Action is not AxisActions axisAction)
+                return vector;
 
             return axisAction.OutputShape switch
             {
@@ -305,7 +335,10 @@ namespace HandheldCompanion.ViewModels
                 if (Action is not null && value != HapticModeIndex)
                 {
                     Action.HapticMode = (HapticMode)value;
+                    Action.HapticOverride = true;
                     OnPropertyChanged(nameof(HapticModeIndex));
+                    OnPropertyChanged(nameof(UseGlobalTrackpadClickHaptics));
+                    OnPropertyChanged(nameof(HapticControlsEnabled));
                 }
             }
         }
@@ -318,7 +351,10 @@ namespace HandheldCompanion.ViewModels
                 if (Action is not null && value != HapticStrengthIndex)
                 {
                     Action.HapticStrength = (HapticStrength)value;
+                    Action.HapticOverride = true;
                     OnPropertyChanged(nameof(HapticStrengthIndex));
+                    OnPropertyChanged(nameof(UseGlobalTrackpadClickHaptics));
+                    OnPropertyChanged(nameof(HapticControlsEnabled));
                 }
             }
         }
@@ -380,10 +416,13 @@ namespace HandheldCompanion.ViewModels
         }
 
         public override Visibility TouchpadSettingsVisibility =>
-            ActionTypeIndex == (int)ActionType.Button && Action is TouchpadActions
+            ActionTypeIndex == (int)ActionType.Touchpad &&
+            Action is TouchpadActions { TargetType: TouchpadTargetType.Button } touchpadAction &&
+            TouchpadActions.IsCoordinateTarget(touchpadAction.Button)
                 ? Visibility.Visible : Visibility.Collapsed;
         public override Visibility TouchpadSwipeSettingsVisibility =>
-            ActionTypeIndex == (int)ActionType.Button && Action is TouchpadActions { Button: ButtonFlags.TouchpadSwipe }
+            ActionTypeIndex == (int)ActionType.Touchpad &&
+            Action is TouchpadActions { TargetType: TouchpadTargetType.Button, Button: ButtonFlags.TouchpadSwipe }
                 ? Visibility.Visible : Visibility.Collapsed;
 
         public override void OnPropertyChanged(string? propertyName)
@@ -501,6 +540,55 @@ namespace HandheldCompanion.ViewModels
 
                 ReplaceTargets(targets, matchingTargetVm);
             }
+            else if (actionType == ActionType.Touchpad)
+            {
+                bool preserveMissingTarget = Action is TouchpadActions;
+                TouchpadActions touchpadAction = Action as TouchpadActions ?? new TouchpadActions
+                {
+                    pressType = fallbackPressType,
+                    ShiftSlot = ShiftSlot.Any,
+                    ShiftMatchAny = false
+                };
+                if (!preserveMissingTarget)
+                    Action = touchpadAction;
+
+                MappingTargetViewModel? matchingTargetVm = null;
+                foreach (ButtonFlags button in TouchpadActions.GetButtonTargets(controller))
+                {
+                    var mappingTargetVm = CreateTarget(button, controller.GetButtonName(button));
+                    targets.Add(mappingTargetVm);
+
+                    if (touchpadAction.TargetType == TouchpadTargetType.Button && button == touchpadAction.Button)
+                        matchingTargetVm = mappingTargetVm;
+                }
+
+                foreach (AxisLayoutFlags axis in TouchpadActions.GetAxisTargets(controller))
+                {
+                    var mappingTargetVm = CreateTarget(axis, controller.GetAxisName(axis));
+                    targets.Add(mappingTargetVm);
+
+                    if (touchpadAction.TargetType == TouchpadTargetType.Axis && axis == touchpadAction.Axis)
+                        matchingTargetVm = mappingTargetVm;
+                }
+
+                if (matchingTargetVm is null && preserveMissingTarget)
+                {
+                    if (touchpadAction.TargetType == TouchpadTargetType.Button && touchpadAction.Button != ButtonFlags.None)
+                    {
+                        matchingTargetVm = CreateUnsupportedTarget(touchpadAction.Button,
+                            controller.GetButtonName(touchpadAction.Button));
+                        targets.Add(matchingTargetVm);
+                    }
+                    else if (touchpadAction.TargetType == TouchpadTargetType.Axis && touchpadAction.Axis != AxisLayoutFlags.None)
+                    {
+                        matchingTargetVm = CreateUnsupportedTarget(touchpadAction.Axis,
+                            controller.GetAxisName(touchpadAction.Axis));
+                        targets.Add(matchingTargetVm);
+                    }
+                }
+
+                ReplaceTargets(targets, matchingTargetVm);
+            }
             else if (actionType == ActionType.Keyboard)
             {
                 if (Action is null || Action is not KeyboardActions)
@@ -530,7 +618,7 @@ namespace HandheldCompanion.ViewModels
                 }
 
                 MappingTargetViewModel? matchingTargetVm = null;
-                foreach (var axis in controller.GetTargetAxis())
+                foreach (var axis in GetJoystickTargets(controller))
                 {
                     var mappingTargetVm = CreateTarget(axis, controller.GetAxisName(axis));
                     targets.Add(mappingTargetVm);
@@ -644,9 +732,13 @@ namespace HandheldCompanion.ViewModels
             {
                 case ActionType.Button:
                     if (SelectedTarget.Tag is ButtonFlags buttonFlags)
-                    {
-                        SetButtonTarget(buttonFlags);
+                        ((ButtonActions)Action).Button = buttonFlags;
+                    break;
 
+                case ActionType.Touchpad:
+                    if (SelectedTarget.Tag is not null)
+                    {
+                        SetTouchpadTarget(SelectedTarget.Tag);
                         OnPropertyChanged(string.Empty);
                     }
                     break;

--- a/HandheldCompanion/ViewModels/Layout/Mappings/ButtonMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/ButtonMappingViewModel.cs
@@ -380,9 +380,12 @@ namespace HandheldCompanion.ViewModels
             }
         }
 
-        public Visibility TouchpadSettingsVisibility => Action is TouchpadActions ? Visibility.Visible : Visibility.Collapsed;
-        public Visibility TouchpadSwipeSettingsVisibility => Action is TouchpadActions touchpad && touchpad.Button == ButtonFlags.TouchpadSwipe
-            ? Visibility.Visible : Visibility.Collapsed;
+        public override Visibility TouchpadSettingsVisibility =>
+            ActionTypeIndex == (int)ActionType.Button && Action is TouchpadActions
+                ? Visibility.Visible : Visibility.Collapsed;
+        public override Visibility TouchpadSwipeSettingsVisibility =>
+            ActionTypeIndex == (int)ActionType.Button && Action is TouchpadActions { Button: ButtonFlags.TouchpadSwipe }
+                ? Visibility.Visible : Visibility.Collapsed;
         public int TouchpadMaxX => DS4Touch.TOUCHPAD_WIDTH - 1;
         public int TouchpadMaxY => DS4Touch.TOUCHPAD_HEIGHT - 1;
         public double TouchpadMaxDuration => TouchpadActions.MaximumSwipeDuration;

--- a/HandheldCompanion/ViewModels/Layout/Mappings/ButtonMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/ButtonMappingViewModel.cs
@@ -1,7 +1,6 @@
 ﻿using GregsStack.InputSimulatorStandard.Native;
 using HandheldCompanion.Actions;
 using HandheldCompanion.Controllers;
-using HandheldCompanion.Controllers.Dummies;
 using HandheldCompanion.Inputs;
 using HandheldCompanion.Managers;
 using HandheldCompanion.Properties;
@@ -386,15 +385,6 @@ namespace HandheldCompanion.ViewModels
         public override Visibility TouchpadSwipeSettingsVisibility =>
             ActionTypeIndex == (int)ActionType.Button && Action is TouchpadActions { Button: ButtonFlags.TouchpadSwipe }
                 ? Visibility.Visible : Visibility.Collapsed;
-        public int TouchpadMaxX => DS4Touch.TOUCHPAD_WIDTH - 1;
-        public int TouchpadMaxY => DS4Touch.TOUCHPAD_HEIGHT - 1;
-        public double TouchpadMaxDuration => TouchpadActions.MaximumSwipeDuration;
-        public string TouchpadCoordinateRangeDescription => $"DualSense coordinates: X 0–{TouchpadMaxX}, Y 0–{TouchpadMaxY}";
-        public int TouchpadX { get => Action is TouchpadActions a ? a.X : 0; set { if (Action is TouchpadActions a) { a.X = value; OnPropertyChanged(nameof(TouchpadX)); } } }
-        public int TouchpadY { get => Action is TouchpadActions a ? a.Y : 0; set { if (Action is TouchpadActions a) { a.Y = value; OnPropertyChanged(nameof(TouchpadY)); } } }
-        public int TouchpadEndX { get => Action is TouchpadActions a ? a.EndX : 0; set { if (Action is TouchpadActions a) { a.EndX = value; OnPropertyChanged(nameof(TouchpadEndX)); } } }
-        public int TouchpadEndY { get => Action is TouchpadActions a ? a.EndY : 0; set { if (Action is TouchpadActions a) { a.EndY = value; OnPropertyChanged(nameof(TouchpadEndY)); } } }
-        public double TouchpadSwipeDuration { get => Action is TouchpadActions a ? a.SwipeDuration : TouchpadActions.DefaultSwipeDuration; set { if (Action is TouchpadActions a) { a.SwipeDuration = (float)value; OnPropertyChanged(nameof(TouchpadSwipeDuration)); } } }
 
         public override void OnPropertyChanged(string? propertyName)
         {
@@ -493,27 +483,13 @@ namespace HandheldCompanion.ViewModels
                 }
 
                 MappingTargetViewModel? matchingTargetVm = null;
-                foreach (var button in controller.GetTargetButtons())
+                foreach (var button in GetButtonTargets(controller))
                 {
                     var mappingTargetVm = CreateTarget(button, controller.GetButtonName(button));
                     targets.Add(mappingTargetVm);
 
                     if (button == ((ButtonActions)Action).Button)
                         matchingTargetVm = mappingTargetVm;
-                }
-
-                // Parameterized touchpad gestures are mapping actions rather than
-                // physical controller buttons. Expose them only in the button editor.
-                if (controller is DummyDualSenseController)
-                {
-                    foreach (var button in TouchpadActions.Targets)
-                    {
-                        var mappingTargetVm = CreateTarget(button, controller.GetButtonName(button));
-                        targets.Add(mappingTargetVm);
-
-                        if (button == ((ButtonActions)Action).Button)
-                            matchingTargetVm = mappingTargetVm;
-                    }
                 }
 
                 if (matchingTargetVm is null && preserveMissingTarget)
@@ -669,22 +645,7 @@ namespace HandheldCompanion.ViewModels
                 case ActionType.Button:
                     if (SelectedTarget.Tag is ButtonFlags buttonFlags)
                     {
-                        bool isTouchpadAction = TouchpadActions.IsTouchpadTarget(buttonFlags);
-
-                        if (isTouchpadAction && Action is not TouchpadActions)
-                        {
-                            IActions previous = Action;
-                            Action = new TouchpadActions(buttonFlags);
-                            Action.CopyConfigurationFrom(previous);
-                        }
-                        else if (!isTouchpadAction && Action is TouchpadActions)
-                        {
-                            IActions previous = Action;
-                            Action = new ButtonActions(buttonFlags);
-                            Action.CopyConfigurationFrom(previous);
-                        }
-                        else
-                            ((ButtonActions)Action).Button = buttonFlags;
+                        SetButtonTarget(buttonFlags);
 
                         OnPropertyChanged(string.Empty);
                     }

--- a/HandheldCompanion/ViewModels/Layout/Mappings/ButtonMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/ButtonMappingViewModel.cs
@@ -379,6 +379,15 @@ namespace HandheldCompanion.ViewModels
             }
         }
 
+        public Visibility TouchpadSettingsVisibility => Action is TouchpadActions ? Visibility.Visible : Visibility.Collapsed;
+        public Visibility TouchpadSwipeSettingsVisibility => Action is TouchpadActions touchpad && touchpad.Button == ButtonFlags.TouchpadSwipe
+            ? Visibility.Visible : Visibility.Collapsed;
+        public int TouchpadX { get => Action is TouchpadActions a ? a.X : 0; set { if (Action is TouchpadActions a) { a.X = Math.Clamp(value, 0, DS4Touch.TOUCHPAD_WIDTH - 1); OnPropertyChanged(nameof(TouchpadX)); } } }
+        public int TouchpadY { get => Action is TouchpadActions a ? a.Y : 0; set { if (Action is TouchpadActions a) { a.Y = Math.Clamp(value, 0, DS4Touch.TOUCHPAD_HEIGHT - 1); OnPropertyChanged(nameof(TouchpadY)); } } }
+        public int TouchpadEndX { get => Action is TouchpadActions a ? a.EndX : 0; set { if (Action is TouchpadActions a) { a.EndX = Math.Clamp(value, 0, DS4Touch.TOUCHPAD_WIDTH - 1); OnPropertyChanged(nameof(TouchpadEndX)); } } }
+        public int TouchpadEndY { get => Action is TouchpadActions a ? a.EndY : 0; set { if (Action is TouchpadActions a) { a.EndY = Math.Clamp(value, 0, DS4Touch.TOUCHPAD_HEIGHT - 1); OnPropertyChanged(nameof(TouchpadEndY)); } } }
+        public double TouchpadSwipeDuration { get => Action is TouchpadActions a ? a.SwipeDuration : 300.0; set { if (Action is TouchpadActions a) { a.SwipeDuration = (float)Math.Clamp(value, 16.0, 5000.0); OnPropertyChanged(nameof(TouchpadSwipeDuration)); } } }
+
         public override void OnPropertyChanged(string? propertyName)
         {
             switch (propertyName)
@@ -403,6 +412,8 @@ namespace HandheldCompanion.ViewModels
                     OnPropertyChanged(nameof(AxisVisualizerInnerDeadzoneSize));
                     OnPropertyChanged(nameof(AxisVisualizerOuterDeadzoneSize));
                     OnPropertyChanged(nameof(AxisVisualizerAntiDeadzoneSize));
+                    OnPropertyChanged(nameof(TouchpadSettingsVisibility));
+                    OnPropertyChanged(nameof(TouchpadSwipeSettingsVisibility));
                     break;
             }
 
@@ -635,7 +646,19 @@ namespace HandheldCompanion.ViewModels
             {
                 case ActionType.Button:
                     if (SelectedTarget.Tag is ButtonFlags buttonFlags)
-                        ((ButtonActions)Action).Button = buttonFlags;
+                    {
+                        bool isTouchpadAction = buttonFlags is ButtonFlags.TouchpadCoordinateClick or
+                            ButtonFlags.TouchpadCoordinateTouch or ButtonFlags.TouchpadSwipe;
+
+                        if (isTouchpadAction && Action is not TouchpadActions)
+                            Action = new TouchpadActions(buttonFlags) { pressType = (PressType)_pressTypeFallbackIndex };
+                        else if (!isTouchpadAction && Action is TouchpadActions)
+                            Action = new ButtonActions(buttonFlags) { pressType = (PressType)_pressTypeFallbackIndex };
+                        else
+                            ((ButtonActions)Action).Button = buttonFlags;
+
+                        OnPropertyChanged(string.Empty);
+                    }
                     break;
 
                 case ActionType.Keyboard:

--- a/HandheldCompanion/ViewModels/Layout/Mappings/ButtonMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/ButtonMappingViewModel.cs
@@ -391,7 +391,7 @@ namespace HandheldCompanion.ViewModels
         public int TouchpadY { get => Action is TouchpadActions a ? a.Y : 0; set { if (Action is TouchpadActions a) { a.Y = value; OnPropertyChanged(nameof(TouchpadY)); } } }
         public int TouchpadEndX { get => Action is TouchpadActions a ? a.EndX : 0; set { if (Action is TouchpadActions a) { a.EndX = value; OnPropertyChanged(nameof(TouchpadEndX)); } } }
         public int TouchpadEndY { get => Action is TouchpadActions a ? a.EndY : 0; set { if (Action is TouchpadActions a) { a.EndY = value; OnPropertyChanged(nameof(TouchpadEndY)); } } }
-        public double TouchpadSwipeDuration { get => Action is TouchpadActions a ? a.SwipeDuration : 300.0; set { if (Action is TouchpadActions a) { a.SwipeDuration = (float)value; OnPropertyChanged(nameof(TouchpadSwipeDuration)); } } }
+        public double TouchpadSwipeDuration { get => Action is TouchpadActions a ? a.SwipeDuration : TouchpadActions.DefaultSwipeDuration; set { if (Action is TouchpadActions a) { a.SwipeDuration = (float)value; OnPropertyChanged(nameof(TouchpadSwipeDuration)); } } }
 
         public override void OnPropertyChanged(string? propertyName)
         {

--- a/HandheldCompanion/ViewModels/Layout/Mappings/ButtonMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/ButtonMappingViewModel.cs
@@ -431,7 +431,7 @@ namespace HandheldCompanion.ViewModels
         public override Visibility TouchpadSettingsVisibility =>
             ActionTypeIndex == (int)ActionType.Touchpad &&
             Action is TouchpadActions { TargetType: TouchpadTargetType.Button } touchpadAction &&
-            TouchpadActions.IsCoordinateTarget(touchpadAction.Button)
+            TouchpadActions.IsGestureTarget(touchpadAction.Button)
                 ? Visibility.Visible : Visibility.Collapsed;
         public override Visibility TouchpadSwipeSettingsVisibility =>
             ActionTypeIndex == (int)ActionType.Touchpad &&

--- a/HandheldCompanion/ViewModels/Layout/Mappings/ButtonMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/ButtonMappingViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using GregsStack.InputSimulatorStandard.Native;
 using HandheldCompanion.Actions;
 using HandheldCompanion.Controllers;
+using HandheldCompanion.Controllers.Dummies;
 using HandheldCompanion.Inputs;
 using HandheldCompanion.Managers;
 using HandheldCompanion.Properties;
@@ -384,13 +385,13 @@ namespace HandheldCompanion.ViewModels
             ? Visibility.Visible : Visibility.Collapsed;
         public int TouchpadMaxX => DS4Touch.TOUCHPAD_WIDTH - 1;
         public int TouchpadMaxY => DS4Touch.TOUCHPAD_HEIGHT - 1;
-        public double TouchpadMaxDuration => 5000.0;
+        public double TouchpadMaxDuration => TouchpadActions.MaximumSwipeDuration;
         public string TouchpadCoordinateRangeDescription => $"DualSense coordinates: X 0–{TouchpadMaxX}, Y 0–{TouchpadMaxY}";
-        public int TouchpadX { get => Action is TouchpadActions a ? a.X : 0; set { if (Action is TouchpadActions a) { a.X = Math.Clamp(value, 0, DS4Touch.TOUCHPAD_WIDTH - 1); OnPropertyChanged(nameof(TouchpadX)); } } }
-        public int TouchpadY { get => Action is TouchpadActions a ? a.Y : 0; set { if (Action is TouchpadActions a) { a.Y = Math.Clamp(value, 0, DS4Touch.TOUCHPAD_HEIGHT - 1); OnPropertyChanged(nameof(TouchpadY)); } } }
-        public int TouchpadEndX { get => Action is TouchpadActions a ? a.EndX : 0; set { if (Action is TouchpadActions a) { a.EndX = Math.Clamp(value, 0, DS4Touch.TOUCHPAD_WIDTH - 1); OnPropertyChanged(nameof(TouchpadEndX)); } } }
-        public int TouchpadEndY { get => Action is TouchpadActions a ? a.EndY : 0; set { if (Action is TouchpadActions a) { a.EndY = Math.Clamp(value, 0, DS4Touch.TOUCHPAD_HEIGHT - 1); OnPropertyChanged(nameof(TouchpadEndY)); } } }
-        public double TouchpadSwipeDuration { get => Action is TouchpadActions a ? a.SwipeDuration : 300.0; set { if (Action is TouchpadActions a) { a.SwipeDuration = (float)Math.Clamp(value, 16.0, 5000.0); OnPropertyChanged(nameof(TouchpadSwipeDuration)); } } }
+        public int TouchpadX { get => Action is TouchpadActions a ? a.X : 0; set { if (Action is TouchpadActions a) { a.X = value; OnPropertyChanged(nameof(TouchpadX)); } } }
+        public int TouchpadY { get => Action is TouchpadActions a ? a.Y : 0; set { if (Action is TouchpadActions a) { a.Y = value; OnPropertyChanged(nameof(TouchpadY)); } } }
+        public int TouchpadEndX { get => Action is TouchpadActions a ? a.EndX : 0; set { if (Action is TouchpadActions a) { a.EndX = value; OnPropertyChanged(nameof(TouchpadEndX)); } } }
+        public int TouchpadEndY { get => Action is TouchpadActions a ? a.EndY : 0; set { if (Action is TouchpadActions a) { a.EndY = value; OnPropertyChanged(nameof(TouchpadEndY)); } } }
+        public double TouchpadSwipeDuration { get => Action is TouchpadActions a ? a.SwipeDuration : 300.0; set { if (Action is TouchpadActions a) { a.SwipeDuration = (float)value; OnPropertyChanged(nameof(TouchpadSwipeDuration)); } } }
 
         public override void OnPropertyChanged(string? propertyName)
         {
@@ -496,6 +497,20 @@ namespace HandheldCompanion.ViewModels
 
                     if (button == ((ButtonActions)Action).Button)
                         matchingTargetVm = mappingTargetVm;
+                }
+
+                // Parameterized touchpad gestures are mapping actions rather than
+                // physical controller buttons. Expose them only in the button editor.
+                if (controller is DummyDualSenseController)
+                {
+                    foreach (var button in TouchpadActions.Targets)
+                    {
+                        var mappingTargetVm = CreateTarget(button, controller.GetButtonName(button));
+                        targets.Add(mappingTargetVm);
+
+                        if (button == ((ButtonActions)Action).Button)
+                            matchingTargetVm = mappingTargetVm;
+                    }
                 }
 
                 if (matchingTargetVm is null && preserveMissingTarget)
@@ -651,8 +666,7 @@ namespace HandheldCompanion.ViewModels
                 case ActionType.Button:
                     if (SelectedTarget.Tag is ButtonFlags buttonFlags)
                     {
-                        bool isTouchpadAction = buttonFlags is ButtonFlags.TouchpadCoordinateClick or
-                            ButtonFlags.TouchpadCoordinateTouch or ButtonFlags.TouchpadSwipe;
+                        bool isTouchpadAction = TouchpadActions.IsTouchpadTarget(buttonFlags);
 
                         if (isTouchpadAction && Action is not TouchpadActions)
                         {

--- a/HandheldCompanion/ViewModels/Layout/Mappings/GyroMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/GyroMappingViewModel.cs
@@ -297,7 +297,8 @@ namespace HandheldCompanion.ViewModels
 
             if (actionType == ActionType.Joystick)
             {
-                if (Action is null || Action is not AxisActions)
+                bool preserveMissingTarget = Action is AxisActions;
+                if (!preserveMissingTarget)
                 {
                     Action = new AxisActions()
                     {
@@ -308,7 +309,7 @@ namespace HandheldCompanion.ViewModels
                 }
 
                 MappingTargetViewModel? matchingTargetVm = null;
-                foreach (var axis in controller.GetTargetAxis())
+                foreach (var axis in GetJoystickTargets(controller))
                 {
                     var mappingTargetVm = new MappingTargetViewModel
                     {
@@ -323,13 +324,45 @@ namespace HandheldCompanion.ViewModels
                     }
                 }
 
-                lock (_collectionLock)
+                if (matchingTargetVm is null && preserveMissingTarget)
                 {
-                    Targets.Clear();
-                    foreach (var t in targets)
-                        Targets.Add(t);
+                    matchingTargetVm = CreateUnsupportedTarget(((AxisActions)Action).Axis,
+                        controller.GetAxisName(((AxisActions)Action).Axis));
+                    targets.Add(matchingTargetVm);
                 }
-                SelectedTarget = matchingTargetVm ?? Targets.First();
+
+                ReplaceTargets(targets, matchingTargetVm);
+            }
+            else if (actionType == ActionType.Touchpad)
+            {
+                bool preserveMissingTarget = Action is TouchpadActions;
+                TouchpadActions touchpadAction = Action as TouchpadActions ?? new TouchpadActions
+                {
+                    MotionTrigger = (ButtonState)GyroHotkey.inputsChord.ButtonState.Clone()
+                };
+                if (!preserveMissingTarget)
+                    Action = touchpadAction;
+
+                MappingTargetViewModel? matchingTargetVm = null;
+                foreach (AxisLayoutFlags axis in TouchpadActions.GetAxisTargets(controller))
+                {
+                    var mappingTargetVm = CreateTarget(axis, controller.GetAxisName(axis));
+                    targets.Add(mappingTargetVm);
+
+                    if (touchpadAction.TargetType == TouchpadTargetType.Axis && axis == touchpadAction.Axis)
+                        matchingTargetVm = mappingTargetVm;
+                }
+
+                if (matchingTargetVm is null && preserveMissingTarget &&
+                    touchpadAction.TargetType == TouchpadTargetType.Axis &&
+                    touchpadAction.Axis != AxisLayoutFlags.None)
+                {
+                    matchingTargetVm = CreateUnsupportedTarget(touchpadAction.Axis,
+                        controller.GetAxisName(touchpadAction.Axis));
+                    targets.Add(matchingTargetVm);
+                }
+
+                ReplaceTargets(targets, matchingTargetVm);
             }
             else if (actionType == ActionType.Mouse)
             {
@@ -397,6 +430,11 @@ namespace HandheldCompanion.ViewModels
                 case ActionType.Mouse:
                     if (SelectedTarget.Tag is MouseActionsType mouseActionsType)
                         ((MouseActions)Action).MouseType = mouseActionsType;
+                    break;
+
+                case ActionType.Touchpad:
+                    if (SelectedTarget.Tag is not null)
+                        SetTouchpadTarget(SelectedTarget.Tag);
                     break;
             }
         }

--- a/HandheldCompanion/ViewModels/Layout/Mappings/GyroMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/GyroMappingViewModel.cs
@@ -15,6 +15,15 @@ namespace HandheldCompanion.ViewModels
 {
     public class GyroMappingViewModel : MappingViewModel
     {
+        public override ActionType[] SupportedActionTypes =>
+        [
+            ActionType.Disabled,
+            ActionType.Joystick,
+            ActionType.Mouse,
+            ActionType.Touchpad,
+            ActionType.Inherit
+        ];
+
         private static readonly HashSet<MouseActionsType> _unsupportedMouseActionTypes =
         [
             MouseActionsType.LeftButton,

--- a/HandheldCompanion/ViewModels/Layout/Mappings/MappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/MappingViewModel.cs
@@ -407,6 +407,18 @@ namespace HandheldCompanion.ViewModels
         public int TouchpadMaxX => DS4Touch.TOUCHPAD_WIDTH - 1;
         public int TouchpadMaxY => DS4Touch.TOUCHPAD_HEIGHT - 1;
         public double TouchpadMaxDuration => TouchpadActions.MaximumSwipeDuration;
+        public int TouchpadFingerIndex
+        {
+            get => Action is TouchpadActions a ? a.Finger - 1 : 0;
+            set
+            {
+                if (Action is TouchpadActions a && value is >= 0 and <= 1)
+                {
+                    a.Finger = (byte)(value + 1);
+                    OnPropertyChanged(nameof(TouchpadFingerIndex));
+                }
+            }
+        }
         public string TouchpadCoordinateRangeDescription => string.Format(
             Resources.LayoutPage_TouchpadCoordinateRange, TouchpadMaxX, TouchpadMaxY);
         public int TouchpadX { get => Action is TouchpadActions a ? a.X : 0; set { if (Action is TouchpadActions a) { a.X = value; OnPropertyChanged(nameof(TouchpadX)); NotifyTouchpadVisualizer(nameof(TouchpadVisualizerStartX), nameof(TouchpadVisualizerStartY), nameof(TouchpadVisualizerLineStartX), nameof(TouchpadVisualizerLineStartY)); } } }

--- a/HandheldCompanion/ViewModels/Layout/Mappings/MappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/MappingViewModel.cs
@@ -44,9 +44,12 @@ namespace HandheldCompanion.ViewModels
                 {
                     ActionTypeChanged((ActionType)value);
                     OnPropertyChanged(nameof(ActionTypeIndex));
+                    OnPropertyChanged(nameof(SupportedActionTypes));
                 }
             }
         }
+
+        public virtual ActionType[] SupportedActionTypes => [ActionType.Disabled];
 
         public string ActionTypeName => ((ActionType)ActionTypeIndex).ToString();
 
@@ -463,7 +466,7 @@ namespace HandheldCompanion.ViewModels
             get
             {
                 ActionType currentActionType = (ActionType)ActionTypeIndex;
-                if (currentActionType == ActionType.Touchpad && Button2AxisVisibility == Visibility.Visible)
+                if (currentActionType == ActionType.Touchpad || currentActionType == ActionType.Button || currentActionType == ActionType.Keyboard || currentActionType == ActionType.Mouse)
                     return Visibility.Visible;
 
                 if (currentActionType != ActionType.Joystick)

--- a/HandheldCompanion/ViewModels/Layout/Mappings/MappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/MappingViewModel.cs
@@ -342,6 +342,7 @@ namespace HandheldCompanion.ViewModels
         // Axis Direction and Threshold should only be visible for Axis mappings converting to Button
         public virtual Visibility AxisDirectionVisibility => Visibility.Collapsed;
         public virtual Visibility AxisThresholdVisibility => Visibility.Collapsed;
+        public virtual Visibility Trigger2ButtonVisibility => Visibility.Collapsed;
 
         public Visibility TouchpadActionTypeVisibility
         {
@@ -772,6 +773,8 @@ namespace HandheldCompanion.ViewModels
                     base.OnPropertyChanged(nameof(InputShiftDisplayName));
                     base.OnPropertyChanged(nameof(TouchpadActionTypeVisibility));
                     base.OnPropertyChanged(nameof(TouchpadAxisActionTypeVisibility));
+                    base.OnPropertyChanged(nameof(Axis2ButtonVisibility));
+                    base.OnPropertyChanged(nameof(Trigger2ButtonVisibility));
                     break;
             }
 

--- a/HandheldCompanion/ViewModels/Layout/Mappings/MappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/MappingViewModel.cs
@@ -396,6 +396,24 @@ namespace HandheldCompanion.ViewModels
             Action is TouchpadActions { TargetType: TouchpadTargetType.Button, Button: ButtonFlags.TouchpadSwipe }
                 ? Visibility.Visible
                 : Visibility.Collapsed;
+        public virtual Visibility TouchpadCoordinateSettingsVisibility =>
+            ActionTypeIndex == (int)ActionType.Touchpad &&
+            Action is TouchpadActions { TargetType: TouchpadTargetType.Button, Button: ButtonFlags.TouchpadClick or ButtonFlags.TouchpadTouch }
+                ? Visibility.Visible
+                : Visibility.Collapsed;
+        public virtual bool TouchpadUseCoordinates
+        {
+            get => Action is TouchpadActions a && a.UseCoordinates;
+            set
+            {
+                if (Action is TouchpadActions a && value != a.UseCoordinates)
+                {
+                    a.UseCoordinates = value;
+                    OnPropertyChanged(nameof(TouchpadUseCoordinates));
+                    OnPropertyChanged(nameof(TouchpadVisualizerVisibility));
+                }
+            }
+        }
         public virtual Visibility TouchpadVisualizerVisibility => TouchpadSettingsVisibility;
         public double TouchpadVisualizerStartX => TouchpadVisualizerPosition(TouchpadX, TouchpadMaxX, 232.0d);
         public double TouchpadVisualizerStartY => TouchpadVisualizerPosition(TouchpadY, TouchpadMaxY, 112.0d);
@@ -792,6 +810,7 @@ namespace HandheldCompanion.ViewModels
             nameof(InputShiftDisplayName),
             nameof(TouchpadActionTypeVisibility),
             nameof(TouchpadAxisActionTypeVisibility),
+            nameof(TouchpadCoordinateSettingsVisibility),
         ];
 
         public override void OnPropertyChanged(string? propertyName)

--- a/HandheldCompanion/ViewModels/Layout/Mappings/MappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/MappingViewModel.cs
@@ -601,10 +601,7 @@ namespace HandheldCompanion.ViewModels
                 if (Action is not null && value != HapticModeIndex)
                 {
                     Action.HapticMode = (HapticMode)value;
-                    Action.HapticOverride = true;
                     OnPropertyChanged(nameof(HapticModeIndex));
-                    OnPropertyChanged(nameof(UseGlobalTrackpadClickHaptics));
-                    OnPropertyChanged(nameof(HapticControlsEnabled));
                 }
             }
         }
@@ -617,36 +614,10 @@ namespace HandheldCompanion.ViewModels
                 if (Action is not null && value != HapticStrengthIndex)
                 {
                     Action.HapticStrength = (HapticStrength)value;
-                    Action.HapticOverride = true;
                     OnPropertyChanged(nameof(HapticStrengthIndex));
-                    OnPropertyChanged(nameof(UseGlobalTrackpadClickHaptics));
-                    OnPropertyChanged(nameof(HapticControlsEnabled));
                 }
             }
         }
-
-        public Visibility TrackpadClickHapticOverrideVisibility =>
-            Value is ButtonFlags button && TouchpadActions.IsPhysicalClick(button)
-                ? Visibility.Visible
-                : Visibility.Collapsed;
-
-        public bool UseGlobalTrackpadClickHaptics
-        {
-            get => Action is null || !TouchpadActions.HasCustomHapticSettings(Action);
-            set
-            {
-                if (Action is null || value == UseGlobalTrackpadClickHaptics)
-                    return;
-
-                Action.HapticOverride = !value;
-                OnPropertyChanged(nameof(UseGlobalTrackpadClickHaptics));
-                OnPropertyChanged(nameof(HapticControlsEnabled));
-            }
-        }
-
-        public bool HapticControlsEnabled =>
-            TrackpadClickHapticOverrideVisibility != Visibility.Visible ||
-            !UseGlobalTrackpadClickHaptics;
 
         #endregion
 
@@ -821,8 +792,6 @@ namespace HandheldCompanion.ViewModels
             nameof(InputShiftDisplayName),
             nameof(TouchpadActionTypeVisibility),
             nameof(TouchpadAxisActionTypeVisibility),
-            nameof(TrackpadClickHapticOverrideVisibility),
-            nameof(HapticControlsEnabled),
         ];
 
         public override void OnPropertyChanged(string? propertyName)

--- a/HandheldCompanion/ViewModels/Layout/Mappings/MappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/MappingViewModel.cs
@@ -32,6 +32,8 @@ namespace HandheldCompanion.ViewModels
 
     public abstract class MappingViewModel : BaseViewModel
     {
+        #region Core action properties
+
         protected object Value { get; set; }
         public IActions? Action { get; protected set; }
 
@@ -177,6 +179,10 @@ namespace HandheldCompanion.ViewModels
             }
         }
 
+        #endregion
+
+        #region Mouse mapping properties
+
         // Shows the Axis2 panel for Mouse actions of type Scroll or Move
         public Visibility Axis2MouseVisibility
         {
@@ -269,6 +275,17 @@ namespace HandheldCompanion.ViewModels
             set { }
         }
 
+        // Axis to Mouse properties (for Mouse actions) - default to 0/false
+        public virtual int Axis2MousePointerSpeed { get => 0; set { } }
+        public virtual float Axis2MouseAcceleration { get => 0; set { } }
+        public virtual int Axis2MouseDeadzone { get => 0; set { } }
+        public virtual bool Axis2MouseFiltering { get => false; set { } }
+        public virtual float Axis2MouseFilterCutoff { get => 0; set { } }
+
+        #endregion
+
+        #region Axis mapping properties
+
         // Axis direction properties (for Axis2Button) - default to false
         // These should only be visible for AxisMappingViewModel, not ButtonMappingViewModel
         public virtual bool IsUp { get => false; set { } }
@@ -278,20 +295,6 @@ namespace HandheldCompanion.ViewModels
 
         // Property to check if this is an Axis mapping (for visibility conditions)
         public virtual bool IsAxisMapping => false;
-
-        // Property to check if this is a Trigger mapping (for visibility conditions)
-        public virtual bool IsTriggerMapping => false;
-
-        // Trigger output (for Trigger actions) - default to 0
-        // Should only be visible for Button -> Trigger mappings
-        public virtual float TriggerOutput
-        {
-            get => 0;
-            set { }
-        }
-
-        // Visibility for Trigger output - only Button -> Trigger
-        public virtual Visibility TriggerOutputVisibility => Visibility.Collapsed;
 
         // Axis to Axis properties (for Joystick actions) - default to 0/false
         // Should only be visible for Axis -> Joystick mappings
@@ -319,6 +322,18 @@ namespace HandheldCompanion.ViewModels
         public virtual double AxisVisualizerOuterDeadzoneSize => 0.0d;
         public virtual double AxisVisualizerAntiDeadzoneSize => 0.0d;
 
+        // Axis visibility properties - default to Collapsed
+        public virtual Visibility Axis2TouchpadVisibility => Visibility.Collapsed;
+        public virtual Visibility Axis2JoystickVisibility => Visibility.Collapsed;
+
+        // Axis Direction and Threshold should only be visible for Axis mappings converting to Button
+        public virtual Visibility AxisDirectionVisibility => Visibility.Collapsed;
+        public virtual Visibility AxisThresholdVisibility => Visibility.Collapsed;
+
+        #endregion
+
+        #region Trigger mapping properties
+
         // Trigger to Trigger/Axis deadzone properties - default to 0
         // Should only be visible for Trigger -> Trigger/Axis mappings
         public virtual int Trigger2TriggerInnerDeadzone { get => 0; set { } }
@@ -328,21 +343,24 @@ namespace HandheldCompanion.ViewModels
         // Visibility for Trigger deadzone properties - only Trigger -> Trigger/Axis
         public virtual Visibility TriggerDeadzoneVisibility => Visibility.Collapsed;
 
-        // Axis to Mouse properties (for Mouse actions) - default to 0/false
-        public virtual int Axis2MousePointerSpeed { get => 0; set { } }
-        public virtual float Axis2MouseAcceleration { get => 0; set { } }
-        public virtual int Axis2MouseDeadzone { get => 0; set { } }
-        public virtual bool Axis2MouseFiltering { get => false; set { } }
-        public virtual float Axis2MouseFilterCutoff { get => 0; set { } }
+        // Property to check if this is a Trigger mapping (for visibility conditions)
+        public virtual bool IsTriggerMapping => false;
 
-        // Axis visibility properties - default to Collapsed
-        public virtual Visibility Axis2TouchpadVisibility => Visibility.Collapsed;
-        public virtual Visibility Axis2JoystickVisibility => Visibility.Collapsed;
+        // Trigger output (for Trigger actions) - default to 0
+        // Should only be visible for Button -> Trigger mappings
+        public virtual float TriggerOutput
+        {
+            get => 0;
+            set { }
+        }
 
-        // Axis Direction and Threshold should only be visible for Axis mappings converting to Button
-        public virtual Visibility AxisDirectionVisibility => Visibility.Collapsed;
-        public virtual Visibility AxisThresholdVisibility => Visibility.Collapsed;
+        // Visibility for Trigger output - only Button -> Trigger
+        public virtual Visibility TriggerOutputVisibility => Visibility.Collapsed;
         public virtual Visibility Trigger2ButtonVisibility => Visibility.Collapsed;
+
+        #endregion
+
+        #region Touchpad mapping properties
 
         public Visibility TouchpadActionTypeVisibility
         {
@@ -377,16 +395,34 @@ namespace HandheldCompanion.ViewModels
             Action is TouchpadActions { TargetType: TouchpadTargetType.Button, Button: ButtonFlags.TouchpadSwipe }
                 ? Visibility.Visible
                 : Visibility.Collapsed;
+        public virtual Visibility TouchpadVisualizerVisibility => TouchpadSettingsVisibility;
+        public double TouchpadVisualizerStartX => TouchpadVisualizerPosition(TouchpadX, TouchpadMaxX, 232.0d);
+        public double TouchpadVisualizerStartY => TouchpadVisualizerPosition(TouchpadY, TouchpadMaxY, 112.0d);
+        public double TouchpadVisualizerEndX => TouchpadVisualizerPosition(TouchpadEndX, TouchpadMaxX, 232.0d);
+        public double TouchpadVisualizerEndY => TouchpadVisualizerPosition(TouchpadEndY, TouchpadMaxY, 112.0d);
+        public double TouchpadVisualizerLineStartX => TouchpadVisualizerStartX + 4.0d;
+        public double TouchpadVisualizerLineStartY => TouchpadVisualizerStartY + 4.0d;
+        public double TouchpadVisualizerLineEndX => TouchpadVisualizerEndX + 4.0d;
+        public double TouchpadVisualizerLineEndY => TouchpadVisualizerEndY + 4.0d;
         public int TouchpadMaxX => DS4Touch.TOUCHPAD_WIDTH - 1;
         public int TouchpadMaxY => DS4Touch.TOUCHPAD_HEIGHT - 1;
         public double TouchpadMaxDuration => TouchpadActions.MaximumSwipeDuration;
         public string TouchpadCoordinateRangeDescription => string.Format(
             Resources.LayoutPage_TouchpadCoordinateRange, TouchpadMaxX, TouchpadMaxY);
-        public int TouchpadX { get => Action is TouchpadActions a ? a.X : 0; set { if (Action is TouchpadActions a) { a.X = value; OnPropertyChanged(nameof(TouchpadX)); } } }
-        public int TouchpadY { get => Action is TouchpadActions a ? a.Y : 0; set { if (Action is TouchpadActions a) { a.Y = value; OnPropertyChanged(nameof(TouchpadY)); } } }
-        public int TouchpadEndX { get => Action is TouchpadActions a ? a.EndX : 0; set { if (Action is TouchpadActions a) { a.EndX = value; OnPropertyChanged(nameof(TouchpadEndX)); } } }
-        public int TouchpadEndY { get => Action is TouchpadActions a ? a.EndY : 0; set { if (Action is TouchpadActions a) { a.EndY = value; OnPropertyChanged(nameof(TouchpadEndY)); } } }
+        public int TouchpadX { get => Action is TouchpadActions a ? a.X : 0; set { if (Action is TouchpadActions a) { a.X = value; OnPropertyChanged(nameof(TouchpadX)); NotifyTouchpadVisualizer(nameof(TouchpadVisualizerStartX), nameof(TouchpadVisualizerStartY), nameof(TouchpadVisualizerLineStartX), nameof(TouchpadVisualizerLineStartY)); } } }
+        public int TouchpadY { get => Action is TouchpadActions a ? a.Y : 0; set { if (Action is TouchpadActions a) { a.Y = value; OnPropertyChanged(nameof(TouchpadY)); NotifyTouchpadVisualizer(nameof(TouchpadVisualizerStartX), nameof(TouchpadVisualizerStartY), nameof(TouchpadVisualizerLineStartX), nameof(TouchpadVisualizerLineStartY)); } } }
+        public int TouchpadEndX { get => Action is TouchpadActions a ? a.EndX : 0; set { if (Action is TouchpadActions a) { a.EndX = value; OnPropertyChanged(nameof(TouchpadEndX)); NotifyTouchpadVisualizer(nameof(TouchpadVisualizerEndX), nameof(TouchpadVisualizerLineEndX)); } } }
+        public int TouchpadEndY { get => Action is TouchpadActions a ? a.EndY : 0; set { if (Action is TouchpadActions a) { a.EndY = value; OnPropertyChanged(nameof(TouchpadEndY)); NotifyTouchpadVisualizer(nameof(TouchpadVisualizerEndY), nameof(TouchpadVisualizerLineEndY)); } } }
         public double TouchpadSwipeDuration { get => Action is TouchpadActions a ? a.SwipeDuration : TouchpadActions.DefaultSwipeDuration; set { if (Action is TouchpadActions a) { a.SwipeDuration = (float)value; OnPropertyChanged(nameof(TouchpadSwipeDuration)); } } }
+
+        private static double TouchpadVisualizerPosition(int value, int maximum, double available) =>
+            maximum == 0 ? 0.0d : value * available / maximum;
+
+        private void NotifyTouchpadVisualizer(params string[] propertyNames)
+        {
+            foreach (string propertyName in propertyNames)
+                OnPropertyChanged(propertyName);
+        }
 
         protected static IEnumerable<ButtonFlags> GetButtonTargets(IController controller)
         {
@@ -410,6 +446,10 @@ namespace HandheldCompanion.ViewModels
             else if (target is AxisLayoutFlags axis)
                 touchpadAction.SetTarget(axis);
         }
+
+        #endregion
+
+        #region Section visibility
 
         // Combined visibility for settings that apply to both Button mappings and Axis2Button mappings
         // This avoids duplication - shows when ActionTypeIndex is Button/Keyboard/Mouse/Trigger/Shift
@@ -521,6 +561,10 @@ namespace HandheldCompanion.ViewModels
             }
         }
 
+        #endregion
+
+        #region Modifier and press properties
+
         // Modifier properties (for Keyboard/Mouse actions) - default to 0/false
         public virtual int ModifierIndex { get => 0; set { } }
         public virtual bool HasModifier => false;
@@ -530,6 +574,10 @@ namespace HandheldCompanion.ViewModels
         public virtual string PressTypeTooltip => string.Empty;
         public virtual bool HasDuration => false;
         public virtual float LongPressDelay { get => 0; set { } }
+
+        #endregion
+
+        #region Haptic properties
 
         // Haptic properties - default to 0
         public virtual int HapticModeIndex
@@ -586,6 +634,10 @@ namespace HandheldCompanion.ViewModels
         public bool HapticControlsEnabled =>
             TrackpadClickHapticOverrideVisibility != Visibility.Visible ||
             !UseGlobalTrackpadClickHaptics;
+
+        #endregion
+
+        #region Shift properties
 
         // Shift properties - default to Always enabled (index 1)
         public virtual int ShiftModeIndex
@@ -688,6 +740,10 @@ namespace HandheldCompanion.ViewModels
             }
         }
 
+        #endregion
+
+        #region Display helpers
+
         protected string GetActionTypeDisplayName()
         {
             ActionType actionType = (ActionType)ActionTypeIndex;
@@ -735,6 +791,10 @@ namespace HandheldCompanion.ViewModels
                 ? string.Join(", ", selectedShiftSlots)
                 : EnumUtils.GetDescriptionFromEnumValue(ShiftSlot.None);
         }
+
+        #endregion
+
+        #region Notifications and lifecycle
 
         // Purely UI related properties, they should NOT update the Layout
         // Avoid unnecessary save/update calls
@@ -905,5 +965,7 @@ namespace HandheldCompanion.ViewModels
             ActionTypeIndex = 0;
             SelectedTarget = null;
         }
+
+        #endregion
     }
 }

--- a/HandheldCompanion/ViewModels/Layout/Mappings/MappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/MappingViewModel.cs
@@ -312,6 +312,7 @@ namespace HandheldCompanion.ViewModels
 
         // Visibility for Axis invert properties - only Axis mappings
         public virtual Visibility AxisInvertVisibility => Visibility.Collapsed;
+        public virtual Visibility AxisDeadzoneVisibility => Visibility.Collapsed;
         public virtual Visibility Button2AxisVisibility => Visibility.Collapsed;
         public virtual Visibility AxisVisualizerVisibility => Visibility.Collapsed;
         public virtual double AxisVisualizerDotX => 0.0d;

--- a/HandheldCompanion/ViewModels/Layout/Mappings/MappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/MappingViewModel.cs
@@ -330,6 +330,10 @@ namespace HandheldCompanion.ViewModels
         public virtual Visibility AxisDirectionVisibility => Visibility.Collapsed;
         public virtual Visibility AxisThresholdVisibility => Visibility.Collapsed;
 
+        // DualSense touchpad gesture settings are only supported by button mappings.
+        public virtual Visibility TouchpadSettingsVisibility => Visibility.Collapsed;
+        public virtual Visibility TouchpadSwipeSettingsVisibility => Visibility.Collapsed;
+
         // Combined visibility for settings that apply to both Button mappings and Axis2Button mappings
         // This avoids duplication - shows when ActionTypeIndex is Button/Keyboard/Mouse/Trigger/Shift
         // OR when it's an Axis mapping converting to Button

--- a/HandheldCompanion/ViewModels/Layout/Mappings/MappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/MappingViewModel.cs
@@ -1,7 +1,10 @@
 ﻿using GregsStack.InputSimulatorStandard.Native;
 using HandheldCompanion.Actions;
+using HandheldCompanion.Controllers;
+using HandheldCompanion.Controllers.Dummies;
 using HandheldCompanion.Inputs;
 using HandheldCompanion.Managers;
+using HandheldCompanion.Misc;
 using HandheldCompanion.Properties;
 using HandheldCompanion.Utils;
 using HandheldCompanion.Views;
@@ -333,6 +336,49 @@ namespace HandheldCompanion.ViewModels
         // DualSense touchpad gesture settings are only supported by button mappings.
         public virtual Visibility TouchpadSettingsVisibility => Visibility.Collapsed;
         public virtual Visibility TouchpadSwipeSettingsVisibility => Visibility.Collapsed;
+        public int TouchpadMaxX => DS4Touch.TOUCHPAD_WIDTH - 1;
+        public int TouchpadMaxY => DS4Touch.TOUCHPAD_HEIGHT - 1;
+        public double TouchpadMaxDuration => TouchpadActions.MaximumSwipeDuration;
+        public string TouchpadCoordinateRangeDescription => $"DualSense coordinates: X 0–{TouchpadMaxX}, Y 0–{TouchpadMaxY}";
+        public int TouchpadX { get => Action is TouchpadActions a ? a.X : 0; set { if (Action is TouchpadActions a) { a.X = value; OnPropertyChanged(nameof(TouchpadX)); } } }
+        public int TouchpadY { get => Action is TouchpadActions a ? a.Y : 0; set { if (Action is TouchpadActions a) { a.Y = value; OnPropertyChanged(nameof(TouchpadY)); } } }
+        public int TouchpadEndX { get => Action is TouchpadActions a ? a.EndX : 0; set { if (Action is TouchpadActions a) { a.EndX = value; OnPropertyChanged(nameof(TouchpadEndX)); } } }
+        public int TouchpadEndY { get => Action is TouchpadActions a ? a.EndY : 0; set { if (Action is TouchpadActions a) { a.EndY = value; OnPropertyChanged(nameof(TouchpadEndY)); } } }
+        public double TouchpadSwipeDuration { get => Action is TouchpadActions a ? a.SwipeDuration : TouchpadActions.DefaultSwipeDuration; set { if (Action is TouchpadActions a) { a.SwipeDuration = (float)value; OnPropertyChanged(nameof(TouchpadSwipeDuration)); } } }
+
+        protected static IEnumerable<ButtonFlags> GetButtonTargets(IController controller)
+        {
+            foreach (ButtonFlags button in controller.GetTargetButtons())
+                yield return button;
+
+            if (controller is DummyDualSenseController)
+            {
+                foreach (ButtonFlags button in TouchpadActions.Targets)
+                    yield return button;
+            }
+        }
+
+        protected void SetButtonTarget(ButtonFlags button)
+        {
+            bool isTouchpadAction = TouchpadActions.IsTouchpadTarget(button);
+            if (isTouchpadAction && Action is not TouchpadActions)
+            {
+                IActions? previous = Action;
+                Action = new TouchpadActions(button);
+                if (previous is not null)
+                    Action.CopyConfigurationFrom(previous);
+            }
+            else if (!isTouchpadAction && Action is TouchpadActions)
+            {
+                IActions previous = Action;
+                Action = new ButtonActions(button);
+                Action.CopyConfigurationFrom(previous);
+            }
+            else if (Action is ButtonActions buttonAction)
+            {
+                buttonAction.Button = button;
+            }
+        }
 
         // Combined visibility for settings that apply to both Button mappings and Axis2Button mappings
         // This avoids duplication - shows when ActionTypeIndex is Button/Keyboard/Mouse/Trigger/Shift

--- a/HandheldCompanion/ViewModels/Layout/Mappings/MappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/MappingViewModel.cs
@@ -11,6 +11,7 @@ using HandheldCompanion.Views;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Windows;
 using System.Windows.Data;
 
@@ -206,6 +207,10 @@ namespace HandheldCompanion.ViewModels
                 if (currentActionType == ActionType.Button || currentActionType == ActionType.Keyboard)
                     return Visibility.Visible;
 
+                if (currentActionType == ActionType.Touchpad &&
+                    Action is TouchpadActions { TargetType: TouchpadTargetType.Button })
+                    return Visibility.Visible;
+
                 // For Mouse actions, ensure a target exists and check its action type
                 if (currentActionType == ActionType.Mouse && SelectedTarget != null)
                 {
@@ -296,6 +301,8 @@ namespace HandheldCompanion.ViewModels
         public virtual int Button2AxisX { get => 0; set { } }
         public virtual int Button2AxisY { get => 0; set { } }
         public virtual Visibility AxisResponseCurveVisibility => Visibility.Collapsed;
+        public virtual Visibility AxisOutputShapeVisibility =>
+            ActionTypeIndex == (int)ActionType.Joystick ? Visibility.Visible : Visibility.Collapsed;
 
         // Visibility for Axis invert properties - only Axis mappings
         public virtual Visibility AxisInvertVisibility => Visibility.Collapsed;
@@ -333,13 +340,44 @@ namespace HandheldCompanion.ViewModels
         public virtual Visibility AxisDirectionVisibility => Visibility.Collapsed;
         public virtual Visibility AxisThresholdVisibility => Visibility.Collapsed;
 
-        // DualSense touchpad gesture settings are only supported by button mappings.
-        public virtual Visibility TouchpadSettingsVisibility => Visibility.Collapsed;
-        public virtual Visibility TouchpadSwipeSettingsVisibility => Visibility.Collapsed;
+        public Visibility TouchpadActionTypeVisibility
+        {
+            get
+            {
+                IController controller = ControllerManager.GetDefault(true);
+                return Action is TouchpadActions || TouchpadActions.HasTargets(controller)
+                    ? Visibility.Visible
+                    : Visibility.Collapsed;
+            }
+        }
+
+        public Visibility TouchpadAxisActionTypeVisibility
+        {
+            get
+            {
+                IController controller = ControllerManager.GetDefault(true);
+                return Action is TouchpadActions || TouchpadActions.GetAxisTargets(controller).Any()
+                    ? Visibility.Visible
+                    : Visibility.Collapsed;
+            }
+        }
+
+        public virtual Visibility TouchpadSettingsVisibility =>
+            ActionTypeIndex == (int)ActionType.Touchpad &&
+            Action is TouchpadActions { TargetType: TouchpadTargetType.Button } touchpadAction &&
+            TouchpadActions.IsCoordinateTarget(touchpadAction.Button)
+                ? Visibility.Visible
+                : Visibility.Collapsed;
+        public virtual Visibility TouchpadSwipeSettingsVisibility =>
+            ActionTypeIndex == (int)ActionType.Touchpad &&
+            Action is TouchpadActions { TargetType: TouchpadTargetType.Button, Button: ButtonFlags.TouchpadSwipe }
+                ? Visibility.Visible
+                : Visibility.Collapsed;
         public int TouchpadMaxX => DS4Touch.TOUCHPAD_WIDTH - 1;
         public int TouchpadMaxY => DS4Touch.TOUCHPAD_HEIGHT - 1;
         public double TouchpadMaxDuration => TouchpadActions.MaximumSwipeDuration;
-        public string TouchpadCoordinateRangeDescription => $"DualSense coordinates: X 0–{TouchpadMaxX}, Y 0–{TouchpadMaxY}";
+        public string TouchpadCoordinateRangeDescription => string.Format(
+            Resources.LayoutPage_TouchpadCoordinateRange, TouchpadMaxX, TouchpadMaxY);
         public int TouchpadX { get => Action is TouchpadActions a ? a.X : 0; set { if (Action is TouchpadActions a) { a.X = value; OnPropertyChanged(nameof(TouchpadX)); } } }
         public int TouchpadY { get => Action is TouchpadActions a ? a.Y : 0; set { if (Action is TouchpadActions a) { a.Y = value; OnPropertyChanged(nameof(TouchpadY)); } } }
         public int TouchpadEndX { get => Action is TouchpadActions a ? a.EndX : 0; set { if (Action is TouchpadActions a) { a.EndX = value; OnPropertyChanged(nameof(TouchpadEndX)); } } }
@@ -349,35 +387,24 @@ namespace HandheldCompanion.ViewModels
         protected static IEnumerable<ButtonFlags> GetButtonTargets(IController controller)
         {
             foreach (ButtonFlags button in controller.GetTargetButtons())
-                yield return button;
-
-            if (controller is DummyDualSenseController)
             {
-                foreach (ButtonFlags button in TouchpadActions.Targets)
+                if (!TouchpadActions.IsTouchpadButton(button))
                     yield return button;
             }
         }
 
-        protected void SetButtonTarget(ButtonFlags button)
+        protected static IEnumerable<AxisLayoutFlags> GetJoystickTargets(IController controller) =>
+            controller.GetTargetAxis().Where(axis => !TouchpadActions.IsTouchpadAxis(axis));
+
+        protected void SetTouchpadTarget(object target)
         {
-            bool isTouchpadAction = TouchpadActions.IsTouchpadTarget(button);
-            if (isTouchpadAction && Action is not TouchpadActions)
-            {
-                IActions? previous = Action;
-                Action = new TouchpadActions(button);
-                if (previous is not null)
-                    Action.CopyConfigurationFrom(previous);
-            }
-            else if (!isTouchpadAction && Action is TouchpadActions)
-            {
-                IActions previous = Action;
-                Action = new ButtonActions(button);
-                Action.CopyConfigurationFrom(previous);
-            }
-            else if (Action is ButtonActions buttonAction)
-            {
-                buttonAction.Button = button;
-            }
+            if (Action is not TouchpadActions touchpadAction)
+                return;
+
+            if (target is ButtonFlags button)
+                touchpadAction.SetTarget(button);
+            else if (target is AxisLayoutFlags axis)
+                touchpadAction.SetTarget(axis);
         }
 
         // Combined visibility for settings that apply to both Button mappings and Axis2Button mappings
@@ -391,7 +418,8 @@ namespace HandheldCompanion.ViewModels
                 // Show for Button, Keyboard, Mouse, Trigger, Shift
                 if (currentActionType == ActionType.Button || currentActionType == ActionType.Keyboard ||
                     currentActionType == ActionType.Mouse || currentActionType == ActionType.Trigger ||
-                    currentActionType == ActionType.Shift || currentActionType == ActionType.Joystick)
+                    currentActionType == ActionType.Shift || currentActionType == ActionType.Joystick ||
+                    currentActionType == ActionType.Touchpad)
                     return Visibility.Visible;
 
                 // For Axis mappings converting to Button, also show
@@ -435,6 +463,9 @@ namespace HandheldCompanion.ViewModels
             get
             {
                 ActionType currentActionType = (ActionType)ActionTypeIndex;
+                if (currentActionType == ActionType.Touchpad && Button2AxisVisibility == Visibility.Visible)
+                    return Visibility.Visible;
+
                 if (currentActionType != ActionType.Joystick)
                     return Visibility.Collapsed;
 
@@ -505,7 +536,10 @@ namespace HandheldCompanion.ViewModels
                 if (Action is not null && value != HapticModeIndex)
                 {
                     Action.HapticMode = (HapticMode)value;
+                    Action.HapticOverride = true;
                     OnPropertyChanged(nameof(HapticModeIndex));
+                    OnPropertyChanged(nameof(UseGlobalTrackpadClickHaptics));
+                    OnPropertyChanged(nameof(HapticControlsEnabled));
                 }
             }
         }
@@ -518,10 +552,36 @@ namespace HandheldCompanion.ViewModels
                 if (Action is not null && value != HapticStrengthIndex)
                 {
                     Action.HapticStrength = (HapticStrength)value;
+                    Action.HapticOverride = true;
                     OnPropertyChanged(nameof(HapticStrengthIndex));
+                    OnPropertyChanged(nameof(UseGlobalTrackpadClickHaptics));
+                    OnPropertyChanged(nameof(HapticControlsEnabled));
                 }
             }
         }
+
+        public Visibility TrackpadClickHapticOverrideVisibility =>
+            Value is ButtonFlags button && TouchpadActions.IsPhysicalClick(button)
+                ? Visibility.Visible
+                : Visibility.Collapsed;
+
+        public bool UseGlobalTrackpadClickHaptics
+        {
+            get => Action is null || !TouchpadActions.HasCustomHapticSettings(Action);
+            set
+            {
+                if (Action is null || value == UseGlobalTrackpadClickHaptics)
+                    return;
+
+                Action.HapticOverride = !value;
+                OnPropertyChanged(nameof(UseGlobalTrackpadClickHaptics));
+                OnPropertyChanged(nameof(HapticControlsEnabled));
+            }
+        }
+
+        public bool HapticControlsEnabled =>
+            TrackpadClickHapticOverrideVisibility != Visibility.Visible ||
+            !UseGlobalTrackpadClickHaptics;
 
         // Shift properties - default to Always enabled (index 1)
         public virtual int ShiftModeIndex
@@ -682,6 +742,10 @@ namespace HandheldCompanion.ViewModels
             nameof(TurboDisplayName),
             nameof(ToggleDisplayName),
             nameof(InputShiftDisplayName),
+            nameof(TouchpadActionTypeVisibility),
+            nameof(TouchpadAxisActionTypeVisibility),
+            nameof(TrackpadClickHapticOverrideVisibility),
+            nameof(HapticControlsEnabled),
         ];
 
         public override void OnPropertyChanged(string? propertyName)
@@ -703,6 +767,8 @@ namespace HandheldCompanion.ViewModels
                     base.OnPropertyChanged(nameof(TurboDisplayName));
                     base.OnPropertyChanged(nameof(ToggleDisplayName));
                     base.OnPropertyChanged(nameof(InputShiftDisplayName));
+                    base.OnPropertyChanged(nameof(TouchpadActionTypeVisibility));
+                    base.OnPropertyChanged(nameof(TouchpadAxisActionTypeVisibility));
                     break;
             }
 

--- a/HandheldCompanion/ViewModels/Layout/Mappings/MappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/MappingViewModel.cs
@@ -387,7 +387,7 @@ namespace HandheldCompanion.ViewModels
         public virtual Visibility TouchpadSettingsVisibility =>
             ActionTypeIndex == (int)ActionType.Touchpad &&
             Action is TouchpadActions { TargetType: TouchpadTargetType.Button } touchpadAction &&
-            TouchpadActions.IsCoordinateTarget(touchpadAction.Button)
+            TouchpadActions.IsGestureTarget(touchpadAction.Button)
                 ? Visibility.Visible
                 : Visibility.Collapsed;
         public virtual Visibility TouchpadSwipeSettingsVisibility =>

--- a/HandheldCompanion/ViewModels/Layout/Mappings/TriggerMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/TriggerMappingViewModel.cs
@@ -24,10 +24,13 @@ namespace HandheldCompanion.ViewModels
 
         public override bool IsTriggerMapping => true;
         public override Visibility TouchpadSettingsVisibility =>
-            ActionTypeIndex == (int)ActionType.Button && Action is TouchpadActions
+            ActionTypeIndex == (int)ActionType.Touchpad &&
+            Action is TouchpadActions { TargetType: TouchpadTargetType.Button } touchpadAction &&
+            TouchpadActions.IsCoordinateTarget(touchpadAction.Button)
                 ? Visibility.Visible : Visibility.Collapsed;
         public override Visibility TouchpadSwipeSettingsVisibility =>
-            ActionTypeIndex == (int)ActionType.Button && Action is TouchpadActions { Button: ButtonFlags.TouchpadSwipe }
+            ActionTypeIndex == (int)ActionType.Touchpad &&
+            Action is TouchpadActions { TargetType: TouchpadTargetType.Button, Button: ButtonFlags.TouchpadSwipe }
                 ? Visibility.Visible : Visibility.Collapsed;
 
         public override int Trigger2TriggerInnerDeadzone
@@ -165,6 +168,56 @@ namespace HandheldCompanion.ViewModels
 
                 ReplaceTargets(targets, matchingTargetVm);
             }
+            else if (actionType == ActionType.Touchpad)
+            {
+                bool preserveMissingTarget = Action is TouchpadActions;
+                TouchpadActions touchpadAction = Action as TouchpadActions ?? new TouchpadActions
+                {
+                    motionThreshold = Gamepad.TriggerThreshold,
+                    motionDirection = DeflectionDirection.Up,
+                    ShiftSlot = ShiftSlot.Any,
+                    ShiftMatchAny = false
+                };
+                if (!preserveMissingTarget)
+                    Action = touchpadAction;
+
+                MappingTargetViewModel? matchingTargetVm = null;
+                foreach (ButtonFlags button in TouchpadActions.GetButtonTargets(controller))
+                {
+                    var mappingTargetVm = CreateTarget(button, controller.GetButtonName(button));
+                    targets.Add(mappingTargetVm);
+
+                    if (touchpadAction.TargetType == TouchpadTargetType.Button && button == touchpadAction.Button)
+                        matchingTargetVm = mappingTargetVm;
+                }
+
+                foreach (AxisLayoutFlags axis in TouchpadActions.GetAxisTargets(controller))
+                {
+                    var mappingTargetVm = CreateTarget(axis, controller.GetAxisName(axis));
+                    targets.Add(mappingTargetVm);
+
+                    if (touchpadAction.TargetType == TouchpadTargetType.Axis && axis == touchpadAction.Axis)
+                        matchingTargetVm = mappingTargetVm;
+                }
+
+                if (matchingTargetVm is null && preserveMissingTarget)
+                {
+                    if (touchpadAction.TargetType == TouchpadTargetType.Button && touchpadAction.Button != ButtonFlags.None)
+                    {
+                        matchingTargetVm = CreateUnsupportedTarget(touchpadAction.Button,
+                            controller.GetButtonName(touchpadAction.Button));
+                        targets.Add(matchingTargetVm);
+                    }
+                    else if (touchpadAction.TargetType == TouchpadTargetType.Axis && touchpadAction.Axis != AxisLayoutFlags.None)
+                    {
+                        matchingTargetVm = CreateUnsupportedTarget(touchpadAction.Axis,
+                            controller.GetAxisName(touchpadAction.Axis));
+                        targets.Add(matchingTargetVm);
+                    }
+                }
+
+                ReplaceTargets(targets, matchingTargetVm);
+            }
             else if (actionType == ActionType.Keyboard)
             {
                 if (Action is null || Action is not KeyboardActions)
@@ -294,8 +347,13 @@ namespace HandheldCompanion.ViewModels
             {
                 case ActionType.Button:
                     if (SelectedTarget.Tag is ButtonFlags buttonFlags)
+                        ((ButtonActions)Action).Button = buttonFlags;
+                    break;
+
+                case ActionType.Touchpad:
+                    if (SelectedTarget.Tag is not null)
                     {
-                        SetButtonTarget(buttonFlags);
+                        SetTouchpadTarget(SelectedTarget.Tag);
                         OnPropertyChanged(string.Empty);
                     }
                     break;

--- a/HandheldCompanion/ViewModels/Layout/Mappings/TriggerMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/TriggerMappingViewModel.cs
@@ -143,6 +143,9 @@ namespace HandheldCompanion.ViewModels
                 MappingTargetViewModel? matchingTargetVm = null;
                 foreach (var button in controller.GetTargetButtons())
                 {
+                    if (TouchpadActions.IsTouchpadTarget(button))
+                        continue;
+
                     var mappingTargetVm = CreateTarget(button, controller.GetButtonName(button));
                     targets.Add(mappingTargetVm);
 

--- a/HandheldCompanion/ViewModels/Layout/Mappings/TriggerMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/TriggerMappingViewModel.cs
@@ -35,6 +35,7 @@ namespace HandheldCompanion.ViewModels
         ];
 
         public override bool IsTriggerMapping => true;
+        public override Visibility Trigger2ButtonVisibility => Axis2ButtonVisibility;
         public override Visibility TouchpadSettingsVisibility =>
             ActionTypeIndex == (int)ActionType.Touchpad &&
             Action is TouchpadActions { TargetType: TouchpadTargetType.Button } touchpadAction &&
@@ -341,6 +342,7 @@ namespace HandheldCompanion.ViewModels
             {
                 case "SelectedTarget":
                 case "ActionTypeIndex":
+                    OnPropertyChanged(nameof(Trigger2ButtonVisibility));
                     OnPropertyChanged(nameof(TriggerDeadzoneVisibility));
                     OnPropertyChanged(nameof(TriggerSettingsSectionVisibility));
                     OnPropertyChanged(nameof(GeneralActionVisibility));

--- a/HandheldCompanion/ViewModels/Layout/Mappings/TriggerMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/TriggerMappingViewModel.cs
@@ -143,9 +143,6 @@ namespace HandheldCompanion.ViewModels
                 MappingTargetViewModel? matchingTargetVm = null;
                 foreach (var button in controller.GetTargetButtons())
                 {
-                    if (TouchpadActions.IsTouchpadTarget(button))
-                        continue;
-
                     var mappingTargetVm = CreateTarget(button, controller.GetButtonName(button));
                     targets.Add(mappingTargetVm);
 

--- a/HandheldCompanion/ViewModels/Layout/Mappings/TriggerMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/TriggerMappingViewModel.cs
@@ -204,15 +204,6 @@ namespace HandheldCompanion.ViewModels
                         matchingTargetVm = mappingTargetVm;
                 }
 
-                foreach (AxisLayoutFlags axis in TouchpadActions.GetAxisTargets(controller))
-                {
-                    var mappingTargetVm = CreateTarget(axis, controller.GetAxisName(axis));
-                    targets.Add(mappingTargetVm);
-
-                    if (touchpadAction.TargetType == TouchpadTargetType.Axis && axis == touchpadAction.Axis)
-                        matchingTargetVm = mappingTargetVm;
-                }
-
                 if (matchingTargetVm is null && preserveMissingTarget)
                 {
                     if (touchpadAction.TargetType == TouchpadTargetType.Button && touchpadAction.Button != ButtonFlags.None)

--- a/HandheldCompanion/ViewModels/Layout/Mappings/TriggerMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/TriggerMappingViewModel.cs
@@ -39,7 +39,7 @@ namespace HandheldCompanion.ViewModels
         public override Visibility TouchpadSettingsVisibility =>
             ActionTypeIndex == (int)ActionType.Touchpad &&
             Action is TouchpadActions { TargetType: TouchpadTargetType.Button } touchpadAction &&
-            TouchpadActions.IsCoordinateTarget(touchpadAction.Button)
+            TouchpadActions.IsGestureTarget(touchpadAction.Button)
                 ? Visibility.Visible : Visibility.Collapsed;
         public override Visibility TouchpadSwipeSettingsVisibility =>
             ActionTypeIndex == (int)ActionType.Touchpad &&

--- a/HandheldCompanion/ViewModels/Layout/Mappings/TriggerMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/TriggerMappingViewModel.cs
@@ -23,6 +23,12 @@ namespace HandheldCompanion.ViewModels
         ];
 
         public override bool IsTriggerMapping => true;
+        public override Visibility TouchpadSettingsVisibility =>
+            ActionTypeIndex == (int)ActionType.Button && Action is TouchpadActions
+                ? Visibility.Visible : Visibility.Collapsed;
+        public override Visibility TouchpadSwipeSettingsVisibility =>
+            ActionTypeIndex == (int)ActionType.Button && Action is TouchpadActions { Button: ButtonFlags.TouchpadSwipe }
+                ? Visibility.Visible : Visibility.Collapsed;
 
         public override int Trigger2TriggerInnerDeadzone
         {
@@ -141,7 +147,7 @@ namespace HandheldCompanion.ViewModels
                     Action = new ButtonActions() { motionThreshold = Gamepad.TriggerThreshold, motionDirection = DeflectionDirection.Up };
 
                 MappingTargetViewModel? matchingTargetVm = null;
-                foreach (var button in controller.GetTargetButtons())
+                foreach (var button in GetButtonTargets(controller))
                 {
                     var mappingTargetVm = CreateTarget(button, controller.GetButtonName(button));
                     targets.Add(mappingTargetVm);
@@ -288,7 +294,10 @@ namespace HandheldCompanion.ViewModels
             {
                 case ActionType.Button:
                     if (SelectedTarget.Tag is ButtonFlags buttonFlags)
-                        ((ButtonActions)Action).Button = buttonFlags;
+                    {
+                        SetButtonTarget(buttonFlags);
+                        OnPropertyChanged(string.Empty);
+                    }
                     break;
 
                 case ActionType.Keyboard:

--- a/HandheldCompanion/ViewModels/Layout/Mappings/TriggerMappingViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Mappings/TriggerMappingViewModel.cs
@@ -16,6 +16,18 @@ namespace HandheldCompanion.ViewModels
 {
     public class TriggerMappingViewModel : MappingViewModel
     {
+        public override ActionType[] SupportedActionTypes =>
+        [
+            ActionType.Disabled,
+            ActionType.Button,
+            ActionType.Keyboard,
+            ActionType.Mouse,
+            ActionType.Trigger,
+            ActionType.Shift,
+            ActionType.Inherit,
+            ActionType.Touchpad
+        ];
+
         private static readonly HashSet<MouseActionsType> _unsupportedMouseActionTypes =
         [
             MouseActionsType.Move,

--- a/HandheldCompanion/ViewModels/Layout/Pages/TrackpadsPageViewModel.cs
+++ b/HandheldCompanion/ViewModels/Layout/Pages/TrackpadsPageViewModel.cs
@@ -8,7 +8,7 @@ namespace HandheldCompanion.ViewModels
     {
         private static readonly List<ButtonFlags> _leftButtons =
         [
-            ButtonFlags.LeftPadClick, ButtonFlags.LeftPadClickUp, ButtonFlags.LeftPadClickDown,
+            ButtonFlags.LeftPadTouch, ButtonFlags.LeftPadClick, ButtonFlags.LeftPadClickUp, ButtonFlags.LeftPadClickDown,
             ButtonFlags.LeftPadClickLeft, ButtonFlags.LeftPadClickRight
         ];
 
@@ -16,7 +16,7 @@ namespace HandheldCompanion.ViewModels
 
         private static readonly List<ButtonFlags> _rightButtons =
         [
-            ButtonFlags.RightPadClick, ButtonFlags.RightPadClickUp,
+            ButtonFlags.RightPadTouch, ButtonFlags.RightPadClick, ButtonFlags.RightPadClickUp,
             ButtonFlags.RightPadClickDown, ButtonFlags.RightPadClickLeft, ButtonFlags.RightPadClickRight
         ];
 

--- a/HandheldCompanion/ViewModels/Pages/ProfilesPageViewModel.cs
+++ b/HandheldCompanion/ViewModels/Pages/ProfilesPageViewModel.cs
@@ -1,4 +1,5 @@
 using HandheldCompanion.Actions;
+using HandheldCompanion.Controllers;
 using HandheldCompanion.Devices;
 using HandheldCompanion.GraphicsProcessingUnit;
 using HandheldCompanion.Helpers;
@@ -534,7 +535,7 @@ namespace HandheldCompanion.ViewModels
 
         /// <summary>
         /// The currently selected sub-profile ViewModel, used for ComboBox SelectedItem binding.
-        /// Works correctly with sorted views — no index mapping required.
+        /// Works correctly with sorted views - no index mapping required.
         /// Setting this (by user ComboBox interaction) triggers profile application.
         /// </summary>
         public ProfileViewModel? SelectedSubProfileViewModel
@@ -567,10 +568,12 @@ namespace HandheldCompanion.ViewModels
                     // Preserve existing MotionInput and MotionMode if switching between output types
                     MotionInput preservedMotionInput = MotionInput.LocalSpace;
                     MotionMode preservedMotionMode = Utils.MotionMode.Off;
+                    float preservedGyroWeight = GyroActions.DefaultGyroWeight;
                     if (gyroActions is GyroActions existingGyroAction)
                     {
                         preservedMotionInput = existingGyroAction.MotionInput;
                         preservedMotionMode = existingGyroAction.MotionMode;
+                        preservedGyroWeight = existingGyroAction.gyroWeight;
                     }
 
                     MotionOutput motionOutput = (MotionOutput)value;
@@ -589,7 +592,8 @@ namespace HandheldCompanion.ViewModels
                                     Axis = AxisLayoutFlags.LeftStick,
                                     MotionTrigger = (ButtonState)GyroHotkey.inputsChord.ButtonState.Clone(),
                                     MotionInput = preservedMotionInput,
-                                    MotionMode = preservedMotionMode
+                                    MotionMode = preservedMotionMode,
+                                    gyroWeight = preservedGyroWeight
                                 };
                             }
                             else if (gyroActions is AxisActions aa)
@@ -606,7 +610,8 @@ namespace HandheldCompanion.ViewModels
                                     Axis = AxisLayoutFlags.RightStick,
                                     MotionTrigger = (ButtonState)GyroHotkey.inputsChord.ButtonState.Clone(),
                                     MotionInput = preservedMotionInput,
-                                    MotionMode = preservedMotionMode
+                                    MotionMode = preservedMotionMode,
+                                    gyroWeight = preservedGyroWeight
                                 };
                             }
                             else if (gyroActions is AxisActions aa)
@@ -625,7 +630,29 @@ namespace HandheldCompanion.ViewModels
                                     Deadzone = GyroActions.DefaultDeadzone,
                                     MotionTrigger = (ButtonState)GyroHotkey.inputsChord.ButtonState.Clone(),
                                     MotionInput = preservedMotionInput,
-                                    MotionMode = preservedMotionMode
+                                    MotionMode = preservedMotionMode,
+                                    gyroWeight = preservedGyroWeight
+                                };
+                            }
+                            break;
+                        case MotionOutput.LeftPad:
+                        case MotionOutput.RightPad:
+                            AxisLayoutFlags axis = motionOutput == MotionOutput.LeftPad
+                                ? AxisLayoutFlags.LeftPad
+                                : AxisLayoutFlags.RightPad;
+
+                            if (gyroActions is TouchpadActions touchpadActions)
+                            {
+                                touchpadActions.SetTarget(axis);
+                            }
+                            else
+                            {
+                                gyroActions = new TouchpadActions(axis)
+                                {
+                                    MotionTrigger = (ButtonState)GyroHotkey.inputsChord.ButtonState.Clone(),
+                                    MotionInput = preservedMotionInput,
+                                    MotionMode = preservedMotionMode,
+                                    gyroWeight = preservedGyroWeight
                                 };
                             }
                             break;
@@ -634,6 +661,7 @@ namespace HandheldCompanion.ViewModels
                     if (gyroActions is not null)
                         SelectedProfile.Layout.UpdateLayout(AxisLayoutFlags.Gyroscope, gyroActions);
 
+                    RefreshMotionOutputModes();
                     SubmitProfile();
                 }
             }
@@ -962,6 +990,7 @@ namespace HandheldCompanion.ViewModels
                 {
                     SelectedProfile.HID = mode;
                     OnPropertyChanged(nameof(HIDModeIndex));
+                    RefreshMotionOutputModes();
 
                     if (!isLoadingProfile)
                         UpdateProfile();
@@ -1863,11 +1892,7 @@ namespace HandheldCompanion.ViewModels
             SubProfilesView.SortDescriptions.Add(new SortDescription(nameof(ProfileViewModel.SortOrder), ListSortDirection.Ascending));
             SubProfilesView.SortDescriptions.Add(new SortDescription(nameof(ProfileViewModel.Name), ListSortDirection.Ascending));
 
-            // Initialize MotionOutput modes
-            foreach (var mode in Enum.GetValues<MotionOutput>())
-            {
-                MotionOutputModes.Add(new MotionOutputViewModel(mode));
-            }
+            RefreshMotionOutputModes();
 
             // Initialize MotionInput modes
             foreach (var mode in (MotionInput[])Enum.GetValues(typeof(MotionInput)))
@@ -2068,7 +2093,7 @@ namespace HandheldCompanion.ViewModels
                 }
                 else
                 {
-                    // No online results — select manual
+                    // No online results - select manual
                     SelectedLibraryEntry = manualEntry;
                 }
 
@@ -2284,7 +2309,7 @@ namespace HandheldCompanion.ViewModels
             Microsoft.WindowsAPICodePack.Dialogs.CommonOpenFileDialog dlg = new();
             if (libraryType.HasFlag(LibraryType.logo))
             {
-                // Logo requires transparency — PNG only
+                // Logo requires transparency - PNG only
                 dlg.Filters.Add(new Microsoft.WindowsAPICodePack.Dialogs.CommonFileDialogFilter("PNG Image", "*.png"));
             }
             else
@@ -3061,6 +3086,8 @@ namespace HandheldCompanion.ViewModels
 
             using (new LoadingScope(this))
             {
+                RefreshMotionOutputModes();
+
                 GPUScalingEnabled = SelectedProfile.GPUScaling;
                 RSREnabled = SelectedProfile.RSREnabled;
                 RSRValue = SelectedProfile.RSRSharpness;
@@ -3085,6 +3112,16 @@ namespace HandheldCompanion.ViewModels
                     else if (gyroActions is MouseActions mouseActions)
                     {
                         OutputMode = (int)MotionOutput.MoveCursor;
+                    }
+                    else if (gyroActions is TouchpadActions { TargetType: TouchpadTargetType.Axis } touchpadActions)
+                    {
+                        GyroWeightValue = touchpadActions.gyroWeight;
+                        OutputMode = touchpadActions.Axis switch
+                        {
+                            AxisLayoutFlags.LeftPad => (int)MotionOutput.LeftPad,
+                            AxisLayoutFlags.RightPad => (int)MotionOutput.RightPad,
+                            _ => (int)MotionOutput.Disabled
+                        };
                     }
 
                     if (gyroActions is GyroActions gyroAction)
@@ -3114,6 +3151,56 @@ namespace HandheldCompanion.ViewModels
                 UpdateControlsEnabledState();
                 NotifyWrapperProperties();
             }
+        }
+
+        private void RefreshMotionOutputModes()
+        {
+            HashSet<MotionOutput> availableModes =
+            [
+                MotionOutput.Disabled,
+                MotionOutput.LeftStick,
+                MotionOutput.RightStick,
+                MotionOutput.MoveCursor,
+                MotionOutput.ScrollWheel,
+            ];
+
+            if (SelectedProfile is not null)
+            {
+                IController controller = ControllerManager.GetDefault(!IsQuickTools);
+                foreach (AxisLayoutFlags axis in TouchpadActions.GetAxisTargets(controller))
+                {
+                    if (axis == AxisLayoutFlags.LeftPad)
+                        availableModes.Add(MotionOutput.LeftPad);
+                    else if (axis == AxisLayoutFlags.RightPad)
+                        availableModes.Add(MotionOutput.RightPad);
+                }
+
+                if (SelectedProfile.Layout.GyroLayout.TryGetValue(AxisLayoutFlags.Gyroscope, out IActions? action) &&
+                    action is TouchpadActions { TargetType: TouchpadTargetType.Axis } touchpadAction)
+                {
+                    if (touchpadAction.Axis == AxisLayoutFlags.LeftPad)
+                        availableModes.Add(MotionOutput.LeftPad);
+                    else if (touchpadAction.Axis == AxisLayoutFlags.RightPad)
+                        availableModes.Add(MotionOutput.RightPad);
+                }
+            }
+
+            MotionOutput[] desiredModes = Enum.GetValues<MotionOutput>()
+                .Where(availableModes.Contains)
+                .ToArray();
+
+            for (int index = 0; index < desiredModes.Length; index++)
+            {
+                MotionOutput mode = desiredModes[index];
+                MotionOutputViewModel? existing = MotionOutputModes.FirstOrDefault(item => item.Value == mode);
+                if (existing is null)
+                    MotionOutputModes.Insert(index, new MotionOutputViewModel(mode));
+                else if (MotionOutputModes.IndexOf(existing) != index)
+                    MotionOutputModes.Move(MotionOutputModes.IndexOf(existing), index);
+            }
+
+            while (MotionOutputModes.Count > desiredModes.Length)
+                MotionOutputModes.RemoveAt(MotionOutputModes.Count - 1);
         }
 
         /// <summary>

--- a/HandheldCompanion/ViewModels/Pages/ProfilesPageViewModel.cs
+++ b/HandheldCompanion/ViewModels/Pages/ProfilesPageViewModel.cs
@@ -3577,11 +3577,13 @@ namespace HandheldCompanion.ViewModels
             if (SelectedProfile is null)
                 return;
 
-            SelectedProfile.LayoutTitle = layoutTemplate.Name;
-
-            SelectedProfile.Layout.ButtonLayout = layoutTemplate.Layout.ButtonLayout;
-            SelectedProfile.Layout.AxisLayout = layoutTemplate.Layout.AxisLayout;
-            SelectedProfile.Layout.GyroLayout = layoutTemplate.Layout.GyroLayout;
+            lock (SelectedProfile.SyncRoot)
+            {
+                SelectedProfile.LayoutTitle = layoutTemplate.Name;
+                SelectedProfile.Layout.ButtonLayout = layoutTemplate.Layout.ButtonLayout;
+                SelectedProfile.Layout.AxisLayout = layoutTemplate.Layout.AxisLayout;
+                SelectedProfile.Layout.GyroLayout = layoutTemplate.Layout.GyroLayout;
+            }
 
             UpdateProfile();
         }

--- a/HandheldCompanion/ViewModels/ProfileViewModel.cs
+++ b/HandheldCompanion/ViewModels/ProfileViewModel.cs
@@ -422,10 +422,13 @@ namespace HandheldCompanion.ViewModels
                     items.Add(new CollectionMenuItemViewModel(col.Name, Profile.Collections.Contains(colId),
                         new DelegateCommand(() =>
                         {
-                            if (Profile.Collections.Contains(colId))
-                                Profile.Collections.Remove(colId);
-                            else
-                                Profile.Collections.Add(colId);
+                            lock (Profile.SyncRoot)
+                            {
+                                if (Profile.Collections.Contains(colId))
+                                    Profile.Collections.Remove(colId);
+                                else
+                                    Profile.Collections.Add(colId);
+                            }
                             OnPropertyChanged(nameof(CollectionMenuItems));
                             ManagerFactory.profileManager.UpdateOrCreateProfile(Profile);
                         })));
@@ -447,7 +450,8 @@ namespace HandheldCompanion.ViewModels
                         if (result != ContentDialogResult.Primary || string.IsNullOrWhiteSpace(textBox.Text))
                             return;
                         GameCollection newCol = ManagerFactory.collectionManager.CreateCollection(textBox.Text.Trim());
-                        Profile.Collections.Add(newCol.Id);
+                        lock (Profile.SyncRoot)
+                            Profile.Collections.Add(newCol.Id);
                         OnPropertyChanged(nameof(CollectionMenuItems));
                         ManagerFactory.profileManager.UpdateOrCreateProfile(Profile);
                     }), isCheckable: false));

--- a/HandheldCompanion/Views/Pages/ActionSettingsPage.xaml
+++ b/HandheldCompanion/Views/Pages/ActionSettingsPage.xaml
@@ -39,8 +39,7 @@
                         <ComboBoxItem
                             Content="{x:Static resx:Resources.LayoutPage_ActionType_Touchpad}"
                             IsEnabled="{Binding SupportedActionTypes, Converter={StaticResource ActionTypeSupportedConverter}, ConverterParameter={x:Static actions:ActionType.Touchpad}}"
-                            Visibility="{Binding TouchpadActionTypeVisibility, Mode=OneWay}">
-                        </ComboBoxItem>
+                            Visibility="{Binding TouchpadActionTypeVisibility, Mode=OneWay}" />
                     </ComboBox>
                 </ui:SettingsCard>
 
@@ -399,7 +398,7 @@
 
                 <!--  Axis Direction  -->
                 <ui:SettingsCard Header="Axis direction" Visibility="{Binding AxisDirectionVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
-                    <StackPanel>
+                    <StackPanel Visibility="{Binding IsAxisMapping, Converter={StaticResource BooleanToVisibilityConverter}}">
                         <WrapPanel Orientation="Horizontal">
                             <CheckBox Content="Up" IsChecked="{Binding IsUp, Mode=TwoWay}" />
                             <CheckBox Content="Down" IsChecked="{Binding IsDown, Mode=TwoWay}" />
@@ -429,6 +428,30 @@
                             Minimum="1000"
                             SmallChange="1000"
                             TickFrequency="2000"
+                            TickPlacement="BottomRight"
+                            ToolTip="{Binding Value, StringFormat=N0, RelativeSource={RelativeSource Self}, Mode=OneWay}"
+                            Value="{Binding Axis2ButtonThreshold, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    </DockPanel>
+                </ui:SettingsCard>
+
+                <!--  Trigger Threshold  -->
+                <ui:SettingsCard Header="Trigger threshold" Visibility="{Binding Trigger2ButtonVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
+                    <DockPanel>
+                        <TextBox
+                            HorizontalContentAlignment="Center"
+                            IsReadOnly="True"
+                            Text="{Binding Axis2ButtonThreshold, Mode=OneWay, UpdateSourceTrigger=PropertyChanged, StringFormat=N0}" />
+
+                        <Slider
+                            Width="200"
+                            Margin="3,0,0,0"
+                            IsMoveToPointEnabled="True"
+                            IsSnapToTickEnabled="True"
+                            LargeChange="32"
+                            Maximum="255"
+                            Minimum="16"
+                            SmallChange="1"
+                            TickFrequency="16"
                             TickPlacement="BottomRight"
                             ToolTip="{Binding Value, StringFormat=N0, RelativeSource={RelativeSource Self}, Mode=OneWay}"
                             Value="{Binding Axis2ButtonThreshold, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />

--- a/HandheldCompanion/Views/Pages/ActionSettingsPage.xaml
+++ b/HandheldCompanion/Views/Pages/ActionSettingsPage.xaml
@@ -143,6 +143,43 @@
             </ikw:SimpleStackPanel>
         </ikw:SimpleStackPanel>
 
+        <!--  DualSense touchpad gesture settings  -->
+        <ikw:SimpleStackPanel Spacing="8" Visibility="{Binding TouchpadSettingsVisibility, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
+            <TextBlock Style="{StaticResource BaseTextBlockStyle}" Text="DualSense touchpad" />
+            <ikw:SimpleStackPanel Spacing="3">
+                <ui:SettingsCard Header="Start position" Description="DualSense coordinates: X 0–1919, Y 0–942">
+                    <StackPanel>
+                        <DockPanel>
+                            <TextBlock Width="72" VerticalAlignment="Center" Text="{Binding TouchpadX, Mode=OneWay, StringFormat={}X: {0}}" />
+                            <Slider Width="240" Minimum="0" Maximum="1919" TickFrequency="1" IsMoveToPointEnabled="True" Value="{Binding TouchpadX, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        </DockPanel>
+                        <DockPanel Margin="0,6,0,0">
+                            <TextBlock Width="72" VerticalAlignment="Center" Text="{Binding TouchpadY, Mode=OneWay, StringFormat={}Y: {0}}" />
+                            <Slider Width="240" Minimum="0" Maximum="942" TickFrequency="1" IsMoveToPointEnabled="True" Value="{Binding TouchpadY, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        </DockPanel>
+                    </StackPanel>
+                </ui:SettingsCard>
+                <ui:SettingsCard Header="End position" Visibility="{Binding TouchpadSwipeSettingsVisibility, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
+                    <StackPanel>
+                        <DockPanel>
+                            <TextBlock Width="72" VerticalAlignment="Center" Text="{Binding TouchpadEndX, Mode=OneWay, StringFormat={}X: {0}}" />
+                            <Slider Width="240" Minimum="0" Maximum="1919" TickFrequency="1" IsMoveToPointEnabled="True" Value="{Binding TouchpadEndX, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        </DockPanel>
+                        <DockPanel Margin="0,6,0,0">
+                            <TextBlock Width="72" VerticalAlignment="Center" Text="{Binding TouchpadEndY, Mode=OneWay, StringFormat={}Y: {0}}" />
+                            <Slider Width="240" Minimum="0" Maximum="942" TickFrequency="1" IsMoveToPointEnabled="True" Value="{Binding TouchpadEndY, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        </DockPanel>
+                    </StackPanel>
+                </ui:SettingsCard>
+                <ui:SettingsCard Header="Swipe duration" Visibility="{Binding TouchpadSwipeSettingsVisibility, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
+                    <DockPanel>
+                        <TextBox IsReadOnly="True" Text="{Binding TouchpadSwipeDuration, Mode=OneWay, StringFormat={}{0:N0} ms}" />
+                        <Slider Width="220" Margin="6,0,0,0" Minimum="16" Maximum="2000" TickFrequency="16" IsSnapToTickEnabled="True" Value="{Binding TouchpadSwipeDuration, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    </DockPanel>
+                </ui:SettingsCard>
+            </ikw:SimpleStackPanel>
+        </ikw:SimpleStackPanel>
+
         <!--  Trigger settings  -->
         <ikw:SimpleStackPanel Spacing="8" Visibility="{Binding TriggerSettingsSectionVisibility, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
             <TextBlock Style="{StaticResource BaseTextBlockStyle}" Text="Trigger settings" />

--- a/HandheldCompanion/Views/Pages/ActionSettingsPage.xaml
+++ b/HandheldCompanion/Views/Pages/ActionSettingsPage.xaml
@@ -140,15 +140,7 @@
                     d:Visibility="Visible"
                     Header="{x:Static resx:Resources.LayoutPage_HapticFeedback}"
                     Visibility="{Binding ActionTypeIndex, Mode=OneWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource IndexToVisibilityConverter}, ConverterParameter=1|3|4|5|6|8}">
-                    <StackPanel>
-                        <DockPanel
-                            Margin="0,0,0,6"
-                            d:Visibility="Visible"
-                            Visibility="{Binding TrackpadClickHapticOverrideVisibility, Mode=OneWay}">
-                            <ui:ToggleSwitch DockPanel.Dock="Right" IsOn="{Binding UseGlobalTrackpadClickHaptics, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                            <TextBlock VerticalAlignment="Center" Text="{x:Static resx:Resources.LayoutPage_UseGlobalTrackpadClickHaptics}" />
-                        </DockPanel>
-                        <DockPanel IsEnabled="{Binding HapticControlsEnabled, Mode=OneWay}">
+                    <DockPanel>
                             <ComboBox Width="105" SelectedIndex="{Binding HapticModeIndex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
                                 <ComboBoxItem Content="Off" />
                                 <ComboBoxItem Content="Down" />
@@ -163,8 +155,7 @@
                                 <ComboBoxItem Content="Medium" />
                                 <ComboBoxItem Content="High" />
                             </ComboBox>
-                        </DockPanel>
-                    </StackPanel>
+                    </DockPanel>
                 </ui:SettingsCard>
             </ikw:SimpleStackPanel>
         </ikw:SimpleStackPanel>

--- a/HandheldCompanion/Views/Pages/ActionSettingsPage.xaml
+++ b/HandheldCompanion/Views/Pages/ActionSettingsPage.xaml
@@ -35,6 +35,7 @@
                         <ComboBoxItem Content="{x:Static resx:Resources.LayoutPage_ActionType_Trigger}" IsEnabled="True" />
                         <ComboBoxItem Content="{x:Static resx:Resources.LayoutPage_ActionType_Shift}" IsEnabled="True" />
                         <ComboBoxItem Content="{x:Static resx:Resources.LayoutPage_ActionType_Inherit}" IsEnabled="True" />
+                        <ComboBoxItem Content="{x:Static resx:Resources.LayoutPage_ActionType_Touchpad}" IsEnabled="True" Visibility="{Binding TouchpadActionTypeVisibility, Mode=OneWay}" />
                     </ComboBox>
                 </ui:SettingsCard>
 
@@ -122,8 +123,15 @@
                 </ui:SettingsCard>
 
                 <!--  Haptic Feedback  -->
-                <ui:SettingsCard Header="{x:Static resx:Resources.LayoutPage_HapticFeedback}" Visibility="{Binding ActionTypeIndex, Mode=OneWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource IndexToVisibilityConverter}, ConverterParameter=1|3|4|5|6}">
-                    <DockPanel>
+                <ui:SettingsCard Header="{x:Static resx:Resources.LayoutPage_HapticFeedback}" Visibility="{Binding ActionTypeIndex, Mode=OneWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource IndexToVisibilityConverter}, ConverterParameter=1|3|4|5|6|8}">
+                    <StackPanel>
+                        <DockPanel Margin="0,0,0,6" Visibility="{Binding TrackpadClickHapticOverrideVisibility, Mode=OneWay}">
+                            <ui:ToggleSwitch
+                                DockPanel.Dock="Right"
+                                IsOn="{Binding UseGlobalTrackpadClickHaptics, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <TextBlock VerticalAlignment="Center" Text="{x:Static resx:Resources.LayoutPage_UseGlobalTrackpadClickHaptics}" />
+                        </DockPanel>
+                    <DockPanel IsEnabled="{Binding HapticControlsEnabled, Mode=OneWay}">
                         <ComboBox Width="105" SelectedIndex="{Binding HapticModeIndex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
                             <ComboBoxItem Content="Off" />
                             <ComboBoxItem Content="Down" />
@@ -139,39 +147,40 @@
                             <ComboBoxItem Content="High" />
                         </ComboBox>
                     </DockPanel>
+                    </StackPanel>
                 </ui:SettingsCard>
             </ikw:SimpleStackPanel>
         </ikw:SimpleStackPanel>
 
-        <!--  DualSense touchpad gesture settings  -->
+        <!--  Touchpad gesture settings  -->
         <ikw:SimpleStackPanel Spacing="8" Visibility="{Binding TouchpadSettingsVisibility, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
-            <TextBlock Style="{StaticResource BaseTextBlockStyle}" Text="DualSense touchpad" />
+            <TextBlock Style="{StaticResource BaseTextBlockStyle}" Text="{x:Static resx:Resources.LayoutPage_TouchpadSettings}" />
             <ikw:SimpleStackPanel Spacing="3">
-                <ui:SettingsCard Header="Start position" Description="{Binding TouchpadCoordinateRangeDescription, Mode=OneWay}">
+                <ui:SettingsCard Header="{x:Static resx:Resources.LayoutPage_TouchpadStartPosition}" Description="{Binding TouchpadCoordinateRangeDescription, Mode=OneWay}">
                     <StackPanel>
                         <DockPanel>
                             <TextBlock Width="72" VerticalAlignment="Center" Text="{Binding TouchpadX, Mode=OneWay, StringFormat={}X: {0}}" />
-                            <Slider Width="240" Minimum="0" Maximum="{Binding TouchpadMaxX, Mode=OneWay}" TickFrequency="1" IsMoveToPointEnabled="True" Value="{Binding TouchpadX, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <Slider Width="240" Minimum="0" Maximum="{Binding TouchpadMaxX, Mode=OneWay}" TickFrequency="1" IsSnapToTickEnabled="True" IsMoveToPointEnabled="True" Value="{Binding TouchpadX, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                         </DockPanel>
                         <DockPanel Margin="0,6,0,0">
                             <TextBlock Width="72" VerticalAlignment="Center" Text="{Binding TouchpadY, Mode=OneWay, StringFormat={}Y: {0}}" />
-                            <Slider Width="240" Minimum="0" Maximum="{Binding TouchpadMaxY, Mode=OneWay}" TickFrequency="1" IsMoveToPointEnabled="True" Value="{Binding TouchpadY, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <Slider Width="240" Minimum="0" Maximum="{Binding TouchpadMaxY, Mode=OneWay}" TickFrequency="1" IsSnapToTickEnabled="True" IsMoveToPointEnabled="True" Value="{Binding TouchpadY, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                         </DockPanel>
                     </StackPanel>
                 </ui:SettingsCard>
-                <ui:SettingsCard Header="End position" Visibility="{Binding TouchpadSwipeSettingsVisibility, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
+                <ui:SettingsCard Header="{x:Static resx:Resources.LayoutPage_TouchpadEndPosition}" Visibility="{Binding TouchpadSwipeSettingsVisibility, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
                     <StackPanel>
                         <DockPanel>
                             <TextBlock Width="72" VerticalAlignment="Center" Text="{Binding TouchpadEndX, Mode=OneWay, StringFormat={}X: {0}}" />
-                            <Slider Width="240" Minimum="0" Maximum="{Binding TouchpadMaxX, Mode=OneWay}" TickFrequency="1" IsMoveToPointEnabled="True" Value="{Binding TouchpadEndX, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <Slider Width="240" Minimum="0" Maximum="{Binding TouchpadMaxX, Mode=OneWay}" TickFrequency="1" IsSnapToTickEnabled="True" IsMoveToPointEnabled="True" Value="{Binding TouchpadEndX, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                         </DockPanel>
                         <DockPanel Margin="0,6,0,0">
                             <TextBlock Width="72" VerticalAlignment="Center" Text="{Binding TouchpadEndY, Mode=OneWay, StringFormat={}Y: {0}}" />
-                            <Slider Width="240" Minimum="0" Maximum="{Binding TouchpadMaxY, Mode=OneWay}" TickFrequency="1" IsMoveToPointEnabled="True" Value="{Binding TouchpadEndY, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <Slider Width="240" Minimum="0" Maximum="{Binding TouchpadMaxY, Mode=OneWay}" TickFrequency="1" IsSnapToTickEnabled="True" IsMoveToPointEnabled="True" Value="{Binding TouchpadEndY, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                         </DockPanel>
                     </StackPanel>
                 </ui:SettingsCard>
-                <ui:SettingsCard Header="Swipe duration" Visibility="{Binding TouchpadSwipeSettingsVisibility, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
+                <ui:SettingsCard Header="{x:Static resx:Resources.LayoutPage_TouchpadSwipeDuration}" Visibility="{Binding TouchpadSwipeSettingsVisibility, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
                     <DockPanel>
                         <TextBox IsReadOnly="True" Text="{Binding TouchpadSwipeDuration, Mode=OneWay, StringFormat={}{0:N0} ms}" />
                         <Slider Width="220" Margin="6,0,0,0" Minimum="16" Maximum="{Binding TouchpadMaxDuration, Mode=OneWay}" TickFrequency="16" IsSnapToTickEnabled="True" Value="{Binding TouchpadSwipeDuration, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
@@ -377,7 +386,7 @@
                 </ui:SettingsCard>
 
                 <!--  Output shape  -->
-                <ui:SettingsCard Header="Output shape">
+                <ui:SettingsCard Header="Output shape" Visibility="{Binding AxisOutputShapeVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
                     <ComboBox SelectedIndex="{Binding Axis2AxisOutputShapeIndex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
                         <ComboBoxItem>Default</ComboBoxItem>
                         <ComboBoxItem>Circle</ComboBoxItem>

--- a/HandheldCompanion/Views/Pages/ActionSettingsPage.xaml
+++ b/HandheldCompanion/Views/Pages/ActionSettingsPage.xaml
@@ -199,21 +199,21 @@
                                 Y1="{Binding TouchpadVisualizerLineStartY, Mode=OneWay}"
                                 Y2="{Binding TouchpadVisualizerLineEndY, Mode=OneWay}" />
                             <Ellipse
+                                Canvas.Left="{Binding TouchpadVisualizerStartX, Mode=OneWay}"
+                                Canvas.Top="{Binding TouchpadVisualizerStartY, Mode=OneWay}"
                                 Width="8"
                                 Height="8"
                                 Fill="#FFFFFFFF"
                                 Stroke="#FF9AA0AA"
-                                StrokeThickness="1"
-                                Canvas.Left="{Binding TouchpadVisualizerStartX, Mode=OneWay}"
-                                Canvas.Top="{Binding TouchpadVisualizerStartY, Mode=OneWay}" />
+                                StrokeThickness="1" />
                             <Ellipse
+                                Canvas.Left="{Binding TouchpadVisualizerEndX, Mode=OneWay}"
+                                Canvas.Top="{Binding TouchpadVisualizerEndY, Mode=OneWay}"
                                 Width="8"
                                 Height="8"
                                 Fill="#FF5AC8FA"
                                 Stroke="#FFB7E9FF"
                                 StrokeThickness="1"
-                                Canvas.Left="{Binding TouchpadVisualizerEndX, Mode=OneWay}"
-                                Canvas.Top="{Binding TouchpadVisualizerEndY, Mode=OneWay}"
                                 Visibility="{Binding TouchpadSwipeSettingsVisibility, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" />
                         </Canvas>
                     </Border>
@@ -249,6 +249,12 @@
                                 Value="{Binding TouchpadY, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                         </DockPanel>
                     </StackPanel>
+                </ui:SettingsCard>
+                <ui:SettingsCard Header="Touchpad finger">
+                    <ComboBox SelectedIndex="{Binding TouchpadFingerIndex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                        <ComboBoxItem Content="Left" />
+                        <ComboBoxItem Content="Right" />
+                    </ComboBox>
                 </ui:SettingsCard>
                 <ui:SettingsCard
                     d:Visibility="Visible"

--- a/HandheldCompanion/Views/Pages/ActionSettingsPage.xaml
+++ b/HandheldCompanion/Views/Pages/ActionSettingsPage.xaml
@@ -642,7 +642,7 @@
                 <ui:SettingsCard
                     d:Visibility="Visible"
                     Header="Inner deadzone"
-                    Visibility="{Binding AxisInvertVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
+                    Visibility="{Binding AxisDeadzoneVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
                     <DockPanel>
                         <TextBox
                             HorizontalContentAlignment="Center"
@@ -667,7 +667,7 @@
                 <ui:SettingsCard
                     d:Visibility="Visible"
                     Header="Outer deadzone"
-                    Visibility="{Binding AxisInvertVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
+                    Visibility="{Binding AxisDeadzoneVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
                     <DockPanel>
                         <TextBox
                             HorizontalContentAlignment="Center"
@@ -692,7 +692,7 @@
                 <ui:SettingsCard
                     d:Visibility="Visible"
                     Header="Anti deadzone"
-                    Visibility="{Binding AxisInvertVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
+                    Visibility="{Binding AxisDeadzoneVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
                     <DockPanel>
                         <TextBox
                             HorizontalContentAlignment="Center"

--- a/HandheldCompanion/Views/Pages/ActionSettingsPage.xaml
+++ b/HandheldCompanion/Views/Pages/ActionSettingsPage.xaml
@@ -14,7 +14,7 @@
     Title="Action Settings"
     d:Background="White"
     d:DataContext="{d:DesignInstance Type=viewmodels:ButtonMappingViewModel}"
-    d:DesignHeight="4100"
+    d:DesignHeight="4300"
     d:DesignWidth="1000"
     mc:Ignorable="d">
 

--- a/HandheldCompanion/Views/Pages/ActionSettingsPage.xaml
+++ b/HandheldCompanion/Views/Pages/ActionSettingsPage.xaml
@@ -14,7 +14,7 @@
     Title="Action Settings"
     d:Background="White"
     d:DataContext="{d:DesignInstance Type=viewmodels:ButtonMappingViewModel}"
-    d:DesignHeight="3000"
+    d:DesignHeight="4100"
     d:DesignWidth="1000"
     mc:Ignorable="d">
 
@@ -37,6 +37,7 @@
                         <ComboBoxItem Content="{x:Static resx:Resources.LayoutPage_ActionType_Shift}" IsEnabled="{Binding SupportedActionTypes, Converter={StaticResource ActionTypeSupportedConverter}, ConverterParameter={x:Static actions:ActionType.Shift}}" />
                         <ComboBoxItem Content="{x:Static resx:Resources.LayoutPage_ActionType_Inherit}" IsEnabled="{Binding SupportedActionTypes, Converter={StaticResource ActionTypeSupportedConverter}, ConverterParameter={x:Static actions:ActionType.Inherit}}" />
                         <ComboBoxItem
+                            d:Visibility="Visible"
                             Content="{x:Static resx:Resources.LayoutPage_ActionType_Touchpad}"
                             IsEnabled="{Binding SupportedActionTypes, Converter={StaticResource ActionTypeSupportedConverter}, ConverterParameter={x:Static actions:ActionType.Touchpad}}"
                             Visibility="{Binding TouchpadActionTypeVisibility, Mode=OneWay}" />
@@ -70,7 +71,10 @@
                 </ui:SettingsCard>
 
                 <!--  Modifiers  -->
-                <ui:SettingsCard Header="Modifier(s)" Visibility="{Binding HasModifier, Mode=OneWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <ui:SettingsCard
+                    d:Visibility="Visible"
+                    Header="Modifier(s)"
+                    Visibility="{Binding HasModifier, Mode=OneWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BooleanToVisibilityConverter}}">
                     <ComboBox SelectedIndex="{Binding ModifierIndex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
                         <ComboBoxItem Content="None" />
                         <ComboBoxItem Content="Shift" />
@@ -85,6 +89,7 @@
 
                 <!--  Input Type and Shifting  -->
                 <ui:SettingsCard
+                    d:Visibility="Visible"
                     Description="{x:Static resx:Resources.LayoutPage_InputShiftDesc}"
                     Header="{x:Static resx:Resources.LayoutPage_InputShift}"
                     Visibility="{Binding ActionTypeIndex, Mode=OneWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource IndexToVisibilityConverter}, ConverterParameter=1|2|3|4|5|6|7|8|9|10}">
@@ -95,7 +100,7 @@
                             <ComboBoxItem Content="Enabled on shift (strict)" />
                             <ComboBoxItem Content="Enabled on shift (any)" />
                         </ComboBox>
-                        <ikw:SimpleStackPanel Visibility="{Binding ShowShiftSelection, Converter={StaticResource BooleanToVisibilityConverter}}">
+                        <ikw:SimpleStackPanel d:Visibility="Visible" Visibility="{Binding ShowShiftSelection, Converter={StaticResource BooleanToVisibilityConverter}}">
                             <WrapPanel>
                                 <CheckBox Content="A" IsChecked="{Binding ShiftA, Mode=TwoWay}" />
                                 <CheckBox Content="B" IsChecked="{Binding ShiftB, Mode=TwoWay}" />
@@ -110,6 +115,7 @@
 
                 <!--  Action type (Press Type)  -->
                 <ui:SettingsCard
+                    d:Visibility="Visible"
                     Description="{Binding PressTypeTooltip, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
                     Header="{x:Static resx:Resources.LayoutPage_PressType}"
                     Visibility="{Binding ActionTypeIndex, Mode=OneWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource IndexToVisibilityConverter}, ConverterParameter=1|2|3|4|5|6|7|8|9|10}">
@@ -122,14 +128,23 @@
                 </ui:SettingsCard>
 
                 <!--  Interruptable  -->
-                <ui:SettingsCard Header="{x:Static resx:Resources.LayoutPage_Interruptable}" Visibility="{Binding GeneralActionVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
+                <ui:SettingsCard
+                    d:Visibility="Visible"
+                    Header="{x:Static resx:Resources.LayoutPage_Interruptable}"
+                    Visibility="{Binding GeneralActionVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
                     <ui:ToggleSwitch IsOn="{Binding HasInterruptable, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                 </ui:SettingsCard>
 
                 <!--  Haptic Feedback  -->
-                <ui:SettingsCard Header="{x:Static resx:Resources.LayoutPage_HapticFeedback}" Visibility="{Binding ActionTypeIndex, Mode=OneWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource IndexToVisibilityConverter}, ConverterParameter=1|3|4|5|6|8}">
+                <ui:SettingsCard
+                    d:Visibility="Visible"
+                    Header="{x:Static resx:Resources.LayoutPage_HapticFeedback}"
+                    Visibility="{Binding ActionTypeIndex, Mode=OneWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource IndexToVisibilityConverter}, ConverterParameter=1|3|4|5|6|8}">
                     <StackPanel>
-                        <DockPanel Margin="0,0,0,6" Visibility="{Binding TrackpadClickHapticOverrideVisibility, Mode=OneWay}">
+                        <DockPanel
+                            Margin="0,0,0,6"
+                            d:Visibility="Visible"
+                            Visibility="{Binding TrackpadClickHapticOverrideVisibility, Mode=OneWay}">
                             <ui:ToggleSwitch DockPanel.Dock="Right" IsOn="{Binding UseGlobalTrackpadClickHaptics, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                             <TextBlock VerticalAlignment="Center" Text="{x:Static resx:Resources.LayoutPage_UseGlobalTrackpadClickHaptics}" />
                         </DockPanel>
@@ -155,9 +170,54 @@
         </ikw:SimpleStackPanel>
 
         <!--  Touchpad gesture settings  -->
-        <ikw:SimpleStackPanel Spacing="8" Visibility="{Binding TouchpadSettingsVisibility, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
+        <ikw:SimpleStackPanel
+            d:Visibility="Visible"
+            Spacing="8"
+            Visibility="{Binding TouchpadSettingsVisibility, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
             <TextBlock Style="{StaticResource BaseTextBlockStyle}" Text="{x:Static resx:Resources.LayoutPage_TouchpadSettings}" />
             <ikw:SimpleStackPanel Spacing="3">
+                <ui:SettingsCard
+                    d:Visibility="Visible"
+                    Header="Touchpad visualizer"
+                    Visibility="{Binding TouchpadVisualizerVisibility, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
+                    <Border
+                        Width="240"
+                        Height="120"
+                        HorizontalAlignment="Center"
+                        Background="#22262C"
+                        BorderBrush="#4A4F57"
+                        BorderThickness="1"
+                        CornerRadius="3">
+                        <Canvas Width="238" Height="118">
+                            <Line
+                                Stroke="#80FFFFFF"
+                                StrokeDashArray="2,2"
+                                StrokeThickness="1"
+                                Visibility="{Binding TouchpadSwipeSettingsVisibility, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
+                                X1="{Binding TouchpadVisualizerLineStartX, Mode=OneWay}"
+                                X2="{Binding TouchpadVisualizerLineEndX, Mode=OneWay}"
+                                Y1="{Binding TouchpadVisualizerLineStartY, Mode=OneWay}"
+                                Y2="{Binding TouchpadVisualizerLineEndY, Mode=OneWay}" />
+                            <Ellipse
+                                Width="8"
+                                Height="8"
+                                Fill="#FFFFFFFF"
+                                Stroke="#FF9AA0AA"
+                                StrokeThickness="1"
+                                Canvas.Left="{Binding TouchpadVisualizerStartX, Mode=OneWay}"
+                                Canvas.Top="{Binding TouchpadVisualizerStartY, Mode=OneWay}" />
+                            <Ellipse
+                                Width="8"
+                                Height="8"
+                                Fill="#FF5AC8FA"
+                                Stroke="#FFB7E9FF"
+                                StrokeThickness="1"
+                                Canvas.Left="{Binding TouchpadVisualizerEndX, Mode=OneWay}"
+                                Canvas.Top="{Binding TouchpadVisualizerEndY, Mode=OneWay}"
+                                Visibility="{Binding TouchpadSwipeSettingsVisibility, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" />
+                        </Canvas>
+                    </Border>
+                </ui:SettingsCard>
                 <ui:SettingsCard Description="{Binding TouchpadCoordinateRangeDescription, Mode=OneWay}" Header="{x:Static resx:Resources.LayoutPage_TouchpadStartPosition}">
                     <StackPanel>
                         <DockPanel>
@@ -190,7 +250,10 @@
                         </DockPanel>
                     </StackPanel>
                 </ui:SettingsCard>
-                <ui:SettingsCard Header="{x:Static resx:Resources.LayoutPage_TouchpadEndPosition}" Visibility="{Binding TouchpadSwipeSettingsVisibility, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
+                <ui:SettingsCard
+                    d:Visibility="Visible"
+                    Header="{x:Static resx:Resources.LayoutPage_TouchpadEndPosition}"
+                    Visibility="{Binding TouchpadSwipeSettingsVisibility, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
                     <StackPanel>
                         <DockPanel>
                             <TextBlock
@@ -222,7 +285,10 @@
                         </DockPanel>
                     </StackPanel>
                 </ui:SettingsCard>
-                <ui:SettingsCard Header="{x:Static resx:Resources.LayoutPage_TouchpadSwipeDuration}" Visibility="{Binding TouchpadSwipeSettingsVisibility, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
+                <ui:SettingsCard
+                    d:Visibility="Visible"
+                    Header="{x:Static resx:Resources.LayoutPage_TouchpadSwipeDuration}"
+                    Visibility="{Binding TouchpadSwipeSettingsVisibility, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
                     <DockPanel>
                         <TextBox IsReadOnly="True" Text="{Binding TouchpadSwipeDuration, Mode=OneWay, StringFormat={}{0:N0} ms}" />
                         <Slider
@@ -239,12 +305,18 @@
         </ikw:SimpleStackPanel>
 
         <!--  Trigger settings  -->
-        <ikw:SimpleStackPanel Spacing="8" Visibility="{Binding TriggerSettingsSectionVisibility, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
+        <ikw:SimpleStackPanel
+            d:Visibility="Visible"
+            Spacing="8"
+            Visibility="{Binding TriggerSettingsSectionVisibility, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
             <TextBlock Style="{StaticResource BaseTextBlockStyle}" Text="Trigger settings" />
 
             <ikw:SimpleStackPanel Spacing="3">
                 <!--  Trigger value  -->
-                <ui:SettingsCard Header="Trigger value" Visibility="{Binding TriggerOutputVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
+                <ui:SettingsCard
+                    d:Visibility="Visible"
+                    Header="Trigger value"
+                    Visibility="{Binding TriggerOutputVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
                     <DockPanel Margin="12,0,0,0">
                         <TextBox
                             HorizontalContentAlignment="Center"
@@ -266,7 +338,10 @@
                 </ui:SettingsCard>
 
                 <!--  Trigger Inner deadzone  -->
-                <ui:SettingsCard Header="Inner deadzone" Visibility="{Binding TriggerDeadzoneVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
+                <ui:SettingsCard
+                    d:Visibility="Visible"
+                    Header="Inner deadzone"
+                    Visibility="{Binding TriggerDeadzoneVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
                     <DockPanel>
                         <TextBox
                             HorizontalContentAlignment="Center"
@@ -288,7 +363,10 @@
                 </ui:SettingsCard>
 
                 <!--  Trigger Outer deadzone  -->
-                <ui:SettingsCard Header="Outer deadzone" Visibility="{Binding TriggerDeadzoneVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
+                <ui:SettingsCard
+                    d:Visibility="Visible"
+                    Header="Outer deadzone"
+                    Visibility="{Binding TriggerDeadzoneVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
                     <DockPanel>
                         <TextBox
                             HorizontalContentAlignment="Center"
@@ -310,7 +388,10 @@
                 </ui:SettingsCard>
 
                 <!--  Trigger Anti deadzone  -->
-                <ui:SettingsCard Header="Anti deadzone" Visibility="{Binding TriggerDeadzoneVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
+                <ui:SettingsCard
+                    d:Visibility="Visible"
+                    Header="Anti deadzone"
+                    Visibility="{Binding TriggerDeadzoneVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
                     <DockPanel>
                         <TextBox
                             HorizontalContentAlignment="Center"
@@ -334,12 +415,18 @@
         </ikw:SimpleStackPanel>
 
         <!--  Axis settings  -->
-        <ikw:SimpleStackPanel Spacing="8" Visibility="{Binding AxisSettingsSectionVisibility, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
+        <ikw:SimpleStackPanel
+            d:Visibility="Visible"
+            Spacing="8"
+            Visibility="{Binding AxisSettingsSectionVisibility, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
             <TextBlock Style="{StaticResource BaseTextBlockStyle}" Text="Axis settings" />
 
             <ikw:SimpleStackPanel Spacing="3">
                 <!--  Axis visualizer  -->
-                <ui:SettingsCard Header="Axis visualizer" Visibility="{Binding AxisVisualizerVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
+                <ui:SettingsCard
+                    d:Visibility="Visible"
+                    Header="Axis visualizer"
+                    Visibility="{Binding AxisVisualizerVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
                     <Grid
                         Width="200"
                         Height="200"
@@ -397,8 +484,11 @@
                 </ui:SettingsCard>
 
                 <!--  Axis Direction  -->
-                <ui:SettingsCard Header="Axis direction" Visibility="{Binding AxisDirectionVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
-                    <StackPanel Visibility="{Binding IsAxisMapping, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <ui:SettingsCard
+                    d:Visibility="Visible"
+                    Header="Axis direction"
+                    Visibility="{Binding AxisDirectionVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
+                    <StackPanel d:Visibility="Visible" Visibility="{Binding IsAxisMapping, Converter={StaticResource BooleanToVisibilityConverter}}">
                         <WrapPanel Orientation="Horizontal">
                             <CheckBox Content="Up" IsChecked="{Binding IsUp, Mode=TwoWay}" />
                             <CheckBox Content="Down" IsChecked="{Binding IsDown, Mode=TwoWay}" />
@@ -411,7 +501,10 @@
                 </ui:SettingsCard>
 
                 <!--  Axis Threshold  -->
-                <ui:SettingsCard Header="Axis threshold" Visibility="{Binding AxisThresholdVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
+                <ui:SettingsCard
+                    d:Visibility="Visible"
+                    Header="Axis threshold"
+                    Visibility="{Binding AxisThresholdVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
                     <DockPanel>
                         <TextBox
                             HorizontalContentAlignment="Center"
@@ -435,7 +528,10 @@
                 </ui:SettingsCard>
 
                 <!--  Trigger Threshold  -->
-                <ui:SettingsCard Header="Trigger threshold" Visibility="{Binding Trigger2ButtonVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
+                <ui:SettingsCard
+                    d:Visibility="Visible"
+                    Header="Trigger threshold"
+                    Visibility="{Binding Trigger2ButtonVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
                     <DockPanel>
                         <TextBox
                             HorizontalContentAlignment="Center"
@@ -459,7 +555,10 @@
                 </ui:SettingsCard>
 
                 <!--  Output shape  -->
-                <ui:SettingsCard Header="Output shape" Visibility="{Binding AxisOutputShapeVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
+                <ui:SettingsCard
+                    d:Visibility="Visible"
+                    Header="Output shape"
+                    Visibility="{Binding AxisOutputShapeVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
                     <ComboBox SelectedIndex="{Binding Axis2AxisOutputShapeIndex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
                         <ComboBoxItem>Default</ComboBoxItem>
                         <ComboBoxItem>Circle</ComboBoxItem>
@@ -469,7 +568,10 @@
                 </ui:SettingsCard>
 
                 <!--  Button axis output X/Y  -->
-                <ui:SettingsCard Header="Axis output" Visibility="{Binding Button2AxisVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
+                <ui:SettingsCard
+                    d:Visibility="Visible"
+                    Header="Axis output"
+                    Visibility="{Binding Button2AxisVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
                     <StackPanel>
                         <DockPanel>
                             <TextBlock VerticalAlignment="Center" Text="X" />
@@ -515,17 +617,26 @@
                 </ui:SettingsCard>
 
                 <!--  Invert horizontal  -->
-                <ui:SettingsCard ContentAlignment="Left" Visibility="{Binding AxisInvertVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
+                <ui:SettingsCard
+                    d:Visibility="Visible"
+                    ContentAlignment="Left"
+                    Visibility="{Binding AxisInvertVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
                     <CheckBox Content="Invert horizontal axis" IsChecked="{Binding Axis2AxisInvertHorizontal, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                 </ui:SettingsCard>
 
                 <!--  Invert vertical  -->
-                <ui:SettingsCard ContentAlignment="Left" Visibility="{Binding AxisInvertVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
+                <ui:SettingsCard
+                    d:Visibility="Visible"
+                    ContentAlignment="Left"
+                    Visibility="{Binding AxisInvertVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
                     <CheckBox Content="Invert vertical axis" IsChecked="{Binding Axis2AxisInvertVertical, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                 </ui:SettingsCard>
 
                 <!--  Axis Inner deadzone  -->
-                <ui:SettingsCard Header="Inner deadzone" Visibility="{Binding AxisInvertVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
+                <ui:SettingsCard
+                    d:Visibility="Visible"
+                    Header="Inner deadzone"
+                    Visibility="{Binding AxisInvertVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
                     <DockPanel>
                         <TextBox
                             HorizontalContentAlignment="Center"
@@ -547,7 +658,10 @@
                 </ui:SettingsCard>
 
                 <!--  Axis Outer deadzone  -->
-                <ui:SettingsCard Header="Outer deadzone" Visibility="{Binding AxisInvertVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
+                <ui:SettingsCard
+                    d:Visibility="Visible"
+                    Header="Outer deadzone"
+                    Visibility="{Binding AxisInvertVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
                     <DockPanel>
                         <TextBox
                             HorizontalContentAlignment="Center"
@@ -569,7 +683,10 @@
                 </ui:SettingsCard>
 
                 <!--  Anti deadzone  -->
-                <ui:SettingsCard Header="Anti deadzone" Visibility="{Binding AxisInvertVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
+                <ui:SettingsCard
+                    d:Visibility="Visible"
+                    Header="Anti deadzone"
+                    Visibility="{Binding AxisInvertVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
                     <DockPanel>
                         <TextBox
                             HorizontalContentAlignment="Center"
@@ -648,12 +765,18 @@
         </ikw:SimpleStackPanel>
 
         <!--  Mouse settings  -->
-        <ikw:SimpleStackPanel Spacing="8" Visibility="{Binding MouseSettingsSectionVisibility, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
+        <ikw:SimpleStackPanel
+            d:Visibility="Visible"
+            Spacing="8"
+            Visibility="{Binding MouseSettingsSectionVisibility, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
             <TextBlock Style="{StaticResource BaseTextBlockStyle}" Text="Mouse settings" />
 
             <ikw:SimpleStackPanel Spacing="3">
                 <!--  Move mouse cursor to X,Y (Button)  -->
-                <ui:SettingsCard Header="Mouse position" Visibility="{Binding Button2MouseTo, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
+                <ui:SettingsCard
+                    d:Visibility="Visible"
+                    Header="Mouse position"
+                    Visibility="{Binding Button2MouseTo, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
                     <ikw:SimpleStackPanel Spacing="3">
                         <StackPanel Orientation="Horizontal">
                             <TextBlock VerticalAlignment="Center" Text="X" />
@@ -677,12 +800,18 @@
                 </ui:SettingsCard>
 
                 <!--  Restore previous position (Button)  -->
-                <ui:SettingsCard Header="Restore previous position" Visibility="{Binding Button2MouseTo, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
+                <ui:SettingsCard
+                    d:Visibility="Visible"
+                    Header="Restore previous position"
+                    Visibility="{Binding Button2MouseTo, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
                     <ui:ToggleSwitch IsOn="{Binding Button2MouseRestore, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                 </ui:SettingsCard>
 
                 <!--  Move mouse cursor to X,Y (Axis)  -->
-                <ui:SettingsCard Header="Mouse position" Visibility="{Binding Axis2MouseTo, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
+                <ui:SettingsCard
+                    d:Visibility="Visible"
+                    Header="Mouse position"
+                    Visibility="{Binding Axis2MouseTo, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
                     <StackPanel>
                         <WrapPanel Orientation="Horizontal">
                             <TextBlock VerticalAlignment="Center" Text="X" />
@@ -706,12 +835,18 @@
                 </ui:SettingsCard>
 
                 <!--  Restore previous position (Axis)  -->
-                <ui:SettingsCard Header="Restore previous position" Visibility="{Binding Axis2MouseTo, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
+                <ui:SettingsCard
+                    d:Visibility="Visible"
+                    Header="Restore previous position"
+                    Visibility="{Binding Axis2MouseTo, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
                     <ui:ToggleSwitch IsOn="{Binding Axis2MouseRestore, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                 </ui:SettingsCard>
 
                 <!--  Sensitivity  -->
-                <ui:SettingsCard Header="Sensitivity" Visibility="{Binding Axis2MouseVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
+                <ui:SettingsCard
+                    d:Visibility="Visible"
+                    Header="Sensitivity"
+                    Visibility="{Binding Axis2MouseVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
                     <DockPanel>
                         <TextBox
                             HorizontalContentAlignment="Center"
@@ -733,7 +868,10 @@
                 </ui:SettingsCard>
 
                 <!--  Acceleration  -->
-                <ui:SettingsCard Header="Acceleration" Visibility="{Binding Axis2MouseVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
+                <ui:SettingsCard
+                    d:Visibility="Visible"
+                    Header="Acceleration"
+                    Visibility="{Binding Axis2MouseVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
                     <DockPanel>
                         <TextBox
                             HorizontalContentAlignment="Center"
@@ -756,12 +894,18 @@
                 </ui:SettingsCard>
 
                 <!--  Filtering  -->
-                <ui:SettingsCard Header="Filtering" Visibility="{Binding Axis2TouchpadVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
+                <ui:SettingsCard
+                    d:Visibility="Visible"
+                    Header="Filtering"
+                    Visibility="{Binding Axis2TouchpadVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
                     <ui:ToggleSwitch IsOn="{Binding Axis2MouseFiltering, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                 </ui:SettingsCard>
 
                 <!--  Filtering cutoff  -->
-                <ui:SettingsCard Header="Filtering cutoff (less is more filter)" Visibility="{Binding Axis2MouseFiltering, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <ui:SettingsCard
+                    d:Visibility="Visible"
+                    Header="Filtering cutoff (less is more filter)"
+                    Visibility="{Binding Axis2MouseFiltering, Converter={StaticResource BooleanToVisibilityConverter}}">
                     <DockPanel>
                         <TextBox
                             HorizontalContentAlignment="Center"
@@ -784,7 +928,10 @@
                 </ui:SettingsCard>
 
                 <!--  Deadzone (Mouse)  -->
-                <ui:SettingsCard Header="Deadzone" Visibility="{Binding Axis2JoystickVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
+                <ui:SettingsCard
+                    d:Visibility="Visible"
+                    Header="Deadzone"
+                    Visibility="{Binding Axis2JoystickVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
                     <DockPanel>
                         <TextBox
                             HorizontalContentAlignment="Center"
@@ -808,22 +955,32 @@
         </ikw:SimpleStackPanel>
 
         <!--  Timing settings  -->
-        <ikw:SimpleStackPanel Spacing="8" Visibility="{Binding TimingSettingsSectionVisibility, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
+        <ikw:SimpleStackPanel
+            d:Visibility="Visible"
+            Spacing="8"
+            Visibility="{Binding TimingSettingsSectionVisibility, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
             <TextBlock Style="{StaticResource BaseTextBlockStyle}" Text="Timing settings" />
 
             <ikw:SimpleStackPanel Spacing="3">
                 <!--  Press to Toggle  -->
-                <ui:SettingsCard Header="{x:Static resx:Resources.LayoutPage_PressToToggle}" Visibility="{Binding GeneralActionVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
+                <ui:SettingsCard
+                    d:Visibility="Visible"
+                    Header="{x:Static resx:Resources.LayoutPage_PressToToggle}"
+                    Visibility="{Binding GeneralActionVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
                     <ui:ToggleSwitch IsOn="{Binding HasToggle, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                 </ui:SettingsCard>
 
                 <!--  Hold to Repeat  -->
-                <ui:SettingsCard Header="{x:Static resx:Resources.LayoutPage_HoldToRepeat}" Visibility="{Binding GeneralActionVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
+                <ui:SettingsCard
+                    d:Visibility="Visible"
+                    Header="{x:Static resx:Resources.LayoutPage_HoldToRepeat}"
+                    Visibility="{Binding GeneralActionVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
                     <ui:ToggleSwitch HorizontalAlignment="Right" IsOn="{Binding HasTurbo, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                 </ui:SettingsCard>
 
                 <!--  Repeat rate  -->
                 <ui:SettingsCard
+                    d:Visibility="Visible"
                     Header="Repeat rate"
                     IsEnabled="{Binding HasTurbo, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
                     Visibility="{Binding HasTurbo, Converter={StaticResource BooleanToVisibilityConverter}}">
@@ -849,7 +1006,10 @@
                 </ui:SettingsCard>
 
                 <!--  Start delay  -->
-                <ui:SettingsCard Header="Start delay" Visibility="{Binding GeneralActionVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
+                <ui:SettingsCard
+                    d:Visibility="Visible"
+                    Header="Start delay"
+                    Visibility="{Binding GeneralActionVisibility, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}">
                     <DockPanel>
                         <TextBox
                             HorizontalContentAlignment="Center"
@@ -872,6 +1032,7 @@
 
                 <!--  Press duration  -->
                 <ui:SettingsCard
+                    d:Visibility="Visible"
                     Header="Press duration"
                     IsEnabled="{Binding HasDuration, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
                     Visibility="{Binding HasDuration, Converter={StaticResource BooleanToVisibilityConverter}}">
@@ -897,4 +1058,3 @@
         </ikw:SimpleStackPanel>
     </ikw:SimpleStackPanel>
 </Page>
-

--- a/HandheldCompanion/Views/Pages/ActionSettingsPage.xaml
+++ b/HandheldCompanion/Views/Pages/ActionSettingsPage.xaml
@@ -147,15 +147,15 @@
         <ikw:SimpleStackPanel Spacing="8" Visibility="{Binding TouchpadSettingsVisibility, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
             <TextBlock Style="{StaticResource BaseTextBlockStyle}" Text="DualSense touchpad" />
             <ikw:SimpleStackPanel Spacing="3">
-                <ui:SettingsCard Header="Start position" Description="DualSense coordinates: X 0–1919, Y 0–942">
+                <ui:SettingsCard Header="Start position" Description="{Binding TouchpadCoordinateRangeDescription, Mode=OneWay}">
                     <StackPanel>
                         <DockPanel>
                             <TextBlock Width="72" VerticalAlignment="Center" Text="{Binding TouchpadX, Mode=OneWay, StringFormat={}X: {0}}" />
-                            <Slider Width="240" Minimum="0" Maximum="1919" TickFrequency="1" IsMoveToPointEnabled="True" Value="{Binding TouchpadX, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <Slider Width="240" Minimum="0" Maximum="{Binding TouchpadMaxX, Mode=OneWay}" TickFrequency="1" IsMoveToPointEnabled="True" Value="{Binding TouchpadX, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                         </DockPanel>
                         <DockPanel Margin="0,6,0,0">
                             <TextBlock Width="72" VerticalAlignment="Center" Text="{Binding TouchpadY, Mode=OneWay, StringFormat={}Y: {0}}" />
-                            <Slider Width="240" Minimum="0" Maximum="942" TickFrequency="1" IsMoveToPointEnabled="True" Value="{Binding TouchpadY, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <Slider Width="240" Minimum="0" Maximum="{Binding TouchpadMaxY, Mode=OneWay}" TickFrequency="1" IsMoveToPointEnabled="True" Value="{Binding TouchpadY, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                         </DockPanel>
                     </StackPanel>
                 </ui:SettingsCard>
@@ -163,18 +163,18 @@
                     <StackPanel>
                         <DockPanel>
                             <TextBlock Width="72" VerticalAlignment="Center" Text="{Binding TouchpadEndX, Mode=OneWay, StringFormat={}X: {0}}" />
-                            <Slider Width="240" Minimum="0" Maximum="1919" TickFrequency="1" IsMoveToPointEnabled="True" Value="{Binding TouchpadEndX, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <Slider Width="240" Minimum="0" Maximum="{Binding TouchpadMaxX, Mode=OneWay}" TickFrequency="1" IsMoveToPointEnabled="True" Value="{Binding TouchpadEndX, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                         </DockPanel>
                         <DockPanel Margin="0,6,0,0">
                             <TextBlock Width="72" VerticalAlignment="Center" Text="{Binding TouchpadEndY, Mode=OneWay, StringFormat={}Y: {0}}" />
-                            <Slider Width="240" Minimum="0" Maximum="942" TickFrequency="1" IsMoveToPointEnabled="True" Value="{Binding TouchpadEndY, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <Slider Width="240" Minimum="0" Maximum="{Binding TouchpadMaxY, Mode=OneWay}" TickFrequency="1" IsMoveToPointEnabled="True" Value="{Binding TouchpadEndY, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                         </DockPanel>
                     </StackPanel>
                 </ui:SettingsCard>
                 <ui:SettingsCard Header="Swipe duration" Visibility="{Binding TouchpadSwipeSettingsVisibility, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
                     <DockPanel>
                         <TextBox IsReadOnly="True" Text="{Binding TouchpadSwipeDuration, Mode=OneWay, StringFormat={}{0:N0} ms}" />
-                        <Slider Width="220" Margin="6,0,0,0" Minimum="16" Maximum="2000" TickFrequency="16" IsSnapToTickEnabled="True" Value="{Binding TouchpadSwipeDuration, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        <Slider Width="220" Margin="6,0,0,0" Minimum="16" Maximum="{Binding TouchpadMaxDuration, Mode=OneWay}" TickFrequency="16" IsSnapToTickEnabled="True" Value="{Binding TouchpadSwipeDuration, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                     </DockPanel>
                 </ui:SettingsCard>
             </ikw:SimpleStackPanel>

--- a/HandheldCompanion/Views/Pages/ActionSettingsPage.xaml
+++ b/HandheldCompanion/Views/Pages/ActionSettingsPage.xaml
@@ -2,6 +2,7 @@
     x:Class="HandheldCompanion.Views.Pages.ActionSettingsPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:actions="clr-namespace:HandheldCompanion.Actions"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:ikw="http://schemas.inkore.net/lib/ui/wpf"
     xmlns:l="clr-namespace:HandheldCompanion.Localization"
@@ -27,15 +28,19 @@
                 <!--  Target Type  -->
                 <ui:SettingsCard Name="ActionTypeCard" Header="Output type">
                     <ComboBox MinWidth="120" SelectedIndex="{Binding ActionTypeIndex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
-                        <ComboBoxItem Content="{x:Static resx:Resources.LayoutPage_ActionType_Disabled}" IsEnabled="True" />
-                        <ComboBoxItem Content="{x:Static resx:Resources.LayoutPage_ActionType_Button}" IsEnabled="True" />
-                        <ComboBoxItem Content="{x:Static resx:Resources.LayoutPage_ActionType_Joystick}" IsEnabled="True" />
-                        <ComboBoxItem Content="{x:Static resx:Resources.LayoutPage_ActionType_Keyboard}" IsEnabled="True" />
-                        <ComboBoxItem Content="{x:Static resx:Resources.LayoutPage_ActionType_Mouse}" IsEnabled="True" />
-                        <ComboBoxItem Content="{x:Static resx:Resources.LayoutPage_ActionType_Trigger}" IsEnabled="True" />
-                        <ComboBoxItem Content="{x:Static resx:Resources.LayoutPage_ActionType_Shift}" IsEnabled="True" />
-                        <ComboBoxItem Content="{x:Static resx:Resources.LayoutPage_ActionType_Inherit}" IsEnabled="True" />
-                        <ComboBoxItem Content="{x:Static resx:Resources.LayoutPage_ActionType_Touchpad}" IsEnabled="True" Visibility="{Binding TouchpadActionTypeVisibility, Mode=OneWay}" />
+                        <ComboBoxItem Content="{x:Static resx:Resources.LayoutPage_ActionType_Disabled}" IsEnabled="{Binding SupportedActionTypes, Converter={StaticResource ActionTypeSupportedConverter}, ConverterParameter={x:Static actions:ActionType.Disabled}}" />
+                        <ComboBoxItem Content="{x:Static resx:Resources.LayoutPage_ActionType_Button}" IsEnabled="{Binding SupportedActionTypes, Converter={StaticResource ActionTypeSupportedConverter}, ConverterParameter={x:Static actions:ActionType.Button}}" />
+                        <ComboBoxItem Content="{x:Static resx:Resources.LayoutPage_ActionType_Joystick}" IsEnabled="{Binding SupportedActionTypes, Converter={StaticResource ActionTypeSupportedConverter}, ConverterParameter={x:Static actions:ActionType.Joystick}}" />
+                        <ComboBoxItem Content="{x:Static resx:Resources.LayoutPage_ActionType_Keyboard}" IsEnabled="{Binding SupportedActionTypes, Converter={StaticResource ActionTypeSupportedConverter}, ConverterParameter={x:Static actions:ActionType.Keyboard}}" />
+                        <ComboBoxItem Content="{x:Static resx:Resources.LayoutPage_ActionType_Mouse}" IsEnabled="{Binding SupportedActionTypes, Converter={StaticResource ActionTypeSupportedConverter}, ConverterParameter={x:Static actions:ActionType.Mouse}}" />
+                        <ComboBoxItem Content="{x:Static resx:Resources.LayoutPage_ActionType_Trigger}" IsEnabled="{Binding SupportedActionTypes, Converter={StaticResource ActionTypeSupportedConverter}, ConverterParameter={x:Static actions:ActionType.Trigger}}" />
+                        <ComboBoxItem Content="{x:Static resx:Resources.LayoutPage_ActionType_Shift}" IsEnabled="{Binding SupportedActionTypes, Converter={StaticResource ActionTypeSupportedConverter}, ConverterParameter={x:Static actions:ActionType.Shift}}" />
+                        <ComboBoxItem Content="{x:Static resx:Resources.LayoutPage_ActionType_Inherit}" IsEnabled="{Binding SupportedActionTypes, Converter={StaticResource ActionTypeSupportedConverter}, ConverterParameter={x:Static actions:ActionType.Inherit}}" />
+                        <ComboBoxItem
+                            Content="{x:Static resx:Resources.LayoutPage_ActionType_Touchpad}"
+                            IsEnabled="{Binding SupportedActionTypes, Converter={StaticResource ActionTypeSupportedConverter}, ConverterParameter={x:Static actions:ActionType.Touchpad}}"
+                            Visibility="{Binding TouchpadActionTypeVisibility, Mode=OneWay}">
+                        </ComboBoxItem>
                     </ComboBox>
                 </ui:SettingsCard>
 
@@ -126,27 +131,25 @@
                 <ui:SettingsCard Header="{x:Static resx:Resources.LayoutPage_HapticFeedback}" Visibility="{Binding ActionTypeIndex, Mode=OneWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource IndexToVisibilityConverter}, ConverterParameter=1|3|4|5|6|8}">
                     <StackPanel>
                         <DockPanel Margin="0,0,0,6" Visibility="{Binding TrackpadClickHapticOverrideVisibility, Mode=OneWay}">
-                            <ui:ToggleSwitch
-                                DockPanel.Dock="Right"
-                                IsOn="{Binding UseGlobalTrackpadClickHaptics, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <ui:ToggleSwitch DockPanel.Dock="Right" IsOn="{Binding UseGlobalTrackpadClickHaptics, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                             <TextBlock VerticalAlignment="Center" Text="{x:Static resx:Resources.LayoutPage_UseGlobalTrackpadClickHaptics}" />
                         </DockPanel>
-                    <DockPanel IsEnabled="{Binding HapticControlsEnabled, Mode=OneWay}">
-                        <ComboBox Width="105" SelectedIndex="{Binding HapticModeIndex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
-                            <ComboBoxItem Content="Off" />
-                            <ComboBoxItem Content="Down" />
-                            <ComboBoxItem Content="Up" />
-                            <ComboBoxItem Content="Both" />
-                        </ComboBox>
-                        <ComboBox
-                            Width="105"
-                            Margin="3,0,0,0"
-                            SelectedIndex="{Binding HapticStrengthIndex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
-                            <ComboBoxItem Content="Low" />
-                            <ComboBoxItem Content="Medium" />
-                            <ComboBoxItem Content="High" />
-                        </ComboBox>
-                    </DockPanel>
+                        <DockPanel IsEnabled="{Binding HapticControlsEnabled, Mode=OneWay}">
+                            <ComboBox Width="105" SelectedIndex="{Binding HapticModeIndex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                                <ComboBoxItem Content="Off" />
+                                <ComboBoxItem Content="Down" />
+                                <ComboBoxItem Content="Up" />
+                                <ComboBoxItem Content="Both" />
+                            </ComboBox>
+                            <ComboBox
+                                Width="105"
+                                Margin="3,0,0,0"
+                                SelectedIndex="{Binding HapticStrengthIndex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                                <ComboBoxItem Content="Low" />
+                                <ComboBoxItem Content="Medium" />
+                                <ComboBoxItem Content="High" />
+                            </ComboBox>
+                        </DockPanel>
                     </StackPanel>
                 </ui:SettingsCard>
             </ikw:SimpleStackPanel>
@@ -156,34 +159,81 @@
         <ikw:SimpleStackPanel Spacing="8" Visibility="{Binding TouchpadSettingsVisibility, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
             <TextBlock Style="{StaticResource BaseTextBlockStyle}" Text="{x:Static resx:Resources.LayoutPage_TouchpadSettings}" />
             <ikw:SimpleStackPanel Spacing="3">
-                <ui:SettingsCard Header="{x:Static resx:Resources.LayoutPage_TouchpadStartPosition}" Description="{Binding TouchpadCoordinateRangeDescription, Mode=OneWay}">
+                <ui:SettingsCard Description="{Binding TouchpadCoordinateRangeDescription, Mode=OneWay}" Header="{x:Static resx:Resources.LayoutPage_TouchpadStartPosition}">
                     <StackPanel>
                         <DockPanel>
-                            <TextBlock Width="72" VerticalAlignment="Center" Text="{Binding TouchpadX, Mode=OneWay, StringFormat={}X: {0}}" />
-                            <Slider Width="240" Minimum="0" Maximum="{Binding TouchpadMaxX, Mode=OneWay}" TickFrequency="1" IsSnapToTickEnabled="True" IsMoveToPointEnabled="True" Value="{Binding TouchpadX, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <TextBlock
+                                Width="72"
+                                VerticalAlignment="Center"
+                                Text="{Binding TouchpadX, Mode=OneWay, StringFormat={}X: {0}}" />
+                            <Slider
+                                Width="240"
+                                IsMoveToPointEnabled="True"
+                                IsSnapToTickEnabled="True"
+                                Maximum="{Binding TouchpadMaxX, Mode=OneWay}"
+                                Minimum="0"
+                                TickFrequency="1"
+                                Value="{Binding TouchpadX, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                         </DockPanel>
                         <DockPanel Margin="0,6,0,0">
-                            <TextBlock Width="72" VerticalAlignment="Center" Text="{Binding TouchpadY, Mode=OneWay, StringFormat={}Y: {0}}" />
-                            <Slider Width="240" Minimum="0" Maximum="{Binding TouchpadMaxY, Mode=OneWay}" TickFrequency="1" IsSnapToTickEnabled="True" IsMoveToPointEnabled="True" Value="{Binding TouchpadY, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <TextBlock
+                                Width="72"
+                                VerticalAlignment="Center"
+                                Text="{Binding TouchpadY, Mode=OneWay, StringFormat={}Y: {0}}" />
+                            <Slider
+                                Width="240"
+                                IsMoveToPointEnabled="True"
+                                IsSnapToTickEnabled="True"
+                                Maximum="{Binding TouchpadMaxY, Mode=OneWay}"
+                                Minimum="0"
+                                TickFrequency="1"
+                                Value="{Binding TouchpadY, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                         </DockPanel>
                     </StackPanel>
                 </ui:SettingsCard>
                 <ui:SettingsCard Header="{x:Static resx:Resources.LayoutPage_TouchpadEndPosition}" Visibility="{Binding TouchpadSwipeSettingsVisibility, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
                     <StackPanel>
                         <DockPanel>
-                            <TextBlock Width="72" VerticalAlignment="Center" Text="{Binding TouchpadEndX, Mode=OneWay, StringFormat={}X: {0}}" />
-                            <Slider Width="240" Minimum="0" Maximum="{Binding TouchpadMaxX, Mode=OneWay}" TickFrequency="1" IsSnapToTickEnabled="True" IsMoveToPointEnabled="True" Value="{Binding TouchpadEndX, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <TextBlock
+                                Width="72"
+                                VerticalAlignment="Center"
+                                Text="{Binding TouchpadEndX, Mode=OneWay, StringFormat={}X: {0}}" />
+                            <Slider
+                                Width="240"
+                                IsMoveToPointEnabled="True"
+                                IsSnapToTickEnabled="True"
+                                Maximum="{Binding TouchpadMaxX, Mode=OneWay}"
+                                Minimum="0"
+                                TickFrequency="1"
+                                Value="{Binding TouchpadEndX, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                         </DockPanel>
                         <DockPanel Margin="0,6,0,0">
-                            <TextBlock Width="72" VerticalAlignment="Center" Text="{Binding TouchpadEndY, Mode=OneWay, StringFormat={}Y: {0}}" />
-                            <Slider Width="240" Minimum="0" Maximum="{Binding TouchpadMaxY, Mode=OneWay}" TickFrequency="1" IsSnapToTickEnabled="True" IsMoveToPointEnabled="True" Value="{Binding TouchpadEndY, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <TextBlock
+                                Width="72"
+                                VerticalAlignment="Center"
+                                Text="{Binding TouchpadEndY, Mode=OneWay, StringFormat={}Y: {0}}" />
+                            <Slider
+                                Width="240"
+                                IsMoveToPointEnabled="True"
+                                IsSnapToTickEnabled="True"
+                                Maximum="{Binding TouchpadMaxY, Mode=OneWay}"
+                                Minimum="0"
+                                TickFrequency="1"
+                                Value="{Binding TouchpadEndY, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                         </DockPanel>
                     </StackPanel>
                 </ui:SettingsCard>
                 <ui:SettingsCard Header="{x:Static resx:Resources.LayoutPage_TouchpadSwipeDuration}" Visibility="{Binding TouchpadSwipeSettingsVisibility, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
                     <DockPanel>
                         <TextBox IsReadOnly="True" Text="{Binding TouchpadSwipeDuration, Mode=OneWay, StringFormat={}{0:N0} ms}" />
-                        <Slider Width="220" Margin="6,0,0,0" Minimum="16" Maximum="{Binding TouchpadMaxDuration, Mode=OneWay}" TickFrequency="16" IsSnapToTickEnabled="True" Value="{Binding TouchpadSwipeDuration, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        <Slider
+                            Width="220"
+                            Margin="6,0,0,0"
+                            IsSnapToTickEnabled="True"
+                            Maximum="{Binding TouchpadMaxDuration, Mode=OneWay}"
+                            Minimum="16"
+                            TickFrequency="16"
+                            Value="{Binding TouchpadSwipeDuration, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                     </DockPanel>
                 </ui:SettingsCard>
             </ikw:SimpleStackPanel>

--- a/HandheldCompanion/Views/Pages/ActionSettingsPage.xaml
+++ b/HandheldCompanion/Views/Pages/ActionSettingsPage.xaml
@@ -209,7 +209,15 @@
                         </Canvas>
                     </Border>
                 </ui:SettingsCard>
-                <ui:SettingsCard Description="{Binding TouchpadCoordinateRangeDescription, Mode=OneWay}" Header="{x:Static resx:Resources.LayoutPage_TouchpadStartPosition}">
+                <ui:SettingsCard
+                    Header="Use touchpad coordinates"
+                    Visibility="{Binding TouchpadCoordinateSettingsVisibility, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
+                    <ui:ToggleSwitch IsOn="{Binding TouchpadUseCoordinates, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                </ui:SettingsCard>
+                <ui:SettingsCard
+                    Description="{Binding TouchpadCoordinateRangeDescription, Mode=OneWay}"
+                    Header="{x:Static resx:Resources.LayoutPage_TouchpadStartPosition}"
+                    IsEnabled="{Binding TouchpadUseCoordinates, Mode=OneWay}">
                     <StackPanel>
                         <DockPanel>
                             <TextBlock

--- a/HandheldCompanion/Views/Pages/ControllerPage.xaml
+++ b/HandheldCompanion/Views/Pages/ControllerPage.xaml
@@ -307,20 +307,6 @@
                             </ComboBox>
                         </ui:SettingsCard>
 
-                        <!--  Trackpad click haptics  -->
-                        <ui:SettingsCard Description="Controls press and release feedback for both Steam Deck trackpads" Header="Trackpad click haptics">
-                            <ui:SettingsCard.HeaderIcon>
-                                <ui:FontIcon Glyph="&#xE877;" />
-                            </ui:SettingsCard.HeaderIcon>
-
-                            <ComboBox Name="cB_SteamTrackpadClickHaptics" Width="120" SelectionChanged="cB_SteamTrackpadClickHaptics_SelectionChanged">
-                                <ComboBoxItem Content="Off" />
-                                <ComboBoxItem Content="Low" />
-                                <ComboBoxItem Content="Medium" />
-                                <ComboBoxItem Content="High" />
-                            </ComboBox>
-                        </ui:SettingsCard>
-
                         <!--  Vibration Interval  -->
                         <ui:SettingsCard Description="Change controller vibration interval" Header="Vibration interval">
                             <ui:SettingsCard.HeaderIcon>
@@ -352,6 +338,29 @@
                                     ValueChanged="SliderInterval_ValueChanged"
                                     Value="100" />
                             </DockPanel>
+                        </ui:SettingsCard>
+                    </ikw:SimpleStackPanel>
+                </ikw:SimpleStackPanel>
+
+                <!--  Steam trackpad settings  -->
+
+                <ikw:SimpleStackPanel Spacing="8">
+                    <TextBlock
+                        Style="{StaticResource BaseTextBlockStyle}"
+                        Text="Steam trackpad settings"
+                        Visibility="{Binding ElementName=SteamTrackpadHapticsPanel, Path=Visibility}" />
+                    <ikw:SimpleStackPanel Name="SteamTrackpadHapticsPanel" Spacing="3">
+                        <ui:SettingsCard Description="Controls press and release feedback for both Steam trackpads" Header="Trackpad click haptics">
+                            <ui:SettingsCard.HeaderIcon>
+                                <ui:FontIcon Glyph="&#xE877;" />
+                            </ui:SettingsCard.HeaderIcon>
+
+                            <ComboBox Name="cB_SteamTrackpadClickHaptics" Width="120" SelectionChanged="cB_SteamTrackpadClickHaptics_SelectionChanged">
+                                <ComboBoxItem Content="Off" />
+                                <ComboBoxItem Content="Low" />
+                                <ComboBoxItem Content="Medium" />
+                                <ComboBoxItem Content="High" />
+                            </ComboBox>
                         </ui:SettingsCard>
                     </ikw:SimpleStackPanel>
                 </ikw:SimpleStackPanel>

--- a/HandheldCompanion/Views/Pages/ControllerPage.xaml
+++ b/HandheldCompanion/Views/Pages/ControllerPage.xaml
@@ -341,31 +341,6 @@
                     </ikw:SimpleStackPanel>
                 </ikw:SimpleStackPanel>
 
-                <!--  Trackpad settings  -->
-                <ikw:SimpleStackPanel
-                    d:Visibility="Visible"
-                    Spacing="8"
-                    Visibility="{Binding ElementName=TrackpadHapticsPanel, Path=Visibility}">
-                    <TextBlock Style="{StaticResource BaseTextBlockStyle}" Text="{l:Static resx:Resources.ControllerPage_TrackpadSettings}" />
-                    <ikw:SimpleStackPanel Name="TrackpadHapticsPanel" Spacing="3">
-                        <ui:SettingsCard Description="{l:Static resx:Resources.ControllerPage_TrackpadClickHapticsDesc}" Header="{l:Static resx:Resources.ControllerPage_TrackpadClickHaptics}">
-                            <ui:SettingsCard.HeaderIcon>
-                                <ui:FontIcon Glyph="&#xE877;" />
-                            </ui:SettingsCard.HeaderIcon>
-
-                            <ComboBox
-                                Name="cB_TrackpadClickHaptics"
-                                Width="120"
-                                SelectionChanged="cB_TrackpadClickHaptics_SelectionChanged">
-                                <ComboBoxItem Content="{l:Static resx:Resources.ControllerPage_TrackpadClickHapticsOff}" />
-                                <ComboBoxItem Content="{l:Static resx:Resources.ControllerPage_TrackpadClickHapticsLow}" />
-                                <ComboBoxItem Content="{l:Static resx:Resources.ControllerPage_TrackpadClickHapticsMedium}" />
-                                <ComboBoxItem Content="{l:Static resx:Resources.ControllerPage_TrackpadClickHapticsHigh}" />
-                            </ComboBox>
-                        </ui:SettingsCard>
-                    </ikw:SimpleStackPanel>
-                </ikw:SimpleStackPanel>
-
                 <!--  Physical controller settings  -->
                 <ikw:SimpleStackPanel Spacing="8">
                     <TextBlock Style="{StaticResource BaseTextBlockStyle}" Text="{l:Static resx:Resources.ControllerPage_PhysicalDeviceSettings}" />

--- a/HandheldCompanion/Views/Pages/ControllerPage.xaml
+++ b/HandheldCompanion/Views/Pages/ControllerPage.xaml
@@ -307,6 +307,20 @@
                             </ComboBox>
                         </ui:SettingsCard>
 
+                        <!--  Trackpad click haptics  -->
+                        <ui:SettingsCard Description="Controls press and release feedback for both Steam Deck trackpads" Header="Trackpad click haptics">
+                            <ui:SettingsCard.HeaderIcon>
+                                <ui:FontIcon Glyph="&#xE877;" />
+                            </ui:SettingsCard.HeaderIcon>
+
+                            <ComboBox Name="cB_SteamTrackpadClickHaptics" Width="120" SelectionChanged="cB_SteamTrackpadClickHaptics_SelectionChanged">
+                                <ComboBoxItem Content="Off" />
+                                <ComboBoxItem Content="Low" />
+                                <ComboBoxItem Content="Medium" />
+                                <ComboBoxItem Content="High" />
+                            </ComboBox>
+                        </ui:SettingsCard>
+
                         <!--  Vibration Interval  -->
                         <ui:SettingsCard Description="Change controller vibration interval" Header="Vibration interval">
                             <ui:SettingsCard.HeaderIcon>

--- a/HandheldCompanion/Views/Pages/ControllerPage.xaml
+++ b/HandheldCompanion/Views/Pages/ControllerPage.xaml
@@ -342,24 +342,24 @@
                     </ikw:SimpleStackPanel>
                 </ikw:SimpleStackPanel>
 
-                <!--  Steam trackpad settings  -->
+                <!--  Trackpad settings  -->
 
                 <ikw:SimpleStackPanel Spacing="8">
                     <TextBlock
                         Style="{StaticResource BaseTextBlockStyle}"
-                        Text="Steam trackpad settings"
-                        Visibility="{Binding ElementName=SteamTrackpadHapticsPanel, Path=Visibility}" />
-                    <ikw:SimpleStackPanel Name="SteamTrackpadHapticsPanel" Spacing="3">
-                        <ui:SettingsCard Description="Controls press and release feedback for both Steam trackpads" Header="Trackpad click haptics">
+                        Text="{l:Static resx:Resources.ControllerPage_TrackpadSettings}"
+                        Visibility="{Binding ElementName=TrackpadHapticsPanel, Path=Visibility}" />
+                    <ikw:SimpleStackPanel Name="TrackpadHapticsPanel" Spacing="3">
+                        <ui:SettingsCard Description="{l:Static resx:Resources.ControllerPage_TrackpadClickHapticsDesc}" Header="{l:Static resx:Resources.ControllerPage_TrackpadClickHaptics}">
                             <ui:SettingsCard.HeaderIcon>
                                 <ui:FontIcon Glyph="&#xE877;" />
                             </ui:SettingsCard.HeaderIcon>
 
-                            <ComboBox Name="cB_SteamTrackpadClickHaptics" Width="120" SelectionChanged="cB_SteamTrackpadClickHaptics_SelectionChanged">
-                                <ComboBoxItem Content="Off" />
-                                <ComboBoxItem Content="Low" />
-                                <ComboBoxItem Content="Medium" />
-                                <ComboBoxItem Content="High" />
+                            <ComboBox Name="cB_TrackpadClickHaptics" Width="120" SelectionChanged="cB_TrackpadClickHaptics_SelectionChanged">
+                                <ComboBoxItem Content="{l:Static resx:Resources.ControllerPage_TrackpadClickHapticsOff}" />
+                                <ComboBoxItem Content="{l:Static resx:Resources.ControllerPage_TrackpadClickHapticsLow}" />
+                                <ComboBoxItem Content="{l:Static resx:Resources.ControllerPage_TrackpadClickHapticsMedium}" />
+                                <ComboBoxItem Content="{l:Static resx:Resources.ControllerPage_TrackpadClickHapticsHigh}" />
                             </ComboBox>
                         </ui:SettingsCard>
                     </ikw:SimpleStackPanel>

--- a/HandheldCompanion/Views/Pages/ControllerPage.xaml
+++ b/HandheldCompanion/Views/Pages/ControllerPage.xaml
@@ -16,7 +16,7 @@
     Margin="20"
     d:Background="White"
     d:DataContext="{d:DesignInstance Type=viewmodels:ControllerPageViewModel}"
-    d:DesignHeight="1800"
+    d:DesignHeight="2200"
     d:DesignWidth="1000"
     KeepAlive="True"
     Loaded="Page_Loaded"
@@ -288,12 +288,11 @@
                 </ikw:SimpleStackPanel>
 
                 <!--  Steam Deck settings  -->
-
-                <ikw:SimpleStackPanel Spacing="8">
-                    <TextBlock
-                        Style="{StaticResource BaseTextBlockStyle}"
-                        Text="Steam Deck settings"
-                        Visibility="{Binding ElementName=SteamDeckPanel, Path=Visibility}" />
+                <ikw:SimpleStackPanel
+                    d:Visibility="Visible"
+                    Spacing="8"
+                    Visibility="{Binding ElementName=SteamDeckPanel, Path=Visibility}">
+                    <TextBlock Style="{StaticResource BaseTextBlockStyle}" Text="Steam Deck settings" />
                     <ikw:SimpleStackPanel Name="SteamDeckPanel" Spacing="3">
                         <!--  Mute virtual controller (Steam Deck)  -->
                         <ui:SettingsCard Description="{l:Static resx:Resources.ControllerPage_SteamControllerModeDesc}" Header="{l:Static resx:Resources.ControllerPage_SteamControllerMode}">
@@ -343,19 +342,21 @@
                 </ikw:SimpleStackPanel>
 
                 <!--  Trackpad settings  -->
-
-                <ikw:SimpleStackPanel Spacing="8">
-                    <TextBlock
-                        Style="{StaticResource BaseTextBlockStyle}"
-                        Text="{l:Static resx:Resources.ControllerPage_TrackpadSettings}"
-                        Visibility="{Binding ElementName=TrackpadHapticsPanel, Path=Visibility}" />
+                <ikw:SimpleStackPanel
+                    d:Visibility="Visible"
+                    Spacing="8"
+                    Visibility="{Binding ElementName=TrackpadHapticsPanel, Path=Visibility}">
+                    <TextBlock Style="{StaticResource BaseTextBlockStyle}" Text="{l:Static resx:Resources.ControllerPage_TrackpadSettings}" />
                     <ikw:SimpleStackPanel Name="TrackpadHapticsPanel" Spacing="3">
                         <ui:SettingsCard Description="{l:Static resx:Resources.ControllerPage_TrackpadClickHapticsDesc}" Header="{l:Static resx:Resources.ControllerPage_TrackpadClickHaptics}">
                             <ui:SettingsCard.HeaderIcon>
                                 <ui:FontIcon Glyph="&#xE877;" />
                             </ui:SettingsCard.HeaderIcon>
 
-                            <ComboBox Name="cB_TrackpadClickHaptics" Width="120" SelectionChanged="cB_TrackpadClickHaptics_SelectionChanged">
+                            <ComboBox
+                                Name="cB_TrackpadClickHaptics"
+                                Width="120"
+                                SelectionChanged="cB_TrackpadClickHaptics_SelectionChanged">
                                 <ComboBoxItem Content="{l:Static resx:Resources.ControllerPage_TrackpadClickHapticsOff}" />
                                 <ComboBoxItem Content="{l:Static resx:Resources.ControllerPage_TrackpadClickHapticsLow}" />
                                 <ComboBoxItem Content="{l:Static resx:Resources.ControllerPage_TrackpadClickHapticsMedium}" />

--- a/HandheldCompanion/Views/Pages/ControllerPage.xaml.cs
+++ b/HandheldCompanion/Views/Pages/ControllerPage.xaml.cs
@@ -156,8 +156,7 @@ public partial class ControllerPage : Page
         bool isSteamDeck = IDevice.GetCurrent() is SteamDeck;
         var controller = ControllerManager.GetTarget();
         bool hasTrackpadClicks = controller?.HasSourceButton(ButtonFlags.LeftPadClick) == true ||
-            controller?.HasSourceButton(ButtonFlags.RightPadClick) == true ||
-            controller?.HasSourceButton(ButtonFlags.CenterPadClick) == true;
+            controller?.HasSourceButton(ButtonFlags.RightPadClick) == true;
 
         SteamDeckPanel.Visibility = isSteamDeck ? Visibility.Visible : Visibility.Collapsed;
         TrackpadHapticsPanel.Visibility = isSteamDeck || hasTrackpadClicks

--- a/HandheldCompanion/Views/Pages/ControllerPage.xaml.cs
+++ b/HandheldCompanion/Views/Pages/ControllerPage.xaml.cs
@@ -58,6 +58,7 @@ public partial class ControllerPage : Page
         SettingsManager_SettingValueChanged("HIDvibrateonconnect", ManagerFactory.settingsManager.GetString("HIDvibrateonconnect"), false, false);
         SettingsManager_SettingValueChanged("VibrationStrength", ManagerFactory.settingsManager.GetString("VibrationStrength"), false, false);
         SettingsManager_SettingValueChanged("SteamControllerMode", ManagerFactory.settingsManager.GetString("SteamControllerMode"), false, false);
+        SettingsManager_SettingValueChanged("SteamTrackpadClickHaptics", ManagerFactory.settingsManager.GetString("SteamTrackpadClickHaptics"), false, false);
         SettingsManager_SettingValueChanged("SteamControllerRumbleInterval", ManagerFactory.settingsManager.GetString("SteamControllerRumbleInterval"), false, false);
         SettingsManager_SettingValueChanged("HIDmode", ManagerFactory.settingsManager.GetString("HIDmode"), false, false);
         SettingsManager_SettingValueChanged("HIDstatus", ManagerFactory.settingsManager.GetString("HIDstatus"), false, false);
@@ -94,6 +95,9 @@ public partial class ControllerPage : Page
                     break;
                 case "SteamControllerMode":
                     cB_SCModeController.SelectedIndex = Convert.ToInt32(value);
+                    break;
+                case "SteamTrackpadClickHaptics":
+                    cB_SteamTrackpadClickHaptics.SelectedIndex = Convert.ToInt32(value);
                     break;
                 case "SteamControllerRumbleInterval":
                     SliderInterval.Value = Convert.ToDouble(value);
@@ -285,6 +289,14 @@ public partial class ControllerPage : Page
             return;
 
         ManagerFactory.settingsManager.SetProperty("SteamControllerMode", cB_SCModeController.SelectedIndex);
+    }
+
+    private void cB_SteamTrackpadClickHaptics_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (!IsLoaded || cB_SteamTrackpadClickHaptics.SelectedIndex == -1)
+            return;
+
+        ManagerFactory.settingsManager.SetProperty("SteamTrackpadClickHaptics", cB_SteamTrackpadClickHaptics.SelectedIndex);
     }
 
     private void cB_ControllerPlugBehavior_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/HandheldCompanion/Views/Pages/ControllerPage.xaml.cs
+++ b/HandheldCompanion/Views/Pages/ControllerPage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using HandheldCompanion.Devices;
+﻿using HandheldCompanion.Controllers;
+using HandheldCompanion.Devices;
 using HandheldCompanion.Helpers;
 using HandheldCompanion.Inputs;
 using HandheldCompanion.Managers;
@@ -154,14 +155,14 @@ public partial class ControllerPage : Page
     private void UpdateTrackpadSettingsVisibility()
     {
         bool isSteamDeck = IDevice.GetCurrent() is SteamDeck;
-        var controller = ControllerManager.GetTarget();
-        bool hasTrackpadClicks = controller?.HasSourceButton(ButtonFlags.LeftPadClick) == true ||
-            controller?.HasSourceButton(ButtonFlags.RightPadClick) == true;
+        IController? controller = ControllerManager.GetTarget();
+        if (controller is null)
+            return;
+
+        bool hasTrackpadClicks = controller.HasSourceButton(ButtonFlags.LeftPadClick) || controller.HasSourceButton(ButtonFlags.RightPadClick);
 
         SteamDeckPanel.Visibility = isSteamDeck ? Visibility.Visible : Visibility.Collapsed;
-        TrackpadHapticsPanel.Visibility = isSteamDeck || hasTrackpadClicks
-            ? Visibility.Visible
-            : Visibility.Collapsed;
+        TrackpadHapticsPanel.Visibility = isSteamDeck || hasTrackpadClicks ? Visibility.Visible : Visibility.Collapsed;
     }
 
     private string GetResourceString(string baseKey, int attempts)

--- a/HandheldCompanion/Views/Pages/ControllerPage.xaml.cs
+++ b/HandheldCompanion/Views/Pages/ControllerPage.xaml.cs
@@ -26,7 +26,8 @@ public partial class ControllerPage : Page
         DataContext = ViewModel;
         InitializeComponent();
 
-        SteamDeckPanel.Visibility = IDevice.GetCurrent() is SteamDeck ? Visibility.Visible : Visibility.Collapsed;
+        UpdateSteamSettingsVisibility();
+        ControllerManager.ControllerSelected += ControllerManager_ControllerSelected;
 
         // manage events
         switch (ManagerFactory.settingsManager.Status)
@@ -140,7 +141,24 @@ public partial class ControllerPage : Page
     public void Page_Closed()
     {
         ManagerFactory.settingsManager.SettingValueChanged -= SettingsManager_SettingValueChanged;
+        ControllerManager.ControllerSelected -= ControllerManager_ControllerSelected;
         ViewModel.Dispose();
+    }
+
+    private void ControllerManager_ControllerSelected(HandheldCompanion.Controllers.IController controller)
+    {
+        UIHelper.TryInvoke(UpdateSteamSettingsVisibility);
+    }
+
+    private void UpdateSteamSettingsVisibility()
+    {
+        bool isSteamDeck = IDevice.GetCurrent() is SteamDeck;
+        bool hasSteamTrackpads = ControllerManager.GetTarget() is HandheldCompanion.Controllers.Steam.SteamController;
+
+        SteamDeckPanel.Visibility = isSteamDeck ? Visibility.Visible : Visibility.Collapsed;
+        SteamTrackpadHapticsPanel.Visibility = isSteamDeck || hasSteamTrackpads
+            ? Visibility.Visible
+            : Visibility.Collapsed;
     }
 
     private string GetResourceString(string baseKey, int attempts)

--- a/HandheldCompanion/Views/Pages/ControllerPage.xaml.cs
+++ b/HandheldCompanion/Views/Pages/ControllerPage.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using HandheldCompanion.Devices;
 using HandheldCompanion.Helpers;
+using HandheldCompanion.Inputs;
 using HandheldCompanion.Managers;
 using HandheldCompanion.Misc;
 using HandheldCompanion.Utils;
@@ -26,7 +27,7 @@ public partial class ControllerPage : Page
         DataContext = ViewModel;
         InitializeComponent();
 
-        UpdateSteamSettingsVisibility();
+        UpdateTrackpadSettingsVisibility();
         ControllerManager.ControllerSelected += ControllerManager_ControllerSelected;
 
         // manage events
@@ -59,7 +60,7 @@ public partial class ControllerPage : Page
         SettingsManager_SettingValueChanged("HIDvibrateonconnect", ManagerFactory.settingsManager.GetString("HIDvibrateonconnect"), false, false);
         SettingsManager_SettingValueChanged("VibrationStrength", ManagerFactory.settingsManager.GetString("VibrationStrength"), false, false);
         SettingsManager_SettingValueChanged("SteamControllerMode", ManagerFactory.settingsManager.GetString("SteamControllerMode"), false, false);
-        SettingsManager_SettingValueChanged("SteamTrackpadClickHaptics", ManagerFactory.settingsManager.GetString("SteamTrackpadClickHaptics"), false, false);
+        SettingsManager_SettingValueChanged("TrackpadClickHaptics", ManagerFactory.settingsManager.GetString("TrackpadClickHaptics"), false, false);
         SettingsManager_SettingValueChanged("SteamControllerRumbleInterval", ManagerFactory.settingsManager.GetString("SteamControllerRumbleInterval"), false, false);
         SettingsManager_SettingValueChanged("HIDmode", ManagerFactory.settingsManager.GetString("HIDmode"), false, false);
         SettingsManager_SettingValueChanged("HIDstatus", ManagerFactory.settingsManager.GetString("HIDstatus"), false, false);
@@ -97,8 +98,8 @@ public partial class ControllerPage : Page
                 case "SteamControllerMode":
                     cB_SCModeController.SelectedIndex = Convert.ToInt32(value);
                     break;
-                case "SteamTrackpadClickHaptics":
-                    cB_SteamTrackpadClickHaptics.SelectedIndex = Convert.ToInt32(value);
+                case "TrackpadClickHaptics":
+                    cB_TrackpadClickHaptics.SelectedIndex = Convert.ToInt32(value);
                     break;
                 case "SteamControllerRumbleInterval":
                     SliderInterval.Value = Convert.ToDouble(value);
@@ -147,16 +148,19 @@ public partial class ControllerPage : Page
 
     private void ControllerManager_ControllerSelected(HandheldCompanion.Controllers.IController controller)
     {
-        UIHelper.TryInvoke(UpdateSteamSettingsVisibility);
+        UIHelper.TryInvoke(UpdateTrackpadSettingsVisibility);
     }
 
-    private void UpdateSteamSettingsVisibility()
+    private void UpdateTrackpadSettingsVisibility()
     {
         bool isSteamDeck = IDevice.GetCurrent() is SteamDeck;
-        bool hasSteamTrackpads = ControllerManager.GetTarget() is HandheldCompanion.Controllers.Steam.SteamController;
+        var controller = ControllerManager.GetTarget();
+        bool hasTrackpadClicks = controller?.HasSourceButton(ButtonFlags.LeftPadClick) == true ||
+            controller?.HasSourceButton(ButtonFlags.RightPadClick) == true ||
+            controller?.HasSourceButton(ButtonFlags.CenterPadClick) == true;
 
         SteamDeckPanel.Visibility = isSteamDeck ? Visibility.Visible : Visibility.Collapsed;
-        SteamTrackpadHapticsPanel.Visibility = isSteamDeck || hasSteamTrackpads
+        TrackpadHapticsPanel.Visibility = isSteamDeck || hasTrackpadClicks
             ? Visibility.Visible
             : Visibility.Collapsed;
     }
@@ -309,12 +313,12 @@ public partial class ControllerPage : Page
         ManagerFactory.settingsManager.SetProperty("SteamControllerMode", cB_SCModeController.SelectedIndex);
     }
 
-    private void cB_SteamTrackpadClickHaptics_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    private void cB_TrackpadClickHaptics_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
-        if (!IsLoaded || cB_SteamTrackpadClickHaptics.SelectedIndex == -1)
+        if (!IsLoaded || cB_TrackpadClickHaptics.SelectedIndex == -1)
             return;
 
-        ManagerFactory.settingsManager.SetProperty("SteamTrackpadClickHaptics", cB_SteamTrackpadClickHaptics.SelectedIndex);
+        ManagerFactory.settingsManager.SetProperty("TrackpadClickHaptics", cB_TrackpadClickHaptics.SelectedIndex);
     }
 
     private void cB_ControllerPlugBehavior_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/HandheldCompanion/Views/Pages/ControllerPage.xaml.cs
+++ b/HandheldCompanion/Views/Pages/ControllerPage.xaml.cs
@@ -61,7 +61,6 @@ public partial class ControllerPage : Page
         SettingsManager_SettingValueChanged("HIDvibrateonconnect", ManagerFactory.settingsManager.GetString("HIDvibrateonconnect"), false, false);
         SettingsManager_SettingValueChanged("VibrationStrength", ManagerFactory.settingsManager.GetString("VibrationStrength"), false, false);
         SettingsManager_SettingValueChanged("SteamControllerMode", ManagerFactory.settingsManager.GetString("SteamControllerMode"), false, false);
-        SettingsManager_SettingValueChanged("TrackpadClickHaptics", ManagerFactory.settingsManager.GetString("TrackpadClickHaptics"), false, false);
         SettingsManager_SettingValueChanged("SteamControllerRumbleInterval", ManagerFactory.settingsManager.GetString("SteamControllerRumbleInterval"), false, false);
         SettingsManager_SettingValueChanged("HIDmode", ManagerFactory.settingsManager.GetString("HIDmode"), false, false);
         SettingsManager_SettingValueChanged("HIDstatus", ManagerFactory.settingsManager.GetString("HIDstatus"), false, false);
@@ -98,9 +97,6 @@ public partial class ControllerPage : Page
                     break;
                 case "SteamControllerMode":
                     cB_SCModeController.SelectedIndex = Convert.ToInt32(value);
-                    break;
-                case "TrackpadClickHaptics":
-                    cB_TrackpadClickHaptics.SelectedIndex = Convert.ToInt32(value);
                     break;
                 case "SteamControllerRumbleInterval":
                     SliderInterval.Value = Convert.ToDouble(value);
@@ -155,14 +151,7 @@ public partial class ControllerPage : Page
     private void UpdateTrackpadSettingsVisibility()
     {
         bool isSteamDeck = IDevice.GetCurrent() is SteamDeck;
-        IController? controller = ControllerManager.GetTarget();
-        if (controller is null)
-            return;
-
-        bool hasTrackpadClicks = controller.HasSourceButton(ButtonFlags.LeftPadClick) || controller.HasSourceButton(ButtonFlags.RightPadClick);
-
         SteamDeckPanel.Visibility = isSteamDeck ? Visibility.Visible : Visibility.Collapsed;
-        TrackpadHapticsPanel.Visibility = isSteamDeck || hasTrackpadClicks ? Visibility.Visible : Visibility.Collapsed;
     }
 
     private string GetResourceString(string baseKey, int attempts)
@@ -311,14 +300,6 @@ public partial class ControllerPage : Page
             return;
 
         ManagerFactory.settingsManager.SetProperty("SteamControllerMode", cB_SCModeController.SelectedIndex);
-    }
-
-    private void cB_TrackpadClickHaptics_SelectionChanged(object sender, SelectionChangedEventArgs e)
-    {
-        if (!IsLoaded || cB_TrackpadClickHaptics.SelectedIndex == -1)
-            return;
-
-        ManagerFactory.settingsManager.SetProperty("TrackpadClickHaptics", cB_TrackpadClickHaptics.SelectedIndex);
     }
 
     private void cB_ControllerPlugBehavior_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/HandheldCompanion/Views/Pages/DevicePage.xaml
+++ b/HandheldCompanion/Views/Pages/DevicePage.xaml
@@ -912,9 +912,7 @@
                         <ui:ToggleSwitch IsOn="{Binding ClawOverBoost, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                     </ui:SettingsCard>
 
-                    <ui:SettingsCard
-                        Description="Disable the PS/2 Windows service to mute the virtual keyboard used to open Game Bar"
-                        Header="Disable PS/2 Windows service">
+                    <ui:SettingsCard Description="Disable the PS/2 Windows service to mute the virtual keyboard used to open Game Bar" Header="Disable PS/2 Windows service">
                         <ui:SettingsCard.HeaderIcon>
                             <ui:FontIcon Glyph="&#xe765;" />
                         </ui:SettingsCard.HeaderIcon>

--- a/HandheldCompanion/Views/Pages/LayoutPage.xaml.cs
+++ b/HandheldCompanion/Views/Pages/LayoutPage.xaml.cs
@@ -313,9 +313,12 @@ public partial class LayoutPage : Page
                         // because they both have important Update notifitications set
                         using (Layout newLayout = (Layout)layoutTemplate.Layout.Clone())
                         {
-                            currentTemplate.Layout.AxisLayout = CloningHelper.DeepClone(newLayout.AxisLayout);
-                            currentTemplate.Layout.ButtonLayout = CloningHelper.DeepClone(newLayout.ButtonLayout);
-                            currentTemplate.Layout.GyroLayout = CloningHelper.DeepClone(newLayout.GyroLayout);
+                            lock (currentTemplate.Layout.SyncRoot)
+                            {
+                                currentTemplate.Layout.AxisLayout = CloningHelper.DeepClone(newLayout.AxisLayout);
+                                currentTemplate.Layout.ButtonLayout = CloningHelper.DeepClone(newLayout.ButtonLayout);
+                                currentTemplate.Layout.GyroLayout = CloningHelper.DeepClone(newLayout.GyroLayout);
+                            }
                         }
 
                         currentTemplate.Name = layoutTemplate.Name;
@@ -362,15 +365,18 @@ public partial class LayoutPage : Page
                     Profile currentProfile = ProfilesPage.selectedProfile;
 
                     // Clear the layout
-                    currentTemplate.Layout.ButtonLayout.Clear();
-                    currentTemplate.Layout.AxisLayout.Clear();
-                    currentTemplate.Layout.GyroLayout.Clear();
+                    lock (currentTemplate.Layout.SyncRoot)
+                    {
+                        currentTemplate.Layout.ButtonLayout.Clear();
+                        currentTemplate.Layout.AxisLayout.Clear();
+                        currentTemplate.Layout.GyroLayout.Clear();
 
-                    // Fill with appropriate defaults
-                    if (currentProfile.Default)
-                        currentTemplate.Layout.FillDefault();
-                    else
-                        currentTemplate.Layout.FillInherit();
+                        // Fill with appropriate defaults
+                        if (currentProfile.Default)
+                            currentTemplate.Layout.FillDefault();
+                        else
+                            currentTemplate.Layout.FillInherit();
+                    }
 
                     currentTemplate.Name = LayoutTemplate.DefaultLayout.Name;
 

--- a/HandheldCompanion/Views/QuickPages/QuickProfilesPage.xaml
+++ b/HandheldCompanion/Views/QuickPages/QuickProfilesPage.xaml
@@ -270,7 +270,7 @@
                         <ui:SettingsCard
                             Description="{l:Static resx:Resources.ProfilesPage_StyleofInputTooltip}"
                             Header="{l:Static resx:Resources.ProfilesPage_StyleofInput}"
-                            Visibility="{Binding OutputMode, Converter={StaticResource IndexToVisibilityConverter}, ConverterParameter=1|2|3|4|5}">
+                            Visibility="{Binding OutputMode, Converter={StaticResource IndexToVisibilityConverter}, ConverterParameter=1|2|3|4|5|6}">
                             <ComboBox
                                 Name="MotionInputComboBox"
                                 ItemsSource="{Binding MotionInputModes, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
@@ -290,7 +290,7 @@
                             </ComboBox>
                         </ui:SettingsCard>
 
-                        <ui:SettingsCard Header="{l:Static resx:Resources.ProfilesPage_UMCMotionOnOff}" Visibility="{Binding OutputMode, Converter={StaticResource IndexToVisibilityConverter}, ConverterParameter=1|2|3|4|5}">
+                        <ui:SettingsCard Header="{l:Static resx:Resources.ProfilesPage_UMCMotionOnOff}" Visibility="{Binding OutputMode, Converter={StaticResource IndexToVisibilityConverter}, ConverterParameter=1|2|3|4|5|6}">
 
                             <ui:SettingsCard.Resources>
                                 <sys:Double x:Key="SettingsCardWrapThreshold">476</sys:Double>
@@ -426,7 +426,7 @@
                         <ui:SettingsCard
                             Description="{l:Static resx:Resources.ProfilesPage_UMCAntiDeadzoneDesc}"
                             Header="{l:Static resx:Resources.ProfilesPage_UMCAntiDeadzone}"
-                            Visibility="{Binding OutputMode, Converter={StaticResource IndexToVisibilityConverter}, ConverterParameter=1|2|3|4|5}">
+                            Visibility="{Binding OutputMode, Converter={StaticResource IndexToVisibilityConverter}, ConverterParameter=1|2}">
                             <ui:SettingsCard.Resources>
                                 <sys:Double x:Key="SettingsCardWrapThreshold">476</sys:Double>
                                 <sys:Double x:Key="SettingsCardWrapNoIconThreshold">286</sys:Double>
@@ -457,9 +457,9 @@
 
                         <!--  Gyrometer weight  -->
                         <ui:SettingsCard
-                            Description="Modify the gyrometer weight when applied against joystick movements"
+                            Description="Adjusts how strongly gyroscope movement is mixed with existing input"
                             Header="Gyrometer weight"
-                            Visibility="{Binding OutputMode, Converter={StaticResource IndexToVisibilityConverter}, ConverterParameter=1|2|3|4|5}">
+                            Visibility="{Binding OutputMode, Converter={StaticResource IndexToVisibilityConverter}, ConverterParameter=1|2|3|4|5|6}">
                             <ui:SettingsCard.Resources>
                                 <sys:Double x:Key="SettingsCardWrapThreshold">476</sys:Double>
                                 <sys:Double x:Key="SettingsCardWrapNoIconThreshold">286</sys:Double>
@@ -489,7 +489,7 @@
                         </ui:SettingsCard>
 
                         <!--  Horizontal sensitivity  -->
-                        <ui:SettingsCard Header="Horizontal sensitivity" Visibility="{Binding OutputMode, Converter={StaticResource IndexToVisibilityConverter}, ConverterParameter=1|2|3|4|5}">
+                        <ui:SettingsCard Header="Horizontal sensitivity" Visibility="{Binding OutputMode, Converter={StaticResource IndexToVisibilityConverter}, ConverterParameter=1|2|3|4|5|6}">
                             <ui:SettingsCard.Resources>
                                 <sys:Double x:Key="SettingsCardWrapThreshold">476</sys:Double>
                                 <sys:Double x:Key="SettingsCardWrapNoIconThreshold">286</sys:Double>
@@ -522,7 +522,7 @@
                         </ui:SettingsCard>
 
                         <!--  Vertical sensitivity  -->
-                        <ui:SettingsCard Header="Vertical sensitivity" Visibility="{Binding OutputMode, Converter={StaticResource IndexToVisibilityConverter}, ConverterParameter=1|2|3|4|5}">
+                        <ui:SettingsCard Header="Vertical sensitivity" Visibility="{Binding OutputMode, Converter={StaticResource IndexToVisibilityConverter}, ConverterParameter=1|2|3|4|5|6}">
                             <ui:SettingsCard.Resources>
                                 <sys:Double x:Key="SettingsCardWrapThreshold">476</sys:Double>
                                 <sys:Double x:Key="SettingsCardWrapNoIconThreshold">286</sys:Double>

--- a/HandheldCompanion/Views/TemplatesDictionary.xaml
+++ b/HandheldCompanion/Views/TemplatesDictionary.xaml
@@ -1239,6 +1239,7 @@
                     <ComboBoxItem Content="{x:Static resx:Resources.LayoutPage_ActionType_Trigger}" IsEnabled="False" />
                     <ComboBoxItem Content="{x:Static resx:Resources.LayoutPage_ActionType_Shift}" IsEnabled="False" />
                     <ComboBoxItem Content="{x:Static resx:Resources.LayoutPage_ActionType_Inherit}" IsEnabled="False" />
+                    <ComboBoxItem Content="{x:Static resx:Resources.LayoutPage_ActionType_Touchpad}" IsEnabled="True" Visibility="{Binding TouchpadAxisActionTypeVisibility, Mode=OneWay}" />
                 </ComboBox>
             </ui:SettingsCard>
 
@@ -1434,9 +1435,9 @@
             <!--  Joystick  -->
             <!--  Gyrometer weight  -->
             <ui:SettingsCard
-                Description="Modify the gyrometer weight when applied against joystick movements"
+                Description="Modify the gyrometer weight when combined with target axis movements"
                 Header="Gyrometer weight"
-                Visibility="{Binding ActionTypeIndex, Mode=OneWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource IndexToVisibilityConverter}, ConverterParameter=2}">
+                Visibility="{Binding ActionTypeIndex, Mode=OneWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource IndexToVisibilityConverter}, ConverterParameter=2|8}">
                 <DockPanel>
                     <TextBox Text="{Binding GyroWeight, Mode=OneWay, UpdateSourceTrigger=PropertyChanged, StringFormat=N1}" TextAlignment="Center" />
                     <Slider

--- a/steam-hidapi.net/Hid/HidEnums.cs
+++ b/steam-hidapi.net/Hid/HidEnums.cs
@@ -87,11 +87,12 @@ namespace steam_hidapi.net.Hid
     internal struct SCHapticPacket
     {
         public byte packet_type; // = 0x8f;
-        public byte len;         // = 0x07;
+        public byte len;         // = 0x08;
         public byte position;    // = 0|1;
         public UInt16 amplitude;
         public UInt16 period;
         public UInt16 count;
+        public sbyte gain;        // decibels, -24..+6
     }
 
     // GORDON CONTROLLER SPECIFIC

--- a/steam-hidapi.net/SteamController.cs
+++ b/steam-hidapi.net/SteamController.cs
@@ -56,7 +56,7 @@ namespace steam_hidapi.net
             return _hidDevice.RequestFeatureReport(req);
         }
 
-        public virtual byte[] SetHaptic(byte position, ushort amplitude, ushort period, ushort count)
+        public virtual byte[] SetHaptic(byte position, ushort amplitude, ushort period, ushort count, sbyte gain = 0)
         {
             if (!_hidDevice.IsDeviceValid)
                 return null;
@@ -64,11 +64,12 @@ namespace steam_hidapi.net
             SCHapticPacket haptic = new SCHapticPacket
             {
                 packet_type = (byte)SCPacketType.SET_HAPTIC,
-                len = 0x07,
+                len = 0x08,
                 position = position,
                 amplitude = amplitude,
                 period = period,
-                count = count
+                count = count,
+                gain = gain
             };
 
             byte[] data = haptic.ToBytes();

--- a/steam-hidapi.net/SteamController.cs
+++ b/steam-hidapi.net/SteamController.cs
@@ -19,6 +19,7 @@ namespace steam_hidapi.net
 
         // device configuration
         protected bool _lizard = true;
+        public bool LizardModeEnabled => _lizard;
 
         public string SerialNumber { get; private set; }
 


### PR DESCRIPTION
## Summary

- Move touchpad button and axis targets into `TouchpadActions`.
- Show Touchpad in layout target lists only when the selected virtual controller advertises compatible targets.
- Restore trackpad movement feedback while Steam lizard mode is disabled.
- Add press and release click feedback with Off, Low, Medium, and High levels. High is the default.
- Support left and right touchpad gyro output in Quick Profiles.

## Problem

Disabling Steam lizard mode also removes the firmware-generated trackpad feedback. Touchpad behavior had also become split across mouse and button actions, which made device support and settings difficult to keep consistent.

## Implementation

`TouchpadActions` now owns touchpad button targets, axis targets, coordinate and swipe handling, and touchpad haptics. Layout target lists are built from the capabilities advertised by the selected virtual controller. Existing mappings with unavailable targets are kept intact instead of being silently replaced.

Movement feedback uses the selected controller's normal haptic path. Steam trackpad clicks use native Steam haptic commands for distinct strength levels and correct left and right routing. Per-mapping haptic settings can override the global click setting, and the Controller page reports when an override is active.

Quick Profiles now represents gyro output to either touchpad. These options are capability-driven while still displaying an existing unsupported mapping so loading a profile remains non-destructive.

## Validation

- Built the Debug solution with 0 errors.
- Tested movement feedback on both Steam Deck trackpads.
- Tested press and release click feedback and correct left and right routing.
- Tested global and per-mapping haptic settings, including Off, Low, Medium, and High.
- Confirmed High is the default.
- Tested left and right touchpad gyro output in Quick Profiles.
- Verified the changed XAML and resources parse successfully.
- Ran `git diff --check` successfully.

Physical validation was performed on a Steam Deck. Other controller paths require testing on their respective hardware.

Built on #1454.

Closes #590
