### PR TITLE
Add LavX to About page contributors

### DIFF
--- a/HandheldCompanion/Views/Pages/AboutPage.xaml
+++ b/HandheldCompanion/Views/Pages/AboutPage.xaml
@@ -151,7 +151,7 @@
                                 Margin="0,0,0,5"
                                 Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                                 Style="{StaticResource BodyTextBlockStyle}"
-                                Text="Nefarius, CasperH2O, B-Core, Frank东, Toomy, Havner, CoryManson, MSeys, ShadowFlare, trippyone, MiguelLedesmaC, Cheng77777, thororen1234, fighterguard, micdah, Geckon01, Bagboii, MeikoMenmaHonma, cerahmed, indiesaudi, Radther, Staubgeborener, twjmy, m33ts4k0z, howanghk, Creaous, xerootg, quangmach, MrCivsteR, 0SkillAllLuck, DevL0rd, romracer, JT, Moyogii, Sanheiii, Hijae" />
+                                Text="Nefarius, CasperH2O, B-Core, Frank东, Toomy, Havner, CoryManson, MSeys, ShadowFlare, trippyone, MiguelLedesmaC, Cheng77777, thororen1234, fighterguard, micdah, Geckon01, Bagboii, MeikoMenmaHonma, cerahmed, indiesaudi, Radther, Staubgeborener, twjmy, m33ts4k0z, howanghk, Creaous, xerootg, quangmach, MrCivsteR, 0SkillAllLuck, DevL0rd, romracer, JT, Moyogii, Sanheiii, Hijae, LavX" />
 
                             <!--  Description  -->
                             <TextBlock


### PR DESCRIPTION
## Summary

Adds `LavX` to the contributor list shown on the About page.

I have contributed several changes to Handheld Companion, including Steam Deck trackpad haptics and controller mapping work. I would be grateful to be included in the existing contributor credits.

Thank you for considering this small update.

## Testing

- Built the solution locally with 0 errors.
- Verified that `LavX` appears at the end of the Contributors list on the About page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the About page to include contributor LavX.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->