### PR TITLE
Fix OneXPlayer X2 gamepad going dead from vendor 0xB2 init

### DIFF
--- a/HandheldCompanion/Devices/OneXPlayer/OneXPlayerX2.cs
+++ b/HandheldCompanion/Devices/OneXPlayer/OneXPlayerX2.cs
@@ -146,16 +146,16 @@ public class OneXPlayerX2 : OneXPlayerX1
 
     protected override void InitializeVendorHidCommands()
     {
+        // Wait for the vendor HID interface to be ready after enumeration, then send
+        // only the two remap pages to expose the M1/M2 paddles and OEM buttons.
+        // Do NOT send the vendor 0xB2 command: on the X2 it puts the pad firmware into
+        // intercept mode and kills its XInput gamepad reports until a power-cycle.
         Thread.Sleep(4000);
 
         WriteVendorHidCommand(0xB4, BuildRemapPage1(0x01));
         Thread.Sleep(50);
 
         WriteVendorHidCommand(0xB4, BuildRemapPage2(0x01, 0x67, 0x66));
-        Thread.Sleep(50);
-
-        // X2-specific B2 setup; this is not HHD gen_intercept(False).
-        WriteVendorHidCommand(0xB2, [0x01, 0x1F, 0x40, 0x03, 0x02, 0x03, 0x00, 0x00, 0x00, 0x01]);
     }
 
     public override XInputController? CreateController(PnPDetails details)


### PR DESCRIPTION
## Summary

On the ONEXPLAYER X2, the main gamepad (sticks / face buttons / d-pad) would go dead while the M1/M2 paddles, Turbo and Home buttons kept working.

## Root cause

`OneXPlayerX2.InitializeVendorHidCommands()` sent a vendor `0xB2` "setup" command (`[0x01,0x1F,0x40,0x03,0x02,0x03,0x00,0x00,0x00,0x01]`) after the remap pages. On the X2 that switches the pad's firmware into vendor/intercept mode, which **silences the controller's XInput gamepad reports** until the controller is power-cycled. Because the paddles/OEM buttons ride the separate vendor-HID collection, they kept working — which made it look like only the main gamepad was affected.

Diagnosis: with the target correctly bound to the physical X2, `XInputGetState` returned all-zeros on every slot while the low-level secret ordinal still saw the pad; removing the `0xB2` command restored the XInput gamepad.

## Change

Send only the two `0xB4` remap pages (which expose the paddles / OEM buttons). Do **not** send the `0xB2` command. The leading readiness delay is kept.

## Validation

- `dotnet build HandheldCompanion/HandheldCompanion.csproj -p:Platform=x64`: 0 errors.
- Verified on ONEXPLAYER X2 hardware: main gamepad, M1/M2 paddles, Turbo and Home all working.

Scope: single file, `OneXPlayerX2.cs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)