### PR TITLE
Preserve extended key flags during simulation

### DIFF
--- a/.github/workflows/publish-hc.yml
+++ b/.github/workflows/publish-hc.yml
@@ -70,7 +70,20 @@ jobs:
 
       - name: Install Innosetup
         run: |
-          choco install innosetup --version=${{ env.INNO_VERSION }} --force
+          $maxAttempts = 3
+          for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+            choco install innosetup --version=${{ env.INNO_VERSION }} --force
+            if ($LASTEXITCODE -eq 0) {
+              break
+            }
+
+            if ($attempt -eq $maxAttempts) {
+              throw "Failed to install Innosetup after $maxAttempts attempts."
+            }
+
+            Write-Host "Retrying Innosetup install in 15 seconds (attempt $attempt of $maxAttempts)..."
+            Start-Sleep -Seconds 15
+          }
           
       - name: Setup dotnet 10 SDK
         uses: actions/setup-dotnet@v3

--- a/.github/workflows/publish-hc.yml
+++ b/.github/workflows/publish-hc.yml
@@ -78,7 +78,7 @@ jobs:
             }
 
             if ($attempt -eq $maxAttempts) {
-              throw "Failed to install Innosetup after $maxAttempts attempts."
+              throw "Failed to install Inno Setup after $maxAttempts attempts."
             }
 
             Write-Host "Retrying Innosetup install in 15 seconds (attempt $attempt of $maxAttempts)..."

--- a/HandheldCompanion/Managers/InputsManager.cs
+++ b/HandheldCompanion/Managers/InputsManager.cs
@@ -72,7 +72,6 @@ public static class InputsManager
     private static readonly Dictionary<bool, short> KeyIndexOEM = new() { { true, 0 }, { false, 0 } };
     private static readonly Dictionary<bool, short> KeyIndexHotkey = new() { { true, 0 }, { false, 0 } };
     private static readonly Dictionary<bool, bool> KeyUsed = new() { { true, false }, { false, false } };
-    private static readonly HashSet<Keys> PhysicalModifiersDown = new();
     private static readonly FirmwareWorkarounds.MSI MsiFirmwareWorkaround = new();
 
     public static bool IsInitialized;
@@ -251,16 +250,6 @@ public static class InputsManager
 
         bool Injected = (args.Flags & LLKHF_INJECTED) > 0;
         bool InjectedLL = (args.Flags & LLKHF_LOWER_IL_INJECTED) > 0;
-        bool fromPhysicalKeyboard = !(Injected || InjectedLL);
-
-        // Track physical modifier state (only real hardware events)
-        if (fromPhysicalKeyboard && IsModifierKey(args))
-        {
-            if (args.IsKeyDown)
-                PhysicalModifiersDown.Add(args.KeyCode);
-            else if (args.IsKeyUp)
-                PhysicalModifiersDown.Remove(args.KeyCode);
-        }
 
         if (MsiFirmwareWorkaround.ProcessKeyboardEvent(args, Injected || InjectedLL))
             return;
@@ -521,10 +510,6 @@ public static class InputsManager
             BufferKeys[false].Add(args);
         }
 
-        if (fromPhysicalKeyboard && args.IsKeyUp && args.KeyCode == Keys.RMenu &&
-            !IsModifierPhysicallyDown((int)Keys.LControlKey))
-            KeyboardSimulator.KeyUp((VirtualKeyCode)KeyCode.LControl);
-
     Done:
         if (BufferKeys[true].Count > 0 || BufferKeys[false].Count > 0)
             BufferFlushTimer.Start();
@@ -763,36 +748,6 @@ public static class InputsManager
             bufferChord.ButtonState[halfPress] = false;
             buttonState[halfPress] = false;
         }
-    }
-
-    private static bool IsModifierKey(Keys key)
-    {
-        switch (key)
-        {
-            case Keys.LControlKey:
-            case Keys.RControlKey:
-            case Keys.ControlKey:
-            case Keys.LMenu:      // Left Alt
-            case Keys.RMenu:      // Right Alt / AltGr
-            case Keys.Menu:       // Generic Alt
-            case Keys.LShiftKey:
-            case Keys.RShiftKey:
-            case Keys.ShiftKey:
-                return true;
-
-            default:
-                return false;
-        }
-    }
-
-    private static bool IsModifierKey(KeyEventArgsExt args)
-    {
-        return IsModifierKey(args.KeyCode);
-    }
-
-    private static bool IsModifierPhysicallyDown(int keyValue)
-    {
-        return PhysicalModifiersDown.Contains((Keys)keyValue);
     }
 
     private static ButtonFlags currentButtonFlags = ButtonFlags.None;

--- a/HandheldCompanion/Simulators/KeyboardSimulator.cs
+++ b/HandheldCompanion/Simulators/KeyboardSimulator.cs
@@ -116,7 +116,7 @@ public static class KeyboardSimulator
         }
 
         // Send a key down event for the key
-        keybd_event(vk, scan, 0, UIntPtr.Zero);
+        keybd_event(vk, scan, (e.Flags & KEYEVENTF_EXTENDEDKEY) != 0 ? KEYEVENTF_EXTENDEDKEY : 0U, UIntPtr.Zero);
     }
 
     // A function that sends a key up event for a KeyEventArgs object using the keybd_event function
@@ -132,7 +132,7 @@ public static class KeyboardSimulator
                           ((e.Modifiers & System.Windows.Forms.Keys.Shift) != 0);
 
         // Send a key up event for the key
-        keybd_event(vk, scan, KEYEVENTF_KEYUP, UIntPtr.Zero);
+        keybd_event(vk, scan, KEYEVENTF_KEYUP | ((e.Flags & KEYEVENTF_EXTENDEDKEY) != 0 ? KEYEVENTF_EXTENDEDKEY : 0U), UIntPtr.Zero);
 
         // If the key is a modifier key, send a key up event for it
         if (isModifier)


### PR DESCRIPTION
Passes KEYEVENTF_EXTENDEDKEY through keyboard key-down and key-up simulation, while removing physical modifier tracking and the related AltGr workaround.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of extended keyboard keys during simulated key presses and releases.
  * Removed legacy modifier-key handling that could generate unintended Control key events.
  * Retained MSI firmware workaround support.

* **Improvements**
  * Improved installation reliability by automatically retrying failed installation steps before reporting an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->